### PR TITLE
Add improvements

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.endpoint/src/gen/java/org/wso2/carbon/identity/organization/management/endpoint/OrganizationsApi.java
+++ b/components/org.wso2.carbon.identity.organization.management.endpoint/src/gen/java/org/wso2/carbon/identity/organization/management/endpoint/OrganizationsApi.java
@@ -92,9 +92,9 @@ public class OrganizationsApi  {
         @ApiResponse(code = 404, message = "Requested resource is not found.", response = Error.class),
         @ApiResponse(code = 500, message = "Internal server error.", response = Error.class)
     })
-    public Response organizationsOrganizationIdDelete(@ApiParam(value = "ID of the organization to be deleted.",required=true) @PathParam("organization-id") String organizationId,     @Valid@ApiParam(value = "Enforces the forceful deletion of an organization along with the belonging sub organizations.", defaultValue="false") @DefaultValue("false")  @QueryParam("force") Boolean force) {
+    public Response organizationsOrganizationIdDelete(@ApiParam(value = "ID of the organization to be deleted.",required=true) @PathParam("organization-id") String organizationId) {
 
-        return delegate.organizationsOrganizationIdDelete(organizationId,  force );
+        return delegate.organizationsOrganizationIdDelete(organizationId );
     }
 
     @Valid

--- a/components/org.wso2.carbon.identity.organization.management.endpoint/src/gen/java/org/wso2/carbon/identity/organization/management/endpoint/OrganizationsApiService.java
+++ b/components/org.wso2.carbon.identity.organization.management.endpoint/src/gen/java/org/wso2/carbon/identity/organization/management/endpoint/OrganizationsApiService.java
@@ -39,7 +39,7 @@ public interface OrganizationsApiService {
 
       public Response organizationsGet(String filter, Integer limit, String after, String before);
 
-      public Response organizationsOrganizationIdDelete(String organizationId, Boolean force);
+      public Response organizationsOrganizationIdDelete(String organizationId);
 
       public Response organizationsOrganizationIdGet(String organizationId, Boolean showChildren);
 

--- a/components/org.wso2.carbon.identity.organization.management.endpoint/src/gen/java/org/wso2/carbon/identity/organization/management/endpoint/model/BasicOrganizationResponse.java
+++ b/components/org.wso2.carbon.identity.organization.management.endpoint/src/gen/java/org/wso2/carbon/identity/organization/management/endpoint/model/BasicOrganizationResponse.java
@@ -34,7 +34,7 @@ public class BasicOrganizationResponse  {
   
     private String id;
     private String name;
-    private String self;
+    private String ref;
 
     /**
     **/
@@ -78,22 +78,22 @@ public class BasicOrganizationResponse  {
 
     /**
     **/
-    public BasicOrganizationResponse self(String self) {
+    public BasicOrganizationResponse ref(String ref) {
 
-        this.self = self;
+        this.ref = ref;
         return this;
     }
     
     @ApiModelProperty(example = "t/carbon.super/api/identity/organization-mgt/v1.0/b4526d91-a8bf-43d2-8b14-c548cf73065b", required = true, value = "")
-    @JsonProperty("self")
+    @JsonProperty("ref")
     @Valid
-    @NotNull(message = "Property self cannot be null.")
+    @NotNull(message = "Property ref cannot be null.")
 
-    public String getSelf() {
-        return self;
+    public String getRef() {
+        return ref;
     }
-    public void setSelf(String self) {
-        this.self = self;
+    public void setRef(String ref) {
+        this.ref = ref;
     }
 
 
@@ -110,12 +110,12 @@ public class BasicOrganizationResponse  {
         BasicOrganizationResponse basicOrganizationResponse = (BasicOrganizationResponse) o;
         return Objects.equals(this.id, basicOrganizationResponse.id) &&
             Objects.equals(this.name, basicOrganizationResponse.name) &&
-            Objects.equals(this.self, basicOrganizationResponse.self);
+            Objects.equals(this.ref, basicOrganizationResponse.ref);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, self);
+        return Objects.hash(id, name, ref);
     }
 
     @Override
@@ -126,7 +126,7 @@ public class BasicOrganizationResponse  {
         
         sb.append("    id: ").append(toIndentedString(id)).append("\n");
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
-        sb.append("    self: ").append(toIndentedString(self)).append("\n");
+        sb.append("    ref: ").append(toIndentedString(ref)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.organization.management.endpoint/src/gen/java/org/wso2/carbon/identity/organization/management/endpoint/model/ChildOrganization.java
+++ b/components/org.wso2.carbon.identity.organization.management.endpoint/src/gen/java/org/wso2/carbon/identity/organization/management/endpoint/model/ChildOrganization.java
@@ -33,7 +33,7 @@ import javax.xml.bind.annotation.*;
 public class ChildOrganization  {
   
     private String id;
-    private String self;
+    private String ref;
 
     /**
     **/
@@ -57,22 +57,22 @@ public class ChildOrganization  {
 
     /**
     **/
-    public ChildOrganization self(String self) {
+    public ChildOrganization ref(String ref) {
 
-        this.self = self;
+        this.ref = ref;
         return this;
     }
     
     @ApiModelProperty(example = "t/carbon.super/api/identity/organization-mgt/v1.0/d8f9780e-3a9a-4ae0-8d94-1a2d1aa3ec14", required = true, value = "")
-    @JsonProperty("self")
+    @JsonProperty("ref")
     @Valid
-    @NotNull(message = "Property self cannot be null.")
+    @NotNull(message = "Property ref cannot be null.")
 
-    public String getSelf() {
-        return self;
+    public String getRef() {
+        return ref;
     }
-    public void setSelf(String self) {
-        this.self = self;
+    public void setRef(String ref) {
+        this.ref = ref;
     }
 
 
@@ -88,12 +88,12 @@ public class ChildOrganization  {
         }
         ChildOrganization childOrganization = (ChildOrganization) o;
         return Objects.equals(this.id, childOrganization.id) &&
-            Objects.equals(this.self, childOrganization.self);
+            Objects.equals(this.ref, childOrganization.ref);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, self);
+        return Objects.hash(id, ref);
     }
 
     @Override
@@ -103,7 +103,7 @@ public class ChildOrganization  {
         sb.append("class ChildOrganization {\n");
         
         sb.append("    id: ").append(toIndentedString(id)).append("\n");
-        sb.append("    self: ").append(toIndentedString(self)).append("\n");
+        sb.append("    ref: ").append(toIndentedString(ref)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.organization.management.endpoint/src/gen/java/org/wso2/carbon/identity/organization/management/endpoint/model/GetOrganizationResponse.java
+++ b/components/org.wso2.carbon.identity.organization.management.endpoint/src/gen/java/org/wso2/carbon/identity/organization/management/endpoint/model/GetOrganizationResponse.java
@@ -40,6 +40,40 @@ public class GetOrganizationResponse  {
     private String id;
     private String name;
     private String description;
+
+@XmlType(name="StatusEnum")
+@XmlEnum(String.class)
+public enum StatusEnum {
+
+    @XmlEnumValue("ACTIVE") ACTIVE(String.valueOf("ACTIVE")), @XmlEnumValue("DISABLED") DISABLED(String.valueOf("DISABLED"));
+
+
+    private String value;
+
+    StatusEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static StatusEnum fromValue(String value) {
+        for (StatusEnum b : StatusEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private StatusEnum status;
     private String created;
     private String lastModified;
     private ParentOrganization parent;
@@ -108,15 +142,37 @@ public class GetOrganizationResponse  {
 
     /**
     **/
+    public GetOrganizationResponse status(StatusEnum status) {
+
+        this.status = status;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "ACTIVE", required = true, value = "")
+    @JsonProperty("status")
+    @Valid
+    @NotNull(message = "Property status cannot be null.")
+
+    public StatusEnum getStatus() {
+        return status;
+    }
+    public void setStatus(StatusEnum status) {
+        this.status = status;
+    }
+
+    /**
+    **/
     public GetOrganizationResponse created(String created) {
 
         this.created = created;
         return this;
     }
     
-    @ApiModelProperty(example = "2021-10-25T12:31:53.406Z", value = "")
+    @ApiModelProperty(example = "2021-10-25T12:31:53.406Z", required = true, value = "")
     @JsonProperty("created")
     @Valid
+    @NotNull(message = "Property created cannot be null.")
+
     public String getCreated() {
         return created;
     }
@@ -132,9 +188,11 @@ public class GetOrganizationResponse  {
         return this;
     }
     
-    @ApiModelProperty(example = "2021-10-25T12:31:53.406Z", value = "")
+    @ApiModelProperty(example = "2021-10-25T12:31:53.406Z", required = true, value = "")
     @JsonProperty("lastModified")
     @Valid
+    @NotNull(message = "Property lastModified cannot be null.")
+
     public String getLastModified() {
         return lastModified;
     }
@@ -227,6 +285,7 @@ public class GetOrganizationResponse  {
         return Objects.equals(this.id, getOrganizationResponse.id) &&
             Objects.equals(this.name, getOrganizationResponse.name) &&
             Objects.equals(this.description, getOrganizationResponse.description) &&
+            Objects.equals(this.status, getOrganizationResponse.status) &&
             Objects.equals(this.created, getOrganizationResponse.created) &&
             Objects.equals(this.lastModified, getOrganizationResponse.lastModified) &&
             Objects.equals(this.parent, getOrganizationResponse.parent) &&
@@ -236,7 +295,7 @@ public class GetOrganizationResponse  {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, description, created, lastModified, parent, children, attributes);
+        return Objects.hash(id, name, description, status, created, lastModified, parent, children, attributes);
     }
 
     @Override
@@ -248,6 +307,7 @@ public class GetOrganizationResponse  {
         sb.append("    id: ").append(toIndentedString(id)).append("\n");
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
         sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("    status: ").append(toIndentedString(status)).append("\n");
         sb.append("    created: ").append(toIndentedString(created)).append("\n");
         sb.append("    lastModified: ").append(toIndentedString(lastModified)).append("\n");
         sb.append("    parent: ").append(toIndentedString(parent)).append("\n");

--- a/components/org.wso2.carbon.identity.organization.management.endpoint/src/gen/java/org/wso2/carbon/identity/organization/management/endpoint/model/OrganizationPOSTRequest.java
+++ b/components/org.wso2.carbon.identity.organization.management.endpoint/src/gen/java/org/wso2/carbon/identity/organization/management/endpoint/model/OrganizationPOSTRequest.java
@@ -80,6 +80,7 @@ public class OrganizationPOSTRequest  {
     }
 
     /**
+    * If the parentId is not present, the ROOT will be taken as the parent organization.
     **/
     public OrganizationPOSTRequest parentId(String parentId) {
 
@@ -87,11 +88,9 @@ public class OrganizationPOSTRequest  {
         return this;
     }
     
-    @ApiModelProperty(example = "b4526d91-a8bf-43d2-8b14-c548cf73065b", required = true, value = "")
+    @ApiModelProperty(example = "b4526d91-a8bf-43d2-8b14-c548cf73065b", value = "If the parentId is not present, the ROOT will be taken as the parent organization.")
     @JsonProperty("parentId")
     @Valid
-    @NotNull(message = "Property parentId cannot be null.")
-
     public String getParentId() {
         return parentId;
     }

--- a/components/org.wso2.carbon.identity.organization.management.endpoint/src/gen/java/org/wso2/carbon/identity/organization/management/endpoint/model/OrganizationPUTRequest.java
+++ b/components/org.wso2.carbon.identity.organization.management.endpoint/src/gen/java/org/wso2/carbon/identity/organization/management/endpoint/model/OrganizationPUTRequest.java
@@ -37,6 +37,40 @@ public class OrganizationPUTRequest  {
   
     private String name;
     private String description;
+
+@XmlType(name="StatusEnum")
+@XmlEnum(String.class)
+public enum StatusEnum {
+
+    @XmlEnumValue("ACTIVE") ACTIVE(String.valueOf("ACTIVE")), @XmlEnumValue("DISABLED") DISABLED(String.valueOf("DISABLED"));
+
+
+    private String value;
+
+    StatusEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static StatusEnum fromValue(String value) {
+        for (StatusEnum b : StatusEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private StatusEnum status;
     private List<Attribute> attributes = null;
 
 
@@ -80,6 +114,26 @@ public class OrganizationPUTRequest  {
 
     /**
     **/
+    public OrganizationPUTRequest status(StatusEnum status) {
+
+        this.status = status;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "ACTIVE", required = true, value = "")
+    @JsonProperty("status")
+    @Valid
+    @NotNull(message = "Property status cannot be null.")
+
+    public StatusEnum getStatus() {
+        return status;
+    }
+    public void setStatus(StatusEnum status) {
+        this.status = status;
+    }
+
+    /**
+    **/
     public OrganizationPUTRequest attributes(List<Attribute> attributes) {
 
         this.attributes = attributes;
@@ -118,12 +172,13 @@ public class OrganizationPUTRequest  {
         OrganizationPUTRequest organizationPUTRequest = (OrganizationPUTRequest) o;
         return Objects.equals(this.name, organizationPUTRequest.name) &&
             Objects.equals(this.description, organizationPUTRequest.description) &&
+            Objects.equals(this.status, organizationPUTRequest.status) &&
             Objects.equals(this.attributes, organizationPUTRequest.attributes);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, description, attributes);
+        return Objects.hash(name, description, status, attributes);
     }
 
     @Override
@@ -134,6 +189,7 @@ public class OrganizationPUTRequest  {
         
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
         sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("    status: ").append(toIndentedString(status)).append("\n");
         sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");
         sb.append("}");
         return sb.toString();

--- a/components/org.wso2.carbon.identity.organization.management.endpoint/src/gen/java/org/wso2/carbon/identity/organization/management/endpoint/model/OrganizationResponse.java
+++ b/components/org.wso2.carbon.identity.organization.management.endpoint/src/gen/java/org/wso2/carbon/identity/organization/management/endpoint/model/OrganizationResponse.java
@@ -39,6 +39,40 @@ public class OrganizationResponse  {
     private String id;
     private String name;
     private String description;
+
+@XmlType(name="StatusEnum")
+@XmlEnum(String.class)
+public enum StatusEnum {
+
+    @XmlEnumValue("ACTIVE") ACTIVE(String.valueOf("ACTIVE")), @XmlEnumValue("DISABLED") DISABLED(String.valueOf("DISABLED"));
+
+
+    private String value;
+
+    StatusEnum(String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    public static StatusEnum fromValue(String value) {
+        for (StatusEnum b : StatusEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+    private StatusEnum status;
     private String created;
     private String lastModified;
     private ParentOrganization parent;
@@ -105,15 +139,37 @@ public class OrganizationResponse  {
 
     /**
     **/
+    public OrganizationResponse status(StatusEnum status) {
+
+        this.status = status;
+        return this;
+    }
+    
+    @ApiModelProperty(example = "ACTIVE", required = true, value = "")
+    @JsonProperty("status")
+    @Valid
+    @NotNull(message = "Property status cannot be null.")
+
+    public StatusEnum getStatus() {
+        return status;
+    }
+    public void setStatus(StatusEnum status) {
+        this.status = status;
+    }
+
+    /**
+    **/
     public OrganizationResponse created(String created) {
 
         this.created = created;
         return this;
     }
     
-    @ApiModelProperty(example = "2021-10-25T12:31:53.406Z", value = "")
+    @ApiModelProperty(example = "2021-10-25T12:31:53.406Z", required = true, value = "")
     @JsonProperty("created")
     @Valid
+    @NotNull(message = "Property created cannot be null.")
+
     public String getCreated() {
         return created;
     }
@@ -129,9 +185,11 @@ public class OrganizationResponse  {
         return this;
     }
     
-    @ApiModelProperty(example = "2021-10-25T12:31:53.406Z", value = "")
+    @ApiModelProperty(example = "2021-10-25T12:31:53.406Z", required = true, value = "")
     @JsonProperty("lastModified")
     @Valid
+    @NotNull(message = "Property lastModified cannot be null.")
+
     public String getLastModified() {
         return lastModified;
     }
@@ -198,6 +256,7 @@ public class OrganizationResponse  {
         return Objects.equals(this.id, organizationResponse.id) &&
             Objects.equals(this.name, organizationResponse.name) &&
             Objects.equals(this.description, organizationResponse.description) &&
+            Objects.equals(this.status, organizationResponse.status) &&
             Objects.equals(this.created, organizationResponse.created) &&
             Objects.equals(this.lastModified, organizationResponse.lastModified) &&
             Objects.equals(this.parent, organizationResponse.parent) &&
@@ -206,7 +265,7 @@ public class OrganizationResponse  {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, description, created, lastModified, parent, attributes);
+        return Objects.hash(id, name, description, status, created, lastModified, parent, attributes);
     }
 
     @Override
@@ -218,6 +277,7 @@ public class OrganizationResponse  {
         sb.append("    id: ").append(toIndentedString(id)).append("\n");
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
         sb.append("    description: ").append(toIndentedString(description)).append("\n");
+        sb.append("    status: ").append(toIndentedString(status)).append("\n");
         sb.append("    created: ").append(toIndentedString(created)).append("\n");
         sb.append("    lastModified: ").append(toIndentedString(lastModified)).append("\n");
         sb.append("    parent: ").append(toIndentedString(parent)).append("\n");

--- a/components/org.wso2.carbon.identity.organization.management.endpoint/src/gen/java/org/wso2/carbon/identity/organization/management/endpoint/model/ParentOrganization.java
+++ b/components/org.wso2.carbon.identity.organization.management.endpoint/src/gen/java/org/wso2/carbon/identity/organization/management/endpoint/model/ParentOrganization.java
@@ -33,7 +33,7 @@ import javax.xml.bind.annotation.*;
 public class ParentOrganization  {
   
     private String id;
-    private String self;
+    private String ref;
 
     /**
     **/
@@ -57,22 +57,22 @@ public class ParentOrganization  {
 
     /**
     **/
-    public ParentOrganization self(String self) {
+    public ParentOrganization ref(String ref) {
 
-        this.self = self;
+        this.ref = ref;
         return this;
     }
     
     @ApiModelProperty(example = "t/carbon.super/api/identity/organization-mgt/v1.0/b4526d91-a8bf-43d2-8b14-c548cf73065b", required = true, value = "")
-    @JsonProperty("self")
+    @JsonProperty("ref")
     @Valid
-    @NotNull(message = "Property self cannot be null.")
+    @NotNull(message = "Property ref cannot be null.")
 
-    public String getSelf() {
-        return self;
+    public String getRef() {
+        return ref;
     }
-    public void setSelf(String self) {
-        this.self = self;
+    public void setRef(String ref) {
+        this.ref = ref;
     }
 
 
@@ -88,12 +88,12 @@ public class ParentOrganization  {
         }
         ParentOrganization parentOrganization = (ParentOrganization) o;
         return Objects.equals(this.id, parentOrganization.id) &&
-            Objects.equals(this.self, parentOrganization.self);
+            Objects.equals(this.ref, parentOrganization.ref);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, self);
+        return Objects.hash(id, ref);
     }
 
     @Override
@@ -103,7 +103,7 @@ public class ParentOrganization  {
         sb.append("class ParentOrganization {\n");
         
         sb.append("    id: ").append(toIndentedString(id)).append("\n");
-        sb.append("    self: ").append(toIndentedString(self)).append("\n");
+        sb.append("    ref: ").append(toIndentedString(ref)).append("\n");
         sb.append("}");
         return sb.toString();
     }

--- a/components/org.wso2.carbon.identity.organization.management.endpoint/src/main/java/org/wso2/carbon/identity/organization/management/endpoint/impl/OrganizationsApiServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.endpoint/src/main/java/org/wso2/carbon/identity/organization/management/endpoint/impl/OrganizationsApiServiceImpl.java
@@ -44,9 +44,9 @@ public class OrganizationsApiServiceImpl implements OrganizationsApiService {
     }
 
     @Override
-    public Response organizationsOrganizationIdDelete(String organizationId, Boolean force) {
+    public Response organizationsOrganizationIdDelete(String organizationId) {
 
-        return organizationManagementService.deleteOrganization(organizationId, force);
+        return organizationManagementService.deleteOrganization(organizationId);
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.organization.management.endpoint/src/main/java/org/wso2/carbon/identity/organization/management/endpoint/service/OrganizationManagementService.java
+++ b/components/org.wso2.carbon.identity.organization.management.endpoint/src/main/java/org/wso2/carbon/identity/organization/management/endpoint/service/OrganizationManagementService.java
@@ -39,6 +39,7 @@ import org.wso2.carbon.identity.organization.management.endpoint.model.Organizat
 import org.wso2.carbon.identity.organization.management.endpoint.model.OrganizationsResponse;
 import org.wso2.carbon.identity.organization.management.endpoint.model.ParentOrganization;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementClientException;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementServerException;
@@ -70,6 +71,7 @@ import static org.wso2.carbon.identity.organization.management.endpoint.util.Org
 import static org.wso2.carbon.identity.organization.management.endpoint.util.OrganizationManagementEndpointUtil.handleServerErrorResponse;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_BUILDING_PAGINATED_RESPONSE_URL;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_INVALID_PAGINATION_PARAMETER_NEGATIVE_LIMIT;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ROOT;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.buildURIForBody;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.generateUniqueID;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.handleClientException;
@@ -109,13 +111,12 @@ public class OrganizationManagementService {
      * Delete an organization.
      *
      * @param organizationId Unique identifier for the requested organization to be deleted.
-     * @param force          Enforces the forceful deletion of child organizations belonging to this organization.
      * @return Organization deletion response.
      */
-    public Response deleteOrganization(String organizationId, Boolean force) {
+    public Response deleteOrganization(String organizationId) {
 
         try {
-            getOrganizationManager().deleteOrganization(organizationId, Boolean.TRUE.equals(force));
+            getOrganizationManager().deleteOrganization(organizationId);
             return Response.noContent().build();
         } catch (OrganizationManagementClientException e) {
             return handleClientErrorResponse(e, LOG);
@@ -213,7 +214,13 @@ public class OrganizationManagementService {
         organization.setId(generateUniqueID());
         organization.setName(organizationPOSTRequest.getName());
         organization.setDescription(organizationPOSTRequest.getDescription());
-        organization.getParent().setId(organizationPOSTRequest.getParentId());
+        organization.setStatus(OrganizationManagementConstants.OrganizationStatus.ACTIVE.toString());
+        String parentId = organizationPOSTRequest.getParentId();
+        if (StringUtils.isNotBlank(parentId)) {
+            organization.getParent().setId(parentId);
+        } else {
+            organization.getParent().setId(ROOT);
+        }
         List<Attribute> organizationAttributes = organizationPOSTRequest.getAttributes();
         if (CollectionUtils.isNotEmpty(organizationAttributes)) {
             organization.setAttributes(organizationAttributes.stream().map(attribute ->
@@ -228,6 +235,14 @@ public class OrganizationManagementService {
         organizationResponse.setId(organization.getId());
         organizationResponse.setName(organization.getName());
         organizationResponse.setDescription(organization.getDescription());
+
+        String status = organization.getStatus();
+        if (StringUtils.equals(status, OrganizationResponse.StatusEnum.ACTIVE.toString())) {
+            organizationResponse.setStatus(OrganizationResponse.StatusEnum.ACTIVE);
+        } else {
+            organizationResponse.setStatus(OrganizationResponse.StatusEnum.DISABLED);
+        }
+
         organizationResponse.setCreated(organization.getCreated().toString());
         organizationResponse.setLastModified(organization.getLastModified().toString());
         ParentOrganizationDO parentOrganizationDO = organization.getParent();
@@ -250,6 +265,12 @@ public class OrganizationManagementService {
         organizationResponse.setDescription(organization.getDescription());
         organizationResponse.setCreated(organization.getCreated().toString());
         organizationResponse.setLastModified(organization.getLastModified().toString());
+        String status = organization.getStatus();
+        if (StringUtils.equals(status, OrganizationResponse.StatusEnum.ACTIVE.toString())) {
+            organizationResponse.setStatus(GetOrganizationResponse.StatusEnum.ACTIVE);
+        } else {
+            organizationResponse.setStatus(GetOrganizationResponse.StatusEnum.DISABLED);
+        }
         ParentOrganizationDO parentOrganizationDO = organization.getParent();
         if (parentOrganizationDO != null) {
             organizationResponse.setParent(getParentOrganization(parentOrganizationDO));
@@ -280,7 +301,7 @@ public class OrganizationManagementService {
 
         ParentOrganization parentOrganization = new ParentOrganization();
         parentOrganization.setId(parentOrganizationDO.getId());
-        parentOrganization.setSelf(parentOrganizationDO.getSelf());
+        parentOrganization.setRef(parentOrganizationDO.getRef());
         return parentOrganization;
     }
 
@@ -291,7 +312,7 @@ public class OrganizationManagementService {
             for (ChildOrganizationDO childOrganizationDO : organization.getChildOrganizations()) {
                 ChildOrganization childOrganization = new ChildOrganization();
                 childOrganization.setId(childOrganizationDO.getId());
-                childOrganization.setSelf(childOrganizationDO.getSelf());
+                childOrganization.setRef(childOrganizationDO.getRef());
                 childOrganizations.add(childOrganization);
             }
             if (!childOrganizations.isEmpty()) {
@@ -381,7 +402,7 @@ public class OrganizationManagementService {
                 BasicOrganizationResponse organizationDTO = new BasicOrganizationResponse();
                 organizationDTO.setId(organization.getId());
                 organizationDTO.setName(organization.getName());
-                organizationDTO.setSelf(buildURIForBody(organization.getId()));
+                organizationDTO.setRef(buildURIForBody(organization.getId()));
                 organizationDTOs.add(organizationDTO);
             }
             organizationsResponse.setOrganizations(organizationDTOs);
@@ -398,6 +419,17 @@ public class OrganizationManagementService {
 
         organization.setName(organizationPUTRequest.getName());
         organization.setDescription(organizationPUTRequest.getDescription());
+
+        OrganizationPUTRequest.StatusEnum statusEnum = organizationPUTRequest.getStatus();
+        if (statusEnum != null) {
+            String organizationStatus = statusEnum.toString();
+            if (StringUtils.isNotBlank(organizationStatus)) {
+                organization.setStatus(organizationStatus);
+            }
+        } else {
+            organization.setStatus(null);
+        }
+
         List<Attribute> organizationAttributes = organizationPUTRequest.getAttributes();
         if (CollectionUtils.isNotEmpty(organizationAttributes)) {
             organization.setAttributes(organizationAttributes.stream().map(attribute ->

--- a/components/org.wso2.carbon.identity.organization.management.endpoint/src/main/java/org/wso2/carbon/identity/organization/management/endpoint/service/OrganizationManagementService.java
+++ b/components/org.wso2.carbon.identity.organization.management.endpoint/src/main/java/org/wso2/carbon/identity/organization/management/endpoint/service/OrganizationManagementService.java
@@ -236,12 +236,13 @@ public class OrganizationManagementService {
         organizationResponse.setName(organization.getName());
         organizationResponse.setDescription(organization.getDescription());
 
-        String status = organization.getStatus();
-        if (StringUtils.equals(status, OrganizationResponse.StatusEnum.ACTIVE.toString())) {
-            organizationResponse.setStatus(OrganizationResponse.StatusEnum.ACTIVE);
-        } else {
-            organizationResponse.setStatus(OrganizationResponse.StatusEnum.DISABLED);
+        OrganizationResponse.StatusEnum status;
+        try {
+            status = OrganizationResponse.StatusEnum.valueOf(organization.getStatus());
+        } catch (IllegalArgumentException e) {
+            status = OrganizationResponse.StatusEnum.DISABLED;
         }
+        organizationResponse.setStatus(status);
 
         organizationResponse.setCreated(organization.getCreated().toString());
         organizationResponse.setLastModified(organization.getLastModified().toString());
@@ -265,12 +266,15 @@ public class OrganizationManagementService {
         organizationResponse.setDescription(organization.getDescription());
         organizationResponse.setCreated(organization.getCreated().toString());
         organizationResponse.setLastModified(organization.getLastModified().toString());
-        String status = organization.getStatus();
-        if (StringUtils.equals(status, OrganizationResponse.StatusEnum.ACTIVE.toString())) {
-            organizationResponse.setStatus(GetOrganizationResponse.StatusEnum.ACTIVE);
-        } else {
-            organizationResponse.setStatus(GetOrganizationResponse.StatusEnum.DISABLED);
+
+        GetOrganizationResponse.StatusEnum status;
+        try {
+            status = GetOrganizationResponse.StatusEnum.valueOf(organization.getStatus());
+        } catch (IllegalArgumentException e) {
+            status = GetOrganizationResponse.StatusEnum.DISABLED;
         }
+        organizationResponse.setStatus(status);
+
         ParentOrganizationDO parentOrganizationDO = organization.getParent();
         if (parentOrganizationDO != null) {
             organizationResponse.setParent(getParentOrganization(parentOrganizationDO));

--- a/components/org.wso2.carbon.identity.organization.management.endpoint/src/main/resources/org.wso2.carbon.identity.organization.management.yaml
+++ b/components/org.wso2.carbon.identity.organization.management.endpoint/src/main/resources/org.wso2.carbon.identity.organization.management.yaml
@@ -211,7 +211,6 @@ paths:
           required: true
           schema:
             type: string
-        - $ref: '#/components/parameters/forceQueryParam'
       responses:
         '204':
           description: Successfully deleted
@@ -273,15 +272,6 @@ components:
       schema:
         type: boolean
         default: false
-    forceQueryParam:
-      in: query
-      name: force
-      required: false
-      description:
-        Enforces the forceful deletion of an organization along with the belonging sub organizations.
-      schema:
-        type: boolean
-        default: false
 
   schemas:
     Error:
@@ -311,7 +301,6 @@ components:
       type: object
       required:
         - name
-        - parentId
       properties:
         name:
           type: string
@@ -322,6 +311,7 @@ components:
         parentId:
           type: string
           example: "b4526d91-a8bf-43d2-8b14-c548cf73065b"
+          description: "If the parentId is not present, the ROOT will be taken as the parent organization."
         attributes:
           type: array
           items:
@@ -330,6 +320,7 @@ components:
       type: object
       required:
         - name
+        - status
       properties:
         name:
           type: string
@@ -337,6 +328,10 @@ components:
         description:
           type: string
           example: "Building constructions"
+        status:
+          type: string
+          enum: [ACTIVE, DISABLED]
+          example: ACTIVE
         attributes:
           type: array
           items:
@@ -390,7 +385,7 @@ components:
       required:
         - id
         - name
-        - self
+        - ref
       properties:
         id:
           type: string
@@ -398,7 +393,7 @@ components:
         name:
           type: string
           example: 'ABC Builders'
-        self:
+        ref:
           type: string
           example: 't/carbon.super/api/identity/organization-mgt/v1.0/b4526d91-a8bf-43d2-8b14-c548cf73065b'
     OrganizationResponse:
@@ -406,6 +401,9 @@ components:
       required:
         - id
         - name
+        - status
+        - created
+        - lastModified
       properties:
         id:
           type: string
@@ -416,6 +414,10 @@ components:
         description:
           type: string
           example: 'Building constructions'
+        status:
+          type: string
+          enum: [ACTIVE, DISABLED]
+          example: ACTIVE
         created:
           type: string
           example: '2021-10-25T12:31:53.406Z'
@@ -433,6 +435,9 @@ components:
       required:
         - id
         - name
+        - status
+        - created
+        - lastModified
       properties:
         id:
           type: string
@@ -443,6 +448,10 @@ components:
         description:
           type: string
           example: 'Building constructions'
+        status:
+          type: string
+          enum: [ACTIVE, DISABLED]
+          example: ACTIVE
         created:
           type: string
           example: '2021-10-25T12:31:53.406Z'
@@ -466,12 +475,12 @@ components:
       type: object
       required:
         - id
-        - self
+        - ref
       properties:
         id:
           type: string
           example: 'b4526d91-a8bf-43d2-8b14-c548cf73065b'
-        self:
+        ref:
           type: string
           example: 't/carbon.super/api/identity/organization-mgt/v1.0/b4526d91-a8bf-43d2-8b14-c548cf73065b'
     #-----------------------------------------------------
@@ -481,12 +490,12 @@ components:
       type: object
       required:
         - id
-        - self
+        - ref
       properties:
         id:
           type: string
           example: 'd8f9780e-3a9a-4ae0-8d94-1a2d1aa3ec14'
-        self:
+        ref:
           type: string
           example: 't/carbon.super/api/identity/organization-mgt/v1.0/d8f9780e-3a9a-4ae0-8d94-1a2d1aa3ec14'
 

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManager.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManager.java
@@ -94,10 +94,9 @@ public interface OrganizationManager {
      * Delete the organization identified by the provided ID.
      *
      * @param organizationId The organization ID.
-     * @param force          Enforces the forceful deletion of child organizations belonging to this organization.
      * @throws OrganizationManagementException The exception thrown when deleting an organization.
      */
-    void deleteOrganization(String organizationId, boolean force) throws OrganizationManagementException;
+    void deleteOrganization(String organizationId) throws OrganizationManagementException;
 
     /**
      * Patch organization and its attributes.

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.identity.core.model.Node;
 import org.wso2.carbon.identity.core.model.OperationNode;
 import org.wso2.carbon.identity.organization.management.authz.service.OrganizationManagementAuthorizationManager;
 import org.wso2.carbon.identity.organization.management.authz.service.exception.OrganizationManagementAuthzServiceServerException;
+import org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants;
 import org.wso2.carbon.identity.organization.management.service.dao.OrganizationManagementDAO;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementClientException;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
@@ -56,12 +57,15 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.AND;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.CREATE_ORGANIZATION_ADMIN_PERMISSION;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.CREATE_ORGANIZATION_PERMISSION;
-import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.CREATE_ROOT_ORGANIZATION_PERMISSION;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ACTIVE_CHILD_ORGANIZATIONS_EXIST;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ATTRIBUTE_KEY_MISSING;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ATTRIBUTE_VALUE_MISSING;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_CREATE_REQUEST_PARENT_ORGANIZATION_IS_DISABLED;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_DUPLICATE_ATTRIBUTE_KEYS;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_EVALUATING_ADD_ORGANIZATION_AUTHORIZATION;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_EVALUATING_ADD_ORGANIZATION_TO_ROOT_AUTHORIZATION;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_EVALUATING_ADD_ROOT_ORGANIZATION_AUTHORIZATION;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_INVALID_CURSOR_FOR_PAGINATION;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_INVALID_FILTER_FORMAT;
@@ -72,6 +76,7 @@ import static org.wso2.carbon.identity.organization.management.service.constant.
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ORGANIZATION_ID_UNDEFINED;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ORGANIZATION_NAME_CONFLICT;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ORGANIZATION_NAME_RESERVED;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_PARENT_ORGANIZATION_IS_DISABLED;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_PATCH_OPERATION_UNDEFINED;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_PATCH_REQUEST_ATTRIBUTE_KEY_UNDEFINED;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_PATCH_REQUEST_INVALID_PATH;
@@ -83,6 +88,7 @@ import static org.wso2.carbon.identity.organization.management.service.constant.
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_REQUIRED_FIELDS_MISSING;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_UNSUPPORTED_COMPLEX_QUERY_IN_FILTER;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_UNSUPPORTED_FILTER_ATTRIBUTE;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_UNSUPPORTED_ORGANIZATION_STATUS;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_USER_NOT_AUTHORIZED_TO_CREATE_ORGANIZATION;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_USER_NOT_AUTHORIZED_TO_CREATE_ROOT_ORGANIZATION;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ORGANIZATION_CREATED_TIME_FIELD;
@@ -90,6 +96,9 @@ import static org.wso2.carbon.identity.organization.management.service.constant.
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ORGANIZATION_ID_FIELD;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ORGANIZATION_LAST_MODIFIED_FIELD;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ORGANIZATION_NAME_FIELD;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ORGANIZATION_STATUS_FIELD;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.OrganizationStatus.ACTIVE;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.OrganizationStatus.DISABLED;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.PAGINATION_AFTER;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.PAGINATION_BEFORE;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.PARENT_ID_FIELD;
@@ -99,6 +108,7 @@ import static org.wso2.carbon.identity.organization.management.service.constant.
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.PATCH_PATH_ORG_ATTRIBUTES;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.PATCH_PATH_ORG_DESCRIPTION;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.PATCH_PATH_ORG_NAME;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.PATCH_PATH_ORG_STATUS;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ROOT;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.buildURIForBody;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.generateUniqueID;
@@ -118,7 +128,7 @@ public class OrganizationManagerImpl implements OrganizationManager {
             OrganizationManagementException {
 
         String tenantDomain = getTenantDomain();
-        validateAddOrganizationRequest(organization);
+        validateAddOrganizationRequest(tenantDomain, organization);
         setParentOrganization(organization, tenantDomain);
         setCreatedAndLastModifiedTime(organization);
         getOrganizationManagementDAO().addOrganization(getTenantId(), tenantDomain, organization);
@@ -162,7 +172,7 @@ public class OrganizationManagerImpl implements OrganizationManager {
         }
 
         if (!ROOT.equals(organization.getName())) {
-            organization.getParent().setSelf(buildURIForBody(organization.getParent().getId()));
+            organization.getParent().setRef(buildURIForBody(organization.getParent().getId()));
         }
 
         if (showChildren) {
@@ -173,7 +183,7 @@ public class OrganizationManagerImpl implements OrganizationManager {
                 for (String childOrganizationId : childOrganizationIds) {
                     ChildOrganizationDO childOrganization = new ChildOrganizationDO();
                     childOrganization.setId(childOrganizationId);
-                    childOrganization.setSelf(buildURIForBody(childOrganizationId));
+                    childOrganization.setRef(buildURIForBody(childOrganizationId));
                     childOrganizations.add(childOrganization);
                 }
                 organization.setChildOrganizations(childOrganizations);
@@ -194,7 +204,7 @@ public class OrganizationManagerImpl implements OrganizationManager {
     }
 
     @Override
-    public void deleteOrganization(String organizationId, boolean force) throws OrganizationManagementException {
+    public void deleteOrganization(String organizationId) throws OrganizationManagementException {
 
         if (StringUtils.isBlank(organizationId)) {
             throw handleClientException(ERROR_CODE_ORGANIZATION_ID_UNDEFINED);
@@ -203,15 +213,9 @@ public class OrganizationManagerImpl implements OrganizationManager {
             throw handleClientException(ERROR_CODE_INVALID_ORGANIZATION, organizationId, getTenantDomain());
         }
 
-        /*
-        Organization shouldn't have any child organizations when the organization delete request is not defined as a
-        forceful delete.
-         */
-        if (!force) {
-            validateOrganizationDelete(organizationId);
-        }
-        getOrganizationManagementDAO().deleteOrganization(getTenantId(), organizationId.trim(), getTenantDomain(),
-                force);
+        validateOrganizationDelete(organizationId);
+
+        getOrganizationManagementDAO().deleteOrganization(getTenantId(), organizationId.trim(), getTenantDomain());
     }
 
     @Override
@@ -233,7 +237,7 @@ public class OrganizationManagerImpl implements OrganizationManager {
         Organization organization = getOrganizationManagementDAO().getOrganization(getTenantId(), organizationId,
                 tenantDomain);
         if (!ROOT.equals(organization.getName())) {
-            organization.getParent().setSelf(buildURIForBody(organization.getParent().getId()));
+            organization.getParent().setRef(buildURIForBody(organization.getParent().getId()));
         }
 
         return organization;
@@ -258,7 +262,7 @@ public class OrganizationManagerImpl implements OrganizationManager {
         Organization updatedOrganization = getOrganizationManagementDAO().getOrganization(getTenantId(), organizationId,
                 getTenantDomain());
         if (!ROOT.equals(updatedOrganization.getName())) {
-            updatedOrganization.getParent().setSelf(buildURIForBody(updatedOrganization.getParent().getId()));
+            updatedOrganization.getParent().setRef(buildURIForBody(updatedOrganization.getParent().getId()));
         }
 
         return updatedOrganization;
@@ -288,6 +292,7 @@ public class OrganizationManagerImpl implements OrganizationManager {
         organization.setId(generateUniqueID());
         organization.setName(ROOT);
         setCreatedAndLastModifiedTime(organization);
+        organization.setStatus(ACTIVE.toString());
         getOrganizationManagementDAO().addOrganization(getTenantId(), getTenantDomain(), organization);
     }
 
@@ -298,20 +303,29 @@ public class OrganizationManagerImpl implements OrganizationManager {
         organization.setLastModified(now);
     }
 
-    private void validateAddOrganizationRequest(Organization organization) throws OrganizationManagementException {
+    private void validateAddOrganizationRequest(String tenantDomain, Organization organization) throws
+            OrganizationManagementException {
 
         validateAddOrganizationRequiredFields(organization);
-        validateAddOrganizationNameField(organization);
-        validateOrganizationAttributes(organization);
-        validateAddOrganizationParent(organization);
+        validateAddOrganizationNameField(organization.getName());
+        validateOrganizationAttributes(organization.getAttributes());
+        validateAddOrganizationParentExistence(tenantDomain, organization.getParent().getId());
     }
 
-    private void validateAddOrganizationParent(Organization organization) throws OrganizationManagementException {
+    private void validateAddOrganizationParentExistence(String tenantDomain, String parentId)
+            throws OrganizationManagementException {
 
-        // Check if the parent organization exists.
-        String parentId = organization.getParent().getId();
-        if (!StringUtils.equals(ROOT, parentId) && !isOrganizationExistById(parentId.trim())) {
-            throw handleClientException(ERROR_CODE_INVALID_PARENT_ORGANIZATION, getTenantDomain());
+        if (!StringUtils.equals(ROOT, parentId) && !isOrganizationExistById(parentId)) {
+            throw handleClientException(ERROR_CODE_INVALID_PARENT_ORGANIZATION, tenantDomain);
+        }
+    }
+
+    private void validateAddOrganizationParentStatus(String tenantDomain, String parentId)
+            throws OrganizationManagementException {
+
+        String parentStatus = getOrganizationManagementDAO().getOrganizationStatus(parentId, tenantDomain);
+        if (!StringUtils.equals(ACTIVE.toString(), parentStatus)) {
+            throw handleClientException(ERROR_CODE_CREATE_REQUEST_PARENT_ORGANIZATION_IS_DISABLED, parentId);
         }
     }
 
@@ -326,6 +340,7 @@ public class OrganizationManagerImpl implements OrganizationManager {
             OrganizationManagementClientException {
 
         validateOrganizationRequiredFieldName(organization.getName());
+        validateOrganizationRequiredFieldStatus(organization.getStatus());
     }
 
     private void validateOrganizationRequiredFieldParentId(String parentId) throws
@@ -344,10 +359,16 @@ public class OrganizationManagerImpl implements OrganizationManager {
         }
     }
 
-    private void validateOrganizationAttributes(Organization organization) throws
+    private void validateOrganizationRequiredFieldStatus(String organizationStatus) throws
             OrganizationManagementClientException {
 
-        List<OrganizationAttribute> organizationAttributes = organization.getAttributes();
+        if (StringUtils.isBlank(organizationStatus)) {
+            throw handleClientException(ERROR_CODE_REQUIRED_FIELDS_MISSING, ORGANIZATION_STATUS_FIELD);
+        }
+    }
+
+    private void validateOrganizationAttributes(List<OrganizationAttribute> organizationAttributes) throws
+            OrganizationManagementClientException {
 
         for (OrganizationAttribute attribute : organizationAttributes) {
             String attributeKey = attribute.getKey();
@@ -366,22 +387,19 @@ public class OrganizationManagerImpl implements OrganizationManager {
         // Check if attribute keys are duplicated.
         Set<String> tempSet = organizationAttributes.stream().map(OrganizationAttribute::getKey)
                 .collect(Collectors.toSet());
-        if (organization.getAttributes().size() > tempSet.size()) {
+        if (organizationAttributes.size() > tempSet.size()) {
             throw handleClientException(ERROR_CODE_DUPLICATE_ATTRIBUTE_KEYS);
         }
     }
 
-    private void validateAddOrganizationNameField(Organization organization) throws OrganizationManagementException {
+    private void validateAddOrganizationNameField(String organizationName) throws OrganizationManagementException {
 
-        organization.setName(organization.getName().trim());
-        if (StringUtils.equals(organization.getName(), ROOT)) {
+        if (StringUtils.equals(organizationName, ROOT)) {
             throw handleClientException(ERROR_CODE_ORGANIZATION_NAME_RESERVED, ROOT);
         }
 
-        // Check if the organization name already exists for the given tenant.
-        if (isOrganizationExistByName(organization.getName())) {
-            throw handleClientException(ERROR_CODE_ORGANIZATION_NAME_CONFLICT, organization.getName(),
-                    getTenantDomain());
+        if (isOrganizationExistByName(organizationName)) {
+            throw handleClientException(ERROR_CODE_ORGANIZATION_NAME_CONFLICT, organizationName, getTenantDomain());
         }
     }
 
@@ -390,8 +408,7 @@ public class OrganizationManagerImpl implements OrganizationManager {
 
         ParentOrganizationDO parentOrganization = organization.getParent();
         String parentId = parentOrganization.getId().trim();
-        boolean createOrganizationAuthorizationRequired = true;
-
+        boolean authorized = false;
         /*
         For parentId an alias as 'ROOT' is supported. This indicates that the organization should be created as an
         immediate child of the ROOT organization of this tenant. If a ROOT organization is not already available for
@@ -401,38 +418,56 @@ public class OrganizationManagerImpl implements OrganizationManager {
             String rootOrganizationId = getOrganizationIdByName(ROOT);
             if (StringUtils.isBlank(rootOrganizationId)) {
                 addRootOrganization(tenantDomain);
-                createOrganizationAuthorizationRequired = false;
                 rootOrganizationId = getOrganizationIdByName(ROOT);
+                authorized = true;
             }
             parentId = rootOrganizationId;
         }
 
-        /*
-        For a first time organization creation in a tenant, the evaluation of user's authorization to create an
-        organization as a child of the given parent (ROOT organization) will not happen.
-        Having '/permission/admin/' assigned to the user would be sufficient in this scenario. This permission implies
-        that the user is authorized to create the ROOT organization in the tenant along with the organization that the
-        user is requesting to be created in the request.
-         */
-        if (createOrganizationAuthorizationRequired && !isUserAuthorizedToCreateOrganization(parentId)) {
-            throw handleClientException(ERROR_CODE_USER_NOT_AUTHORIZED_TO_CREATE_ORGANIZATION, parentId);
+        if (!authorized) {
+            validateAddOrganizationParentStatus(tenantDomain, parentId);
+            /*
+            Having '/permission/admin/' assigned to the user would be sufficient to create an organization as an
+            immediate child organization of the ROOT organization.
+             */
+            if (StringUtils.equals(getOrganizationIdByName(ROOT), parentId)) {
+                if (!isUserAuthorizedToCreateChildOrganizationInRoot(tenantDomain) &&
+                        !isUserAuthorizedToCreateOrganization(parentId)) {
+                    throw handleClientException(ERROR_CODE_USER_NOT_AUTHORIZED_TO_CREATE_ORGANIZATION, parentId);
+                }
+            } else if (!isUserAuthorizedToCreateOrganization(parentId)) {
+                throw handleClientException(ERROR_CODE_USER_NOT_AUTHORIZED_TO_CREATE_ORGANIZATION, parentId);
+            }
         }
         parentOrganization.setId(parentId);
-        parentOrganization.setSelf(buildURIForBody(parentId));
+        parentOrganization.setRef(buildURIForBody(parentId));
     }
 
     private boolean isUserAuthorizedToCreateRootOrganization(String tenantDomain) throws
             OrganizationManagementServerException {
 
+        return isUserHavingAdminPermission(tenantDomain,
+                ERROR_CODE_ERROR_EVALUATING_ADD_ROOT_ORGANIZATION_AUTHORIZATION);
+    }
+
+    private boolean isUserAuthorizedToCreateChildOrganizationInRoot(String tenantDomain) throws
+            OrganizationManagementServerException {
+
+        return isUserHavingAdminPermission(tenantDomain,
+                ERROR_CODE_ERROR_EVALUATING_ADD_ORGANIZATION_TO_ROOT_AUTHORIZATION);
+    }
+
+    private boolean isUserHavingAdminPermission(String tenantDomain, OrganizationManagementConstants.ErrorMessages
+            error) throws OrganizationManagementServerException {
+
         String username = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
         try {
             UserRealm tenantUserRealm = getRealmService().getTenantUserRealm(getTenantId());
             AuthorizationManager authorizationManager = tenantUserRealm.getAuthorizationManager();
-            return authorizationManager.isUserAuthorized(username, CREATE_ROOT_ORGANIZATION_PERMISSION,
+            return authorizationManager.isUserAuthorized(username, CREATE_ORGANIZATION_ADMIN_PERMISSION,
                     CarbonConstants.UI_PERMISSION_ACTION);
         } catch (UserStoreException e) {
-            throw handleServerException(ERROR_CODE_ERROR_EVALUATING_ADD_ROOT_ORGANIZATION_AUTHORIZATION, e,
-                    tenantDomain);
+            throw handleServerException(error, e, tenantDomain);
         }
     }
 
@@ -450,6 +485,7 @@ public class OrganizationManagerImpl implements OrganizationManager {
             throws OrganizationManagementException {
 
         validateUpdateOrganizationRequiredFields(organization);
+        validateOrganizationStatusUpdate(organization.getStatus(), organization.getId());
 
         String newOrganizationName = organization.getName().trim();
         // Check if the organization name already exists for the given tenant.
@@ -459,7 +495,7 @@ public class OrganizationManagerImpl implements OrganizationManager {
         }
         organization.setName(newOrganizationName);
 
-        validateOrganizationAttributes(organization);
+        validateOrganizationAttributes(organization.getAttributes());
     }
 
     private void validateOrganizationPatchOperations(List<PatchOperation> patchOperations, String organizationId,
@@ -486,7 +522,7 @@ public class OrganizationManagerImpl implements OrganizationManager {
             Fields such as the parentId can't be modified with the current implementation.
              */
             if (!(path.equals(PATCH_PATH_ORG_NAME) || path.equals(PATCH_PATH_ORG_DESCRIPTION) ||
-                    path.startsWith(PATCH_PATH_ORG_ATTRIBUTES))) {
+                    path.equals(PATCH_PATH_ORG_STATUS) || path.startsWith(PATCH_PATH_ORG_ATTRIBUTES))) {
                 throw handleClientException(ERROR_CODE_PATCH_REQUEST_INVALID_PATH, path);
             }
 
@@ -512,6 +548,10 @@ public class OrganizationManagerImpl implements OrganizationManager {
                 throw handleClientException(ERROR_CODE_ORGANIZATION_NAME_CONFLICT, value, getTenantDomain());
             }
 
+            if (StringUtils.equals(PATCH_PATH_ORG_STATUS, path)) {
+                validateOrganizationStatusUpdate(value, organizationId);
+            }
+
             if (path.startsWith(PATCH_PATH_ORG_ATTRIBUTES)) {
                 String attributeKey = path.replace(PATCH_PATH_ORG_ATTRIBUTES, "").trim();
                 // Attribute key can not be empty.
@@ -535,6 +575,21 @@ public class OrganizationManagerImpl implements OrganizationManager {
             patchOperation.setOp(op);
             patchOperation.setPath(path);
             patchOperation.setValue(value);
+        }
+    }
+
+    private void validateOrganizationStatusUpdate(String value, String organizationId)
+            throws OrganizationManagementException {
+
+        if (!(StringUtils.equals(ACTIVE.toString(), value) || StringUtils.equals(DISABLED.toString(), value))) {
+            throw handleClientException(ERROR_CODE_UNSUPPORTED_ORGANIZATION_STATUS, value);
+        }
+        if (StringUtils.equals(DISABLED.toString(), value) &&
+                getOrganizationManagementDAO().hasActiveChildOrganizations(organizationId)) {
+            throw handleClientException(ERROR_CODE_ACTIVE_CHILD_ORGANIZATIONS_EXIST, organizationId);
+        } else if (StringUtils.equals(ACTIVE.toString(), value) &&
+                getOrganizationManagementDAO().isParentOrganizationDisabled(organizationId, getTenantDomain())) {
+            throw handleClientException(ERROR_CODE_PARENT_ORGANIZATION_IS_DISABLED);
         }
     }
 
@@ -614,6 +669,7 @@ public class OrganizationManagerImpl implements OrganizationManager {
                 !attributeValue.equalsIgnoreCase(ORGANIZATION_DESCRIPTION_FIELD) &&
                 !attributeValue.equalsIgnoreCase(ORGANIZATION_CREATED_TIME_FIELD) &&
                 !attributeValue.equalsIgnoreCase(ORGANIZATION_LAST_MODIFIED_FIELD) &&
+                !attributeValue.equalsIgnoreCase(PARENT_ID_FIELD) &&
                 !attributeValue.equalsIgnoreCase(PAGINATION_AFTER) &&
                 !attributeValue.equalsIgnoreCase(PAGINATION_BEFORE);
     }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
@@ -33,10 +33,12 @@ public class OrganizationManagementConstants {
     public static final String ORGANIZATION_MANAGEMENT_API_PATH_COMPONENT = "/api/identity/organization-mgt/";
     private static final String ORGANIZATION_MANAGEMENT_ERROR_CODE_PREFIX = "ORG-";
 
+    public static final String VIEW_ID_COLUMN = "UM_ID";
     public static final String VIEW_NAME_COLUMN = "UM_ORG_NAME";
     public static final String VIEW_DESCRIPTION_COLUMN = "UM_ORG_DESCRIPTION";
     public static final String VIEW_CREATED_TIME_COLUMN = "UM_CREATED_TIME";
     public static final String VIEW_LAST_MODIFIED_COLUMN = "UM_LAST_MODIFIED";
+    public static final String VIEW_STATUS_COLUMN = "UM_STATUS";
     public static final String VIEW_PARENT_ID_COLUMN = "UM_PARENT_ID";
     public static final String VIEW_ATTR_KEY_COLUMN = "UM_ATTRIBUTE_KEY";
     public static final String VIEW_ATTR_VALUE_COLUMN = "UM_ATTRIBUTE_VALUE";
@@ -46,6 +48,7 @@ public class OrganizationManagementConstants {
     public static final String PATCH_OP_REPLACE = "REPLACE";
     public static final String PATCH_PATH_ORG_NAME = "/name";
     public static final String PATCH_PATH_ORG_DESCRIPTION = "/description";
+    public static final String PATCH_PATH_ORG_STATUS = "/status";
     public static final String PATCH_PATH_ORG_ATTRIBUTES = "/attributes/";
 
     public static final String PARENT_ID_FIELD = "parentId";
@@ -54,11 +57,12 @@ public class OrganizationManagementConstants {
     public static final String ORGANIZATION_DESCRIPTION_FIELD = "description";
     public static final String ORGANIZATION_CREATED_TIME_FIELD = "created";
     public static final String ORGANIZATION_LAST_MODIFIED_FIELD = "lastModified";
+    public static final String ORGANIZATION_STATUS_FIELD = "status";
 
     public static final String PAGINATION_AFTER = "after";
     public static final String PAGINATION_BEFORE = "before";
 
-    public static final String CREATE_ROOT_ORGANIZATION_PERMISSION = "/permission/admin/";
+    public static final String CREATE_ORGANIZATION_ADMIN_PERMISSION = "/permission/admin/";
     public static final String CREATE_ORGANIZATION_PERMISSION = "/permission/admin/manage/identity/organizationmgt/" +
             "create";
     public static final String VIEW_ORGANIZATION_PERMISSION = "/permission/admin/manage/identity/organizationmgt/" +
@@ -78,16 +82,26 @@ public class OrganizationManagementConstants {
 
     static {
 
-        attributeColumnMap.put(ORGANIZATION_NAME_FIELD, "UM_ORG_NAME");
-        attributeColumnMap.put(ORGANIZATION_ID_FIELD, "UM_ID");
-        attributeColumnMap.put(ORGANIZATION_DESCRIPTION_FIELD, "UM_ORG_DESCRIPTION");
-        attributeColumnMap.put(ORGANIZATION_CREATED_TIME_FIELD, "UM_CREATED_TIME");
-        attributeColumnMap.put(ORGANIZATION_LAST_MODIFIED_FIELD, "UM_LAST_MODIFIED");
-        attributeColumnMap.put(PAGINATION_AFTER, "UM_CREATED_TIME");
-        attributeColumnMap.put(PAGINATION_BEFORE, "UM_CREATED_TIME");
+        attributeColumnMap.put(ORGANIZATION_NAME_FIELD, VIEW_NAME_COLUMN);
+        attributeColumnMap.put(ORGANIZATION_ID_FIELD, "UM_ORG." + VIEW_ID_COLUMN);
+        attributeColumnMap.put(ORGANIZATION_DESCRIPTION_FIELD, VIEW_DESCRIPTION_COLUMN);
+        attributeColumnMap.put(ORGANIZATION_CREATED_TIME_FIELD, VIEW_CREATED_TIME_COLUMN);
+        attributeColumnMap.put(ORGANIZATION_LAST_MODIFIED_FIELD, VIEW_LAST_MODIFIED_COLUMN);
+        attributeColumnMap.put(PARENT_ID_FIELD, VIEW_PARENT_ID_COLUMN);
+        attributeColumnMap.put(PAGINATION_AFTER, VIEW_CREATED_TIME_COLUMN);
+        attributeColumnMap.put(PAGINATION_BEFORE, VIEW_CREATED_TIME_COLUMN);
     }
 
     public static final Map<String, String> ATTRIBUTE_COLUMN_MAP = Collections.unmodifiableMap(attributeColumnMap);
+
+    /**
+     * Enum for organization status.
+     */
+    public enum OrganizationStatus {
+
+        ACTIVE,
+        DISABLED
+    }
 
     /**
      * Enum for error messages related to organization management.
@@ -148,6 +162,14 @@ public class OrganizationManagementConstants {
                 "cursor used for pagination."),
         ERROR_CODE_USER_NOT_AUTHORIZED_TO_CREATE_ROOT_ORGANIZATION("60027", "Unable to create the organization.",
                 "User is not authorized to create the root organization in tenant: %s."), // 403
+        ERROR_CODE_UNSUPPORTED_ORGANIZATION_STATUS("60028", "Unsupported status provided.",
+                "Organization status must be 'ACTIVE' or 'DISABLED'."),
+        ERROR_CODE_ACTIVE_CHILD_ORGANIZATIONS_EXIST("60029", "Active child organizations exist.",
+                "Organization with ID: %s can't be disabled as there are active child organizations."),
+        ERROR_CODE_PARENT_ORGANIZATION_IS_DISABLED("60030", "Parent organization is disabled.",
+                "To set the child organization status as active, parent organization should be in active status."),
+        ERROR_CODE_CREATE_REQUEST_PARENT_ORGANIZATION_IS_DISABLED("60031", "Parent organization is disabled.",
+                "To create a child organization in organization with ID: %s, it should be in active status."),
 
         // Server errors.
         ERROR_CODE_UNEXPECTED("65001", "Unexpected processing error",
@@ -200,7 +222,18 @@ public class OrganizationManagementConstants {
                 "Server encountered an error while building paginated response URL."),
         ERROR_CODE_ERROR_EVALUATING_ADD_ROOT_ORGANIZATION_AUTHORIZATION("65021", "Unable to create the organization.",
                 "Server encountered an error while evaluating authorization of user to create the root " +
-                        "organization in tenant: %s.");
+                        "organization in tenant: %s."),
+        ERROR_CODE_ERROR_EVALUATING_ADD_ORGANIZATION_TO_ROOT_AUTHORIZATION("65022", "Unable to create the " +
+                "organization.", "Server encountered an error while evaluating authorization of user to create " +
+                "a child organization in root of tenant: %s."),
+        ERROR_CODE_ERROR_CHECKING_ACTIVE_CHILD_ORGANIZATIONS("65023", "Unable to retrieve active child " +
+                "organizations.", "Server encountered an error while retrieving the active child organizations " +
+                "of organization with ID: %s."),
+        ERROR_CODE_ERROR_RETRIEVING_PARENT_ORGANIZATION_STATUS("65024", "Unable to retrieve the status of " +
+                "the parent organization.", "Server encountered an error while checking the status of the parent " +
+                "organization of organization with ID: %s."),
+        ERROR_CODE_ERROR_RETRIEVING_ORGANIZATION_STATUS("65025", "Unable to retrieve the status of the organization.",
+                "Server encountered an error while checking the status of the organization with ID: %s.");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/SQLConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/SQLConstants.java
@@ -26,11 +26,12 @@ public class SQLConstants {
     public static final String PERMISSION_LIST_PLACEHOLDER = "_PERMISSION_LIST_";
 
     public static final String INSERT_ORGANIZATION = "INSERT INTO UM_ORG (UM_ID, UM_ORG_NAME, UM_ORG_DESCRIPTION, " +
-            "UM_CREATED_TIME, UM_LAST_MODIFIED, UM_TENANT_ID, UM_PARENT_ID) VALUES (:" +
+            "UM_CREATED_TIME, UM_LAST_MODIFIED, UM_STATUS, UM_TENANT_ID, UM_PARENT_ID) VALUES (:" +
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_ID + ";, :" + SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_NAME + ";, :" +
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_DESCRIPTION + ";, :" +
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_CREATED_TIME + ";, :" +
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_LAST_MODIFIED + ";, :" +
+            SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_STATUS + ";, :" +
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_TENANT_ID + ";, :" + SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_PARENT_ID
             + ";)";
 
@@ -51,9 +52,9 @@ public class SQLConstants {
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_KEY + ";, :" + SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_VALUE + ";)";
 
     public static final String GET_ORGANIZATION_BY_ID = "SELECT UM_ORG.UM_ID, UM_ORG_NAME, UM_ORG_DESCRIPTION, " +
-            "UM_CREATED_TIME, UM_LAST_MODIFIED, UM_PARENT_ID, UM_ATTRIBUTE_KEY, UM_ATTRIBUTE_VALUE FROM UM_ORG " +
-            "LEFT OUTER JOIN UM_ORG_ATTRIBUTE ON UM_ORG.UM_ID = UM_ORG_ATTRIBUTE.UM_ORG_ID WHERE UM_ORG.UM_ID = :" +
-            SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_ID + "; AND UM_TENANT_ID = :" +
+            "UM_CREATED_TIME, UM_LAST_MODIFIED, UM_STATUS, UM_PARENT_ID, UM_ATTRIBUTE_KEY, UM_ATTRIBUTE_VALUE FROM " +
+            "UM_ORG LEFT OUTER JOIN UM_ORG_ATTRIBUTE ON UM_ORG.UM_ID = UM_ORG_ATTRIBUTE.UM_ORG_ID WHERE " +
+            "UM_ORG.UM_ID = :" + SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_ID + "; AND UM_TENANT_ID = :" +
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_TENANT_ID + ";";
 
     public static final String GET_ORGANIZATIONS_BY_TENANT_ID = "SELECT UM_ORG.UM_ID, UM_ORG.UM_ORG_NAME, " +
@@ -91,7 +92,8 @@ public class SQLConstants {
     public static final String UPDATE_ORGANIZATION = "UPDATE UM_ORG SET UM_ORG_NAME = :" +
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_NAME + ";, UM_ORG_DESCRIPTION = :" +
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_DESCRIPTION + ";, UM_LAST_MODIFIED = :" +
-            SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_LAST_MODIFIED + "; WHERE UM_ID = :" +
+            SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_LAST_MODIFIED + ";, UM_STATUS = :" +
+            SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_STATUS + "; WHERE UM_ID = :" +
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_ID + ";";
 
     public static final String CHECK_ORGANIZATION_ATTRIBUTE_KEY_EXIST = "SELECT COUNT(1) FROM UM_ORG_ATTRIBUTE WHERE" +
@@ -111,8 +113,17 @@ public class SQLConstants {
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_PARENT_ID + "; AND UM_TENANT_ID = :" +
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_TENANT_ID + ";";
 
+    public static final String CHECK_CHILD_ORGANIZATIONS_STATUS = "SELECT COUNT(1) FROM UM_ORG WHERE UM_PARENT_ID = :" +
+            SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_PARENT_ID + "; AND UM_STATUS = :" +
+            SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_STATUS + ";";
+
+    public static final String GET_PARENT_ORGANIZATION_STATUS = "SELECT UM_STATUS FROM UM_ORG WHERE UM_ID = (SELECT " +
+            "UM_PARENT_ID FROM UM_ORG WHERE UM_ID = :" + SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_ID + ";)";
+
+    public static final String GET_ORGANIZATION_STATUS = "SELECT UM_STATUS FROM UM_ORG WHERE UM_ID = :" +
+            SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_ID + ";";
+
     public static final String COUNT_COLUMN = "COUNT(1)";
-    public static final String VIEW_ID_COLUMN = "UM_ID";
 
     /**
      * SQL Placeholders
@@ -126,6 +137,7 @@ public class SQLConstants {
         public static final String DB_SCHEMA_COLUMN_NAME_LAST_MODIFIED = "LAST_MODIFIED";
         public static final String DB_SCHEMA_COLUMN_NAME_TENANT_ID = "TENANT_ID";
         public static final String DB_SCHEMA_COLUMN_NAME_PARENT_ID = "PARENT_ID";
+        public static final String DB_SCHEMA_COLUMN_NAME_STATUS = "STATUS";
         public static final String DB_SCHEMA_COLUMN_NAME_KEY = "KEY";
         public static final String DB_SCHEMA_COLUMN_NAME_VALUE = "VALUE";
         public static final String DB_SCHEMA_COLUMN_NAME_USER_ID = "USER_ID";

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/OrganizationManagementDAO.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/OrganizationManagementDAO.java
@@ -118,10 +118,9 @@ public interface OrganizationManagementDAO {
      * @param tenantId       The tenant ID corresponding to the tenant where the organization should be deleted.
      * @param organizationId The organization ID.
      * @param tenantDomain   The tenant name corresponding to the tenant where the organization should be deleted.
-     * @param force          Enforces the forceful deletion of child organizations belonging to this organization.
      * @throws OrganizationManagementServerException The server exception thrown when deleting the organization.
      */
-    void deleteOrganization(int tenantId, String organizationId, String tenantDomain, boolean force) throws
+    void deleteOrganization(int tenantId, String organizationId, String tenantDomain) throws
             OrganizationManagementServerException;
 
     /**
@@ -185,4 +184,40 @@ public interface OrganizationManagementDAO {
      */
     List<String> getChildOrganizationIds(int tenantId, String organizationId, String tenantDomain, Organization
             organization) throws OrganizationManagementServerException;
+
+    /**
+     * Check if the organization has any child organizations with the status as 'ACTIVE'.
+     *
+     * @param organizationId The organization ID.
+     * @return true if 'ACTIVE' child organizations exist.
+     * @throws OrganizationManagementServerException The server exception thrown when checking if the organization has
+     *                                               any child organizations with the status as 'ACTIVE'.
+     */
+    boolean hasActiveChildOrganizations(String organizationId) throws OrganizationManagementServerException;
+
+    /**
+     * Check if the parent organization of an organization is having the status as 'DISABLED'.
+     *
+     * @param organizationId The organization ID.
+     * @param tenantDomain   The tenant name.
+     * @return true if the parent organization status is 'DISABLED'.
+     * @throws OrganizationManagementServerException The server exception thrown when checking if the parent
+     *                                               organization status is 'DISABLED'.
+     */
+    boolean isParentOrganizationDisabled(String organizationId, String tenantDomain) throws
+            OrganizationManagementServerException;
+
+    /**
+     * Retrieve the status of the organization.
+     *
+     * @param organizationId The organization ID.
+     * @param tenantDomain   The tenant name.
+     * @return the status of the organization.
+     * @throws OrganizationManagementServerException The server exception thrown when retrieving the status of the
+     *                                               organization.
+     */
+    String getOrganizationStatus(String organizationId, String tenantDomain) throws
+            OrganizationManagementServerException;
+
+
 }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/impl/OrganizationManagementDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/impl/OrganizationManagementDAOImpl.java
@@ -51,6 +51,7 @@ import static org.wso2.carbon.identity.organization.management.service.constant.
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.EQ;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.EW;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_ADDING_ORGANIZATION;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_CHECKING_ACTIVE_CHILD_ORGANIZATIONS;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_CHECKING_ORGANIZATION_ATTRIBUTE_KEY_EXIST;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_CHECKING_ORGANIZATION_EXIST_BY_ID;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_CHECKING_ORGANIZATION_EXIST_BY_NAME;
@@ -64,27 +65,35 @@ import static org.wso2.carbon.identity.organization.management.service.constant.
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_RETRIEVING_ORGANIZATIONS;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_RETRIEVING_ORGANIZATION_BY_ID;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_RETRIEVING_ORGANIZATION_ID_BY_NAME;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_RETRIEVING_ORGANIZATION_STATUS;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_RETRIEVING_PARENT_ORGANIZATION_STATUS;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_UPDATING_ORGANIZATION;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.GE;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.GT;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.LE;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.LT;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.OrganizationStatus.ACTIVE;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.OrganizationStatus.DISABLED;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.PATCH_OP_ADD;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.PATCH_OP_REMOVE;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.PATCH_OP_REPLACE;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.PATCH_PATH_ORG_ATTRIBUTES;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.PATCH_PATH_ORG_DESCRIPTION;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.PATCH_PATH_ORG_NAME;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.PATCH_PATH_ORG_STATUS;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.SW;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.VIEW_ATTR_KEY_COLUMN;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.VIEW_ATTR_VALUE_COLUMN;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.VIEW_CREATED_TIME_COLUMN;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.VIEW_DESCRIPTION_COLUMN;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.VIEW_ID_COLUMN;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.VIEW_LAST_MODIFIED_COLUMN;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.VIEW_NAME_COLUMN;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.VIEW_ORGANIZATION_PERMISSION;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.VIEW_PARENT_ID_COLUMN;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.VIEW_STATUS_COLUMN;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.CHECK_CHILD_ORGANIZATIONS_EXIST;
+import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.CHECK_CHILD_ORGANIZATIONS_STATUS;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.CHECK_ORGANIZATION_ATTRIBUTE_KEY_EXIST;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.CHECK_ORGANIZATION_EXIST_BY_ID;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.CHECK_ORGANIZATION_EXIST_BY_NAME;
@@ -97,6 +106,8 @@ import static org.wso2.carbon.identity.organization.management.service.constant.
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.GET_ORGANIZATIONS_BY_TENANT_ID_TAIL;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.GET_ORGANIZATION_BY_ID;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.GET_ORGANIZATION_ID_BY_NAME;
+import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.GET_ORGANIZATION_STATUS;
+import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.GET_PARENT_ORGANIZATION_STATUS;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.INSERT_ATTRIBUTE;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.INSERT_ORGANIZATION;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.PATCH_ORGANIZATION;
@@ -109,6 +120,7 @@ import static org.wso2.carbon.identity.organization.management.service.constant.
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_LAST_MODIFIED;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_NAME;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_PARENT_ID;
+import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_STATUS;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_TENANT_ID;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_USER_ID;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_VALUE;
@@ -116,7 +128,6 @@ import static org.wso2.carbon.identity.organization.management.service.constant.
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.UPDATE_ORGANIZATION;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.UPDATE_ORGANIZATION_ATTRIBUTE_VALUE;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.UPDATE_ORGANIZATION_LAST_MODIFIED;
-import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.VIEW_ID_COLUMN;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.getUserId;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.handleServerException;
 
@@ -143,6 +154,7 @@ public class OrganizationManagementDAOImpl implements OrganizationManagementDAO 
                             Timestamp.from(organization.getCreated()), CALENDAR);
                     namedPreparedStatement.setTimeStamp(DB_SCHEMA_COLUMN_NAME_LAST_MODIFIED,
                             Timestamp.from(organization.getLastModified()), CALENDAR);
+                    namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_STATUS, organization.getStatus());
                     namedPreparedStatement.setInt(DB_SCHEMA_COLUMN_NAME_TENANT_ID, tenantId);
                     namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_PARENT_ID, organization.getParent().getId());
                 }, organization, false);
@@ -243,6 +255,7 @@ public class OrganizationManagementDAOImpl implements OrganizationManagementDAO 
                                         .toInstant());
                                 collector.setCreated(resultSet.getTimestamp(VIEW_CREATED_TIME_COLUMN, CALENDAR)
                                         .toInstant());
+                                collector.setStatus(resultSet.getString(VIEW_STATUS_COLUMN));
                                 collector.setAttributeKey(resultSet.getString(VIEW_ATTR_KEY_COLUMN));
                                 collector.setAttributeValue(resultSet.getString(VIEW_ATTR_VALUE_COLUMN));
                                 return collector;
@@ -312,7 +325,7 @@ public class OrganizationManagementDAOImpl implements OrganizationManagementDAO 
     }
 
     @Override
-    public void deleteOrganization(int tenantId, String organizationId, String tenantDomain, boolean force) throws
+    public void deleteOrganization(int tenantId, String organizationId, String tenantDomain) throws
             OrganizationManagementServerException {
 
         NamedJdbcTemplate namedJdbcTemplate = Utils.getNewTemplate();
@@ -378,6 +391,7 @@ public class OrganizationManagementDAOImpl implements OrganizationManagementDAO 
                     namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_DESCRIPTION, organization.getDescription());
                     namedPreparedStatement.setTimeStamp(DB_SCHEMA_COLUMN_NAME_LAST_MODIFIED,
                             Timestamp.from(organization.getLastModified()), CALENDAR);
+                    namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_STATUS, organization.getStatus());
                     namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_ID, organizationId);
                 });
                 deleteOrganizationAttributes(organizationId, tenantDomain);
@@ -429,6 +443,54 @@ public class OrganizationManagementDAOImpl implements OrganizationManagementDAO 
         return childOrganizationIds;
     }
 
+    @Override
+    public boolean hasActiveChildOrganizations(String organizationId) throws OrganizationManagementServerException {
+
+        NamedJdbcTemplate namedJdbcTemplate = Utils.getNewTemplate();
+        try {
+            List<Integer> activeChildOrganizations = namedJdbcTemplate.executeQuery(CHECK_CHILD_ORGANIZATIONS_STATUS,
+                    (resultSet, rowNumber) -> resultSet.getInt(COUNT_COLUMN),
+                    namedPreparedStatement -> {
+                        namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_PARENT_ID, organizationId);
+                        namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_STATUS, ACTIVE.toString());
+                    });
+            return activeChildOrganizations.get(0) > 0;
+        } catch (DataAccessException e) {
+            throw handleServerException(ERROR_CODE_ERROR_CHECKING_ACTIVE_CHILD_ORGANIZATIONS, e, organizationId);
+        }
+    }
+
+    @Override
+    public boolean isParentOrganizationDisabled(String organizationId, String tenantDomain) throws
+            OrganizationManagementServerException {
+
+        NamedJdbcTemplate namedJdbcTemplate = Utils.getNewTemplate();
+        try {
+            String status = namedJdbcTemplate.fetchSingleRecord(GET_PARENT_ORGANIZATION_STATUS,
+                    (resultSet, rowNumber) -> resultSet.getString(VIEW_STATUS_COLUMN), namedPreparedStatement -> {
+                        namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_ID, organizationId);
+                    });
+            return StringUtils.equals(status, DISABLED.toString());
+        } catch (DataAccessException e) {
+            throw handleServerException(ERROR_CODE_ERROR_RETRIEVING_PARENT_ORGANIZATION_STATUS, e, organizationId);
+        }
+    }
+
+    @Override
+    public String getOrganizationStatus(String organizationId, String tenantDomain) throws
+            OrganizationManagementServerException {
+
+        NamedJdbcTemplate namedJdbcTemplate = Utils.getNewTemplate();
+        try {
+            return namedJdbcTemplate.fetchSingleRecord(GET_ORGANIZATION_STATUS,
+                    (resultSet, rowNumber) -> resultSet.getString(VIEW_STATUS_COLUMN), namedPreparedStatement -> {
+                        namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_ID, organizationId);
+                    });
+        } catch (DataAccessException e) {
+            throw handleServerException(ERROR_CODE_ERROR_RETRIEVING_ORGANIZATION_STATUS, e, organizationId);
+        }
+    }
+
     private void deleteOrganizationAttributes(String organizationId, String tenantDomain)
             throws OrganizationManagementServerException {
 
@@ -455,6 +517,8 @@ public class OrganizationManagementDAOImpl implements OrganizationManagementDAO 
             sb.append(VIEW_NAME_COLUMN);
         } else if (path.equals(PATCH_PATH_ORG_DESCRIPTION)) {
             sb.append(VIEW_DESCRIPTION_COLUMN);
+        } else if (path.equals(PATCH_PATH_ORG_STATUS)) {
+            sb.append(VIEW_STATUS_COLUMN);
         }
         sb.append(PATCH_ORGANIZATION_CONCLUDE);
         String query = sb.toString();
@@ -578,6 +642,7 @@ public class OrganizationManagementDAOImpl implements OrganizationManagementDAO 
                 organization.getParent().setId(collector.getParentId());
                 organization.setCreated(collector.getCreated());
                 organization.setLastModified(collector.getLastModified());
+                organization.setStatus(collector.getStatus());
             }
             List<OrganizationAttribute> attributes = organization.getAttributes();
             List<String> attributeKeys = new ArrayList<>();

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/impl/OrganizationRowDataCollector.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/impl/OrganizationRowDataCollector.java
@@ -29,6 +29,7 @@ public class OrganizationRowDataCollector {
     private String name;
     private String description;
     private String parentId;
+    private String status;
     private Instant created;
     private Instant lastModified;
     private String attributeKey;
@@ -112,5 +113,15 @@ public class OrganizationRowDataCollector {
     public void setAttributeValue(String attributeValue) {
 
         this.attributeValue = attributeValue;
+    }
+
+    public String getStatus() {
+
+        return status;
+    }
+
+    public void setStatus(String status) {
+
+        this.status = status;
     }
 }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/model/ChildOrganizationDO.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/model/ChildOrganizationDO.java
@@ -24,7 +24,7 @@ package org.wso2.carbon.identity.organization.management.service.model;
 public class ChildOrganizationDO {
 
     private String id;
-    private String self;
+    private String ref;
 
     public String getId() {
 
@@ -36,13 +36,13 @@ public class ChildOrganizationDO {
         this.id = id;
     }
 
-    public String getSelf() {
+    public String getRef() {
 
-        return self;
+        return ref;
     }
 
-    public void setSelf(String self) {
+    public void setRef(String ref) {
 
-        this.self = self;
+        this.ref = ref;
     }
 }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/model/Organization.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/model/Organization.java
@@ -30,6 +30,7 @@ public class Organization {
     private String id;
     private String name;
     private String description;
+    private String status;
     private ParentOrganizationDO parent = new ParentOrganizationDO();
     private Instant lastModified;
     private Instant created;
@@ -114,5 +115,15 @@ public class Organization {
     public void setChildOrganizations(List<ChildOrganizationDO> childOrganizations) {
 
         this.childOrganizations = childOrganizations;
+    }
+
+    public String getStatus() {
+
+        return status;
+    }
+
+    public void setStatus(String status) {
+
+        this.status = status;
     }
 }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/model/ParentOrganizationDO.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/model/ParentOrganizationDO.java
@@ -24,7 +24,7 @@ package org.wso2.carbon.identity.organization.management.service.model;
 public class ParentOrganizationDO {
 
     private String id;
-    private String self;
+    private String ref;
 
     public String getId() {
 
@@ -36,13 +36,13 @@ public class ParentOrganizationDO {
         this.id = id;
     }
 
-    public String getSelf() {
+    public String getRef() {
 
-        return self;
+        return ref;
     }
 
-    public void setSelf(String self) {
+    public void setRef(String ref) {
 
-        this.self = self;
+        this.ref = ref;
     }
 }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/test/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImplTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/test/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImplTest.java
@@ -49,6 +49,7 @@ import org.wso2.carbon.user.core.service.RealmService;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyObject;
@@ -132,7 +133,9 @@ public class OrganizationManagerImplTest extends PowerMockTestCase {
 
         mockBuildURI();
 
-        organizationManager.addOrganization(sampleOrganization);
+        Organization addedOrganization = organizationManager.addOrganization(sampleOrganization);
+        Assert.assertNotNull(addedOrganization.getId(), "Created organization id cannot be null");
+        Assert.assertEquals(addedOrganization.getName(), sampleOrganization.getName());
     }
 
     @Test(expectedExceptions = OrganizationManagementClientException.class)
@@ -588,6 +591,7 @@ public class OrganizationManagerImplTest extends PowerMockTestCase {
     private Organization getOrganization(String name, String parent) {
 
         Organization organization = new Organization();
+        organization.setId(UUID.randomUUID().toString());
         organization.setName(name);
         organization.setDescription(ORG_DESCRIPTION);
         organization.setStatus(OrganizationManagementConstants.OrganizationStatus.ACTIVE.toString());

--- a/components/org.wso2.carbon.identity.organization.management.service/src/test/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImplTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/test/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImplTest.java
@@ -33,6 +33,7 @@ import org.wso2.carbon.identity.core.ServiceURL;
 import org.wso2.carbon.identity.core.ServiceURLBuilder;
 import org.wso2.carbon.identity.core.URLBuilderException;
 import org.wso2.carbon.identity.organization.management.authz.service.OrganizationManagementAuthorizationManager;
+import org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants;
 import org.wso2.carbon.identity.organization.management.service.dao.OrganizationManagementDAO;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementClientException;
 import org.wso2.carbon.identity.organization.management.service.internal.OrganizationManagementDataHolder;
@@ -115,6 +116,9 @@ public class OrganizationManagerImplTest extends PowerMockTestCase {
 
         Organization sampleOrganization = getOrganization(ORG_NAME, ROOT);
         mockCarbonContext();
+
+        when(organizationManagementDataHolder.getOrganizationManagementDAO().getOrganizationStatus(anyString(),
+                anyString())).thenReturn(OrganizationManagementConstants.OrganizationStatus.ACTIVE.toString());
 
         mockAuthorizationManager();
         when(authorizationManager.isUserAuthorized(anyString(), anyString(), anyString())).thenReturn(true);
@@ -245,6 +249,8 @@ public class OrganizationManagerImplTest extends PowerMockTestCase {
         when(organizationManagementDataHolder.getOrganizationManagementDAO().getOrganizationIdByName(anyInt(),
                 anyString(), anyString())).thenReturn(PARENT_ID);
 
+        mockAuthorizationManager();
+        when(authorizationManager.isUserAuthorized(anyString(), anyString(), anyString())).thenReturn(true);
         OrganizationManagementAuthorizationManager authorizationManager =
                 mock(OrganizationManagementAuthorizationManager.class);
         mockStatic(OrganizationManagementAuthorizationManager.class);
@@ -363,39 +369,29 @@ public class OrganizationManagerImplTest extends PowerMockTestCase {
         organizationManager.getOrganizations(10, "MjAyNjkzMjg=", null, "ASC", "name co xyz");
     }
 
-    @DataProvider(name = "dataForDeleteOrganization")
-    public Object[][] dataForDeleteOrganization() {
-
-        return new Object[][]{
-
-                {true},
-                {false}
-        };
-    }
-
-    @Test(dataProvider = "dataForDeleteOrganization")
-    public void testDeleteOrganization(boolean force) throws Exception {
+    @Test
+    public void testDeleteOrganization() throws Exception {
 
         mockCarbonContext();
         when(organizationManagementDataHolder.getOrganizationManagementDAO().isOrganizationExistById(anyInt(),
                 anyString(), anyString())).thenReturn(true);
-        organizationManager.deleteOrganization(ORG_ID, force);
+        organizationManager.deleteOrganization(ORG_ID);
     }
 
-    @Test(dataProvider = "dataForDeleteOrganization", expectedExceptions = OrganizationManagementClientException.class)
-    public void testDeleteOrganizationWithEmptyOrganizationId(boolean force) throws Exception {
+    @Test(expectedExceptions = OrganizationManagementClientException.class)
+    public void testDeleteOrganizationWithEmptyOrganizationId() throws Exception {
 
         mockCarbonContext();
-        organizationManager.deleteOrganization(StringUtils.EMPTY, force);
+        organizationManager.deleteOrganization(StringUtils.EMPTY);
     }
 
-    @Test(dataProvider = "dataForDeleteOrganization", expectedExceptions = OrganizationManagementClientException.class)
-    public void testDeleteOrganizationWithInvalidOrganizationId(boolean force) throws Exception {
+    @Test(expectedExceptions = OrganizationManagementClientException.class)
+    public void testDeleteOrganizationWithInvalidOrganizationId() throws Exception {
 
         mockCarbonContext();
         when(organizationManagementDataHolder.getOrganizationManagementDAO().isOrganizationExistById(anyInt(),
                 anyString(), anyString())).thenReturn(false);
-        organizationManager.deleteOrganization(ORG_ID, force);
+        organizationManager.deleteOrganization(ORG_ID);
     }
 
     @Test(expectedExceptions = OrganizationManagementClientException.class)
@@ -406,18 +402,7 @@ public class OrganizationManagerImplTest extends PowerMockTestCase {
                 anyString(), anyString())).thenReturn(true);
         when(organizationManagementDataHolder.getOrganizationManagementDAO().hasChildOrganizations(anyString(),
                 anyString())).thenReturn(true);
-        organizationManager.deleteOrganization(ORG_ID, false);
-    }
-
-    @Test
-    public void testForceDeleteOrganizationWithChildOrganizations() throws Exception {
-
-        mockCarbonContext();
-        when(organizationManagementDataHolder.getOrganizationManagementDAO().isOrganizationExistById(anyInt(),
-                anyString(), anyString())).thenReturn(true);
-        when(organizationManagementDataHolder.getOrganizationManagementDAO().hasChildOrganizations(anyString(),
-                anyString())).thenReturn(true);
-        organizationManager.deleteOrganization(ORG_ID, true);
+        organizationManager.deleteOrganization(ORG_ID);
     }
 
     @Test
@@ -605,6 +590,7 @@ public class OrganizationManagerImplTest extends PowerMockTestCase {
         Organization organization = new Organization();
         organization.setName(name);
         organization.setDescription(ORG_DESCRIPTION);
+        organization.setStatus(OrganizationManagementConstants.OrganizationStatus.ACTIVE.toString());
         organization.getParent().setId(parent);
         return organization;
     }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/test/java/org/wso2/carbon/identity/organization/management/service/dao/impl/OrganizationManagementDAOImplTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/test/java/org/wso2/carbon/identity/organization/management/service/dao/impl/OrganizationManagementDAOImplTest.java
@@ -115,6 +115,7 @@ public class OrganizationManagementDAOImplTest extends PowerMockTestCase {
             organization.setAttributes(attributes);
 
             organizationManagementDAO.addOrganization(TENANT_ID, TENANT_DOMAIN, organization);
+            Assert.assertNotNull(organizationManagementDAO.getOrganization(TENANT_ID, orgId, TENANT_DOMAIN));
         }
     }
 
@@ -248,6 +249,22 @@ public class OrganizationManagementDAOImplTest extends PowerMockTestCase {
             } else if (StringUtils.equals(key, INVALID_DATA)) {
                 Assert.assertFalse(attributeExistByKey);
             }
+        }
+    }
+
+    @Test
+    public void testDeleteOrganization() throws Exception {
+
+        String id = generateUniqueID();
+        storeOrganization(id, "Dummy organization",
+                "This is a sample organization to test the delete functionality.", rootOrgId);
+
+        DataSource dataSource = mockDataSource();
+        try (Connection connection = getConnection()) {
+            Connection spy = spyConnection(connection);
+            when(dataSource.getConnection()).thenReturn(spy);
+            organizationManagementDAO.deleteOrganization(TENANT_ID, id, TENANT_DOMAIN);
+            Assert.assertNull(organizationManagementDAO.getOrganization(TENANT_ID, id, TENANT_DOMAIN));
         }
     }
 

--- a/components/org.wso2.carbon.identity.organization.management.service/src/test/java/org/wso2/carbon/identity/organization/management/service/dao/impl/OrganizationManagementDAOImplTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/test/java/org/wso2/carbon/identity/organization/management/service/dao/impl/OrganizationManagementDAOImplTest.java
@@ -29,6 +29,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.database.utils.jdbc.JdbcUtils;
 import org.wso2.carbon.database.utils.jdbc.NamedJdbcTemplate;
+import org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants;
 import org.wso2.carbon.identity.organization.management.service.dao.OrganizationManagementDAO;
 import org.wso2.carbon.identity.organization.management.service.model.Organization;
 import org.wso2.carbon.identity.organization.management.service.model.OrganizationAttribute;
@@ -103,6 +104,7 @@ public class OrganizationManagementDAOImplTest extends PowerMockTestCase {
             organization.setDescription("org1 description.");
             organization.setCreated(Instant.now());
             organization.setLastModified(Instant.now());
+            organization.setStatus(OrganizationManagementConstants.OrganizationStatus.ACTIVE.toString());
 
             ParentOrganizationDO parentOrganizationDO = new ParentOrganizationDO();
             parentOrganizationDO.setId(rootOrgId);


### PR DESCRIPTION
This PR adds the following improvements:
- Remove earlier introduced forceful deletion of child orgs (as a cascade delete).
- Change `self` as `ref` to denote the resource URI in the JSON response body.
- Add support to update the organization status.
- If parent ID is not present in the create organization request, the parent will be considered as the ROOT.
- Allow users with '/permission/admin/' assigned to to create an organization as an immediate child organization of the ROOT organization.
- Add filtering support to list organizations based on the `parentId` attribute.
- Fix server error which occurred when filtering organizations from `id` attribute.