### PR TITLE
Improve authorization evaluation logic for ROOT organization creation

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.endpoint/src/main/java/org/wso2/carbon/identity/organization/management/endpoint/util/OrganizationManagementEndpointUtil.java
+++ b/components/org.wso2.carbon.identity.organization.management.endpoint/src/main/java/org/wso2/carbon/identity/organization/management/endpoint/util/OrganizationManagementEndpointUtil.java
@@ -39,6 +39,7 @@ import static org.wso2.carbon.identity.organization.management.service.constant.
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_INVALID_ORGANIZATION;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ORGANIZATION_NAME_CONFLICT;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_USER_NOT_AUTHORIZED_TO_CREATE_ORGANIZATION;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_USER_NOT_AUTHORIZED_TO_CREATE_ROOT_ORGANIZATION;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.getContext;
 
 /**
@@ -97,7 +98,8 @@ public class OrganizationManagementEndpointUtil {
 
     private static boolean isForbiddenError(OrganizationManagementClientException e) {
 
-        return ERROR_CODE_USER_NOT_AUTHORIZED_TO_CREATE_ORGANIZATION.getCode().equals(e.getErrorCode());
+        return ERROR_CODE_USER_NOT_AUTHORIZED_TO_CREATE_ORGANIZATION.getCode().equals(e.getErrorCode()) ||
+                ERROR_CODE_USER_NOT_AUTHORIZED_TO_CREATE_ROOT_ORGANIZATION.getCode().equals(e.getErrorCode());
     }
 
     private static OrganizationManagementEndpointException buildException(Response.Status status, Log log,

--- a/components/org.wso2.carbon.identity.organization.management.service/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.service/pom.xml
@@ -140,7 +140,9 @@
                             org.wso2.carbon.identity.organization.management.service.dao.impl;version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
                             org.wso2.carbon.identity.organization.management.service.exception;version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
                             org.wso2.carbon.identity.organization.management.service.model;version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
-                            org.wso2.carbon.identity.organization.management.service.util;version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}"
+                            org.wso2.carbon.identity.organization.management.service.util;version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
+                            org.wso2.carbon.user.api;version="${carbon.user.api.imp.pkg.version.range}",
+                            org.wso2.carbon.user.core.service;version="${carbon.kernel.package.import.version.range}"
                         </Import-Package>
                     </instructions>
                 </configuration>

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
@@ -20,6 +20,8 @@ package org.wso2.carbon.identity.organization.management.service;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.CarbonConstants;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.core.model.ExpressionNode;
 import org.wso2.carbon.identity.core.model.FilterTreeBuilder;
@@ -38,6 +40,10 @@ import org.wso2.carbon.identity.organization.management.service.model.Organizati
 import org.wso2.carbon.identity.organization.management.service.model.OrganizationAttribute;
 import org.wso2.carbon.identity.organization.management.service.model.ParentOrganizationDO;
 import org.wso2.carbon.identity.organization.management.service.model.PatchOperation;
+import org.wso2.carbon.user.api.AuthorizationManager;
+import org.wso2.carbon.user.api.UserRealm;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.core.service.RealmService;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -51,10 +57,12 @@ import java.util.stream.Collectors;
 
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.AND;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.CREATE_ORGANIZATION_PERMISSION;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.CREATE_ROOT_ORGANIZATION_PERMISSION;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ATTRIBUTE_KEY_MISSING;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ATTRIBUTE_VALUE_MISSING;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_DUPLICATE_ATTRIBUTE_KEYS;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_EVALUATING_ADD_ORGANIZATION_AUTHORIZATION;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_EVALUATING_ADD_ROOT_ORGANIZATION_AUTHORIZATION;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_INVALID_CURSOR_FOR_PAGINATION;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_INVALID_FILTER_FORMAT;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_INVALID_ORGANIZATION;
@@ -76,6 +84,7 @@ import static org.wso2.carbon.identity.organization.management.service.constant.
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_UNSUPPORTED_COMPLEX_QUERY_IN_FILTER;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_UNSUPPORTED_FILTER_ATTRIBUTE;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_USER_NOT_AUTHORIZED_TO_CREATE_ORGANIZATION;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_USER_NOT_AUTHORIZED_TO_CREATE_ROOT_ORGANIZATION;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ORGANIZATION_CREATED_TIME_FIELD;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ORGANIZATION_DESCRIPTION_FIELD;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ORGANIZATION_ID_FIELD;
@@ -108,10 +117,11 @@ public class OrganizationManagerImpl implements OrganizationManager {
     public Organization addOrganization(Organization organization) throws
             OrganizationManagementException {
 
+        String tenantDomain = getTenantDomain();
         validateAddOrganizationRequest(organization);
-        setParentOrganization(organization);
+        setParentOrganization(organization, tenantDomain);
         setCreatedAndLastModifiedTime(organization);
-        getOrganizationManagementDAO().addOrganization(getTenantId(), getTenantDomain(), organization);
+        getOrganizationManagementDAO().addOrganization(getTenantId(), tenantDomain, organization);
         return organization;
     }
 
@@ -267,7 +277,11 @@ public class OrganizationManagerImpl implements OrganizationManager {
         }
     }
 
-    private void addRootOrganization() throws OrganizationManagementServerException {
+    private void addRootOrganization(String tenantDomain) throws OrganizationManagementException {
+
+        if (!isUserAuthorizedToCreateRootOrganization(tenantDomain)) {
+            throw handleClientException(ERROR_CODE_USER_NOT_AUTHORIZED_TO_CREATE_ROOT_ORGANIZATION, tenantDomain);
+        }
 
         Organization organization = new Organization();
         organization.setId(generateUniqueID());
@@ -370,10 +384,12 @@ public class OrganizationManagerImpl implements OrganizationManager {
         }
     }
 
-    private void setParentOrganization(Organization organization) throws OrganizationManagementException {
+    private void setParentOrganization(Organization organization, String tenantDomain)
+            throws OrganizationManagementException {
 
         ParentOrganizationDO parentOrganization = organization.getParent();
         String parentId = parentOrganization.getId().trim();
+        boolean createOrganizationAuthorizationRequired = true;
 
         /*
         For parentId an alias as 'ROOT' is supported. This indicates that the organization should be created as an
@@ -383,17 +399,40 @@ public class OrganizationManagerImpl implements OrganizationManager {
         if (StringUtils.equals(ROOT, parentId)) {
             String rootOrganizationId = getOrganizationIdByName(ROOT);
             if (StringUtils.isBlank(rootOrganizationId)) {
-                addRootOrganization();
+                addRootOrganization(tenantDomain);
+                createOrganizationAuthorizationRequired = false;
                 rootOrganizationId = getOrganizationIdByName(ROOT);
             }
             parentId = rootOrganizationId;
         }
 
-        if (!isUserAuthorizedToCreateOrganization(parentId)) {
+        /*
+        For a first time organization creation in a tenant, the evaluation of user's authorization to create an
+        organization as a child of the given parent (ROOT organization) will not happen.
+        Having '/permission/admin/' assigned to the user would be sufficient in this scenario. This permission implies
+        that the user is authorized to create the ROOT organization in the tenant along with the organization that the
+        user is requesting to be created in the request.
+         */
+        if (createOrganizationAuthorizationRequired && !isUserAuthorizedToCreateOrganization(parentId)) {
             throw handleClientException(ERROR_CODE_USER_NOT_AUTHORIZED_TO_CREATE_ORGANIZATION, parentId);
         }
         parentOrganization.setId(parentId);
         parentOrganization.setSelf(buildURIForBody(parentId));
