### PR TITLE
Fix caching issue with deleting child org entries when parent is deleted

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,0 @@
-blank_issues_enabled: false
-contact_links:
-  - name: Report an issue
-    url: https://github.com/wso2/product-is/issues/new/choose
-    about: Issue creation for this component is done in the product-is repo. Click "Open" to continue.

--- a/components/org.wso2.carbon.identity.organization.management.endpoint/src/gen/java/org/wso2/carbon/identity/organization/management/endpoint/OrganizationsApi.java
+++ b/components/org.wso2.carbon.identity.organization.management.endpoint/src/gen/java/org/wso2/carbon/identity/organization/management/endpoint/OrganizationsApi.java
@@ -151,7 +151,7 @@ public class OrganizationsApi  {
     @Path("/{organization-id}")
     @Consumes({ "application/json" })
     @Produces({ "application/json" })
-    @ApiOperation(value = "Update an organization by ID.", notes = "This API provides the capability to update a secret type by name.", response = OrganizationResponse.class, authorizations = {
+    @ApiOperation(value = "Update an organization by ID.", notes = "This API provides the capability to update an organization by its id.", response = OrganizationResponse.class, authorizations = {
         @Authorization(value = "BasicAuth"),
         @Authorization(value = "OAuth2", scopes = {
             

--- a/components/org.wso2.carbon.identity.organization.management.endpoint/src/main/java/org/wso2/carbon/identity/organization/management/endpoint/service/OrganizationManagementService.java
+++ b/components/org.wso2.carbon.identity.organization.management.endpoint/src/main/java/org/wso2/carbon/identity/organization/management/endpoint/service/OrganizationManagementService.java
@@ -115,7 +115,7 @@ public class OrganizationManagementService {
     public Response deleteOrganization(String organizationId, Boolean force) {
 
         try {
-            getOrganizationManager().deleteOrganization(organizationId, force);
+            getOrganizationManager().deleteOrganization(organizationId, Boolean.TRUE.equals(force));
             return Response.noContent().build();
         } catch (OrganizationManagementClientException e) {
             return handleClientErrorResponse(e, LOG);
@@ -134,7 +134,8 @@ public class OrganizationManagementService {
     public Response getOrganization(String organizationId, Boolean showChildren) {
 
         try {
-            Organization organization = getOrganizationManager().getOrganization(organizationId, showChildren);
+            Organization organization = getOrganizationManager().getOrganization(organizationId,
+                    Boolean.TRUE.equals(showChildren));
             return Response.ok().entity(getOrganizationResponseWithChildren(organization)).build();
         } catch (OrganizationManagementClientException e) {
             return handleClientErrorResponse(e, LOG);

--- a/components/org.wso2.carbon.identity.organization.management.endpoint/src/main/resources/org.wso2.carbon.identity.organization.management.yaml
+++ b/components/org.wso2.carbon.identity.organization.management.endpoint/src/main/resources/org.wso2.carbon.identity.organization.management.yaml
@@ -161,7 +161,7 @@ paths:
         - Organization
     put:
       description:
-        This API provides the capability to update a secret type by name.
+        This API provides the capability to update an organization by its id.
       summary:
         Update an organization by ID.
       parameters:

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManager.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManager.java
@@ -74,7 +74,7 @@ public interface OrganizationManager {
      * @return the organization object.
      * @throws OrganizationManagementException The exception thrown when retrieving an organization.
      */
-    Organization getOrganization(String organizationId, Boolean showChildren) throws OrganizationManagementException;
+    Organization getOrganization(String organizationId, boolean showChildren) throws OrganizationManagementException;
 
     /**
      * List or search organizations.
@@ -97,7 +97,7 @@ public interface OrganizationManager {
      * @param force          Enforces the forceful deletion of child organizations belonging to this organization.
      * @throws OrganizationManagementException The exception thrown when deleting an organization.
      */
-    void deleteOrganization(String organizationId, Boolean force) throws OrganizationManagementException;
+    void deleteOrganization(String organizationId, boolean force) throws OrganizationManagementException;
 
     /**
      * Patch organization and its attributes.

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
@@ -210,7 +210,8 @@ public class OrganizationManagerImpl implements OrganizationManager {
         if (!force) {
             validateOrganizationDelete(organizationId);
         }
-        getOrganizationManagementDAO().deleteOrganization(getTenantId(), organizationId.trim(), getTenantDomain());
+        getOrganizationManagementDAO().deleteOrganization(getTenantId(), organizationId.trim(), getTenantDomain(),
+                force);
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
@@ -146,7 +146,7 @@ public class OrganizationManagerImpl implements OrganizationManager {
     }
 
     @Override
-    public Organization getOrganization(String organizationId, Boolean showChildren) throws
+    public Organization getOrganization(String organizationId, boolean showChildren) throws
             OrganizationManagementException {
 
         if (StringUtils.isBlank(organizationId)) {
@@ -194,7 +194,7 @@ public class OrganizationManagerImpl implements OrganizationManager {
     }
 
     @Override
-    public void deleteOrganization(String organizationId, Boolean force) throws OrganizationManagementException {
+    public void deleteOrganization(String organizationId, boolean force) throws OrganizationManagementException {
 
         if (StringUtils.isBlank(organizationId)) {
             throw handleClientException(ERROR_CODE_ORGANIZATION_ID_UNDEFINED);

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/OrganizationManagementDAO.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/OrganizationManagementDAO.java
@@ -121,7 +121,7 @@ public interface OrganizationManagementDAO {
      * @param force          Enforces the forceful deletion of child organizations belonging to this organization.
      * @throws OrganizationManagementServerException The server exception thrown when deleting the organization.
      */
-    void deleteOrganization(int tenantId, String organizationId, String tenantDomain, Boolean force) throws
+    void deleteOrganization(int tenantId, String organizationId, String tenantDomain, boolean force) throws
             OrganizationManagementServerException;
 
     /**

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/OrganizationManagementDAO.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/OrganizationManagementDAO.java
@@ -118,9 +118,10 @@ public interface OrganizationManagementDAO {
      * @param tenantId       The tenant ID corresponding to the tenant where the organization should be deleted.
      * @param organizationId The organization ID.
      * @param tenantDomain   The tenant name corresponding to the tenant where the organization should be deleted.
+     * @param force          Enforces the forceful deletion of child organizations belonging to this organization.
      * @throws OrganizationManagementServerException The server exception thrown when deleting the organization.
      */
-    void deleteOrganization(int tenantId, String organizationId, String tenantDomain) throws
+    void deleteOrganization(int tenantId, String organizationId, String tenantDomain, Boolean force) throws
             OrganizationManagementServerException;
 
     /**

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/impl/CachedBackedOrganizationManagementDAO.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/impl/CachedBackedOrganizationManagementDAO.java
@@ -131,7 +131,7 @@ public class CachedBackedOrganizationManagementDAO implements OrganizationManage
     }
 
     @Override
-    public void deleteOrganization(int tenantId, String organizationId, String tenantDomain, Boolean force)
+    public void deleteOrganization(int tenantId, String organizationId, String tenantDomain, boolean force)
             throws OrganizationManagementServerException {
 
         deleteOrganizationCacheById(organizationId, tenantDomain);
@@ -329,13 +329,21 @@ public class CachedBackedOrganizationManagementDAO implements OrganizationManage
     TODO: improve to support the cascade deletion of sub organizations when the parent organization is deleted,
      instead of clearing the cache based only on the tenant domain.
      */
-    private void deleteChildOrganizationCache(String tenantDomain, Boolean force) {
+    private void deleteChildOrganizationCache(String tenantDomain, boolean force) {
 
         if (LOG.isDebugEnabled()) {
             LOG.debug(String.format("Clearing child organizations related cache entries in tenant domain: %s",
                     tenantDomain));
         }
         childOrganizationsCache.clear(tenantDomain);
+
+        /*
+        If the delete organization is defined as a forceful delete, it is required to remove child organization cache
+        entries as well.
+        Since the current implementation doesn't have a way to identify the child organization entries that should be
+        removed from the cache, the entire cache based on the tenant domain has been removed to avoid any incorrect
+        behaviors that can occur as a result of a forceful organization delete.
+         */
         if (force) {
             organizationByIdCache.clear(tenantDomain);
             organizationByNameCache.clear(tenantDomain);

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/impl/OrganizationManagementDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/impl/OrganizationManagementDAOImpl.java
@@ -312,7 +312,7 @@ public class OrganizationManagementDAOImpl implements OrganizationManagementDAO 
     }
 
     @Override
-    public void deleteOrganization(int tenantId, String organizationId, String tenantDomain, Boolean force) throws
+    public void deleteOrganization(int tenantId, String organizationId, String tenantDomain, boolean force) throws
             OrganizationManagementServerException {
 
         NamedJdbcTemplate namedJdbcTemplate = Utils.getNewTemplate();

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/impl/OrganizationManagementDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/impl/OrganizationManagementDAOImpl.java
@@ -312,7 +312,7 @@ public class OrganizationManagementDAOImpl implements OrganizationManagementDAO 
     }
 
     @Override
-    public void deleteOrganization(int tenantId, String organizationId, String tenantDomain) throws
+    public void deleteOrganization(int tenantId, String organizationId, String tenantDomain, Boolean force) throws
             OrganizationManagementServerException {
 
         NamedJdbcTemplate namedJdbcTemplate = Utils.getNewTemplate();


### PR DESCRIPTION
## Purpose
When the parent organization is deleted, child organization entries should be removed from the cache. This PR will remove the entire cache by tenant domain to avoid any incorrect behaviours. However, the caching layer should be improved to only perform a cascade deletion of child orgs when the parent org is deleted (force=true).