+    }
+
+    private boolean isUserAuthorizedToCreateRootOrganization(String tenantDomain) throws
+            OrganizationManagementServerException {
+
+        String username = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
+        try {
+            UserRealm tenantUserRealm = getRealmService().getTenantUserRealm(getTenantId());
+            AuthorizationManager authorizationManager = tenantUserRealm.getAuthorizationManager();
+            return authorizationManager.isUserAuthorized(username, CREATE_ROOT_ORGANIZATION_PERMISSION,
+                    CarbonConstants.UI_PERMISSION_ACTION);
+        } catch (UserStoreException e) {
+            throw handleServerException(ERROR_CODE_ERROR_EVALUATING_ADD_ROOT_ORGANIZATION_AUTHORIZATION, e,
+                    tenantDomain);
+        }
     }
 
     private boolean isUserAuthorizedToCreateOrganization(String parentId) throws OrganizationManagementServerException {
@@ -549,7 +588,7 @@ public class OrganizationManagerImpl implements OrganizationManager {
             OrganizationManagementClientException {
 
         if (node instanceof ExpressionNode) {
-            ExpressionNode expressionNode  = (ExpressionNode) node;
+            ExpressionNode expressionNode = (ExpressionNode) node;
             String attributeValue = expressionNode.getAttributeValue();
             if (StringUtils.isNotBlank(attributeValue)) {
                 if (isFilteringAttributeNotSupported(attributeValue)) {
@@ -586,5 +625,10 @@ public class OrganizationManagerImpl implements OrganizationManager {
     private OrganizationManagementDAO getOrganizationManagementDAO() {
 
         return OrganizationManagementDataHolder.getInstance().getOrganizationManagementDAO();
+    }
+
+    private RealmService getRealmService() {
+
+        return OrganizationManagementDataHolder.getInstance().getRealmService();
     }
 }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
@@ -58,6 +58,7 @@ public class OrganizationManagementConstants {
     public static final String PAGINATION_AFTER = "after";
     public static final String PAGINATION_BEFORE = "before";
 
+    public static final String CREATE_ROOT_ORGANIZATION_PERMISSION = "/permission/admin/";
     public static final String CREATE_ORGANIZATION_PERMISSION = "/permission/admin/manage/identity/organizationmgt/" +
             "create";
     public static final String VIEW_ORGANIZATION_PERMISSION = "/permission/admin/manage/identity/organizationmgt/" +
@@ -145,6 +146,8 @@ public class OrganizationManagementConstants {
                 "'limit' shouldn't be negative."),
         ERROR_CODE_INVALID_CURSOR_FOR_PAGINATION("60026", "Unable to retrieve organizations.", "Invalid " +
                 "cursor used for pagination."),
+        ERROR_CODE_USER_NOT_AUTHORIZED_TO_CREATE_ROOT_ORGANIZATION("60027", "Unable to create the organization.",
+                "User is not authorized to create the root organization in tenant: %s."), // 403
 
         // Server errors.
         ERROR_CODE_UNEXPECTED("65001", "Unexpected processing error",
@@ -194,7 +197,10 @@ public class OrganizationManagementConstants {
                 "Server encountered an error while evaluating authorization of user to create the " +
                         "organization in parent organization with ID: %s."),
         ERROR_CODE_ERROR_BUILDING_PAGINATED_RESPONSE_URL("65020", "Unable to retrieve the organizations.",
-                "Server encountered an error while building paginated response URL.");
+                "Server encountered an error while building paginated response URL."),
+        ERROR_CODE_ERROR_EVALUATING_ADD_ROOT_ORGANIZATION_AUTHORIZATION("65021", "Unable to create the organization.",
+                "Server encountered an error while evaluating authorization of user to create the root " +
+                        "organization in tenant: %s.");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/internal/OrganizationManagementDataHolder.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/internal/OrganizationManagementDataHolder.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.organization.management.service.internal;
 
 import org.wso2.carbon.identity.organization.management.service.dao.OrganizationManagementDAO;
+import org.wso2.carbon.user.core.service.RealmService;
 
 /**
  * Organization management data holder.
@@ -27,6 +28,7 @@ public class OrganizationManagementDataHolder {
 
     private static final OrganizationManagementDataHolder instance = new OrganizationManagementDataHolder();
     private OrganizationManagementDAO organizationManagementDAO;
+    private RealmService realmService;
 
     public static OrganizationManagementDataHolder getInstance() {
 
@@ -41,5 +43,15 @@ public class OrganizationManagementDataHolder {
     public void setOrganizationManagementDAO(OrganizationManagementDAO organizationManagementDAO) {
 
         this.organizationManagementDAO = organizationManagementDAO;
+    }
+
+    public RealmService getRealmService() {
+
+        return realmService;
+    }
+
+    public void setRealmService(RealmService realmService) {
+
+        this.realmService = realmService;
     }
 }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/internal/OrganizationManagementServiceComponent.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/internal/OrganizationManagementServiceComponent.java
@@ -24,11 +24,15 @@ import org.osgi.framework.BundleContext;
 import org.osgi.service.component.ComponentContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManagerImpl;
 import org.wso2.carbon.identity.organization.management.service.dao.OrganizationManagementDAO;
 import org.wso2.carbon.identity.organization.management.service.dao.impl.CachedBackedOrganizationManagementDAO;
 import org.wso2.carbon.identity.organization.management.service.dao.impl.OrganizationManagementDAOImpl;
+import org.wso2.carbon.user.core.service.RealmService;
 
 /**
  * OSGi service component for organization management core bundle.
@@ -61,5 +65,38 @@ public class OrganizationManagementServiceComponent {
         } catch (Exception e) {
             LOG.error("Error while activating Organization Management module.", e);
         }
+    }
+
+    /**
+     * Set realm service implementation.
+     *
+     * @param realmService RealmService
+     */
+    @Reference(
+            name = "user.realmservice.default",
+            service = RealmService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetRealmService"
+    )
+    protected void setRealmService(RealmService realmService) {
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Setting the Realm Service.");
+        }
+        OrganizationManagementDataHolder.getInstance().setRealmService(realmService);
+    }
+
+    /**
+     * Unset realm service implementation.
+     *
+     * @param realmService RealmService
+     */
+    protected void unsetRealmService(RealmService realmService) {
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Unsetting the Realm Service.");
+        }
+        OrganizationManagementDataHolder.getInstance().setRealmService(null);
     }
 }


### PR DESCRIPTION
With this change, the user will require to have the permission `/permission/admin/` to create the ROOT internally during the **first** time organization creation request for a tenant.