### PR TITLE
Fix required to be compatible with H2 upgrade to 2.x

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/management/role/mgt/core/constants/DatabaseConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/management/role/mgt/core/constants/DatabaseConstants.java
@@ -28,7 +28,7 @@ public class DatabaseConstants {
      */
     public static final class SQLConstants {
 
-        public static final String COUNT_COLUMN_NAME = "COUNT(1)";
+        public static final int COUNT_COLUMN_INDEX = 1;
         public static final String VIEW_ID_COLUMN = "UM_ID";
         public static final String VIEW_USER_ID_COLUMN = "UM_USER_ID";
         public static final String VIEW_ROLE_ID_COLUMN = "UM_ROLE_ID";

--- a/components/org.wso2.carbon.identity.organization.management.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/management/role/mgt/core/constants/DatabaseConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/management/role/mgt/core/constants/DatabaseConstants.java
@@ -28,7 +28,6 @@ public class DatabaseConstants {
      */
     public static final class SQLConstants {
 
-        public static final int COUNT_COLUMN_INDEX = 1;
         public static final String VIEW_ID_COLUMN = "UM_ID";
         public static final String VIEW_USER_ID_COLUMN = "UM_USER_ID";
         public static final String VIEW_ROLE_ID_COLUMN = "UM_ROLE_ID";

--- a/components/org.wso2.carbon.identity.organization.management.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/management/role/mgt/core/dao/OrganizationUserRoleMgtDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/management/role/mgt/core/dao/OrganizationUserRoleMgtDAOImpl.java
@@ -48,7 +48,7 @@ import java.util.stream.Collectors;
 
 import static org.wso2.carbon.identity.organization.management.role.mgt.core.constants.DatabaseConstants.SQLConstants.AND;
 import static org.wso2.carbon.identity.organization.management.role.mgt.core.constants.DatabaseConstants.SQLConstants.ASSIGNED_AT_ADDING;
-import static org.wso2.carbon.identity.organization.management.role.mgt.core.constants.DatabaseConstants.SQLConstants.COUNT_COLUMN_NAME;
+import static org.wso2.carbon.identity.organization.management.role.mgt.core.constants.DatabaseConstants.SQLConstants.COUNT_COLUMN_INDEX;
 import static org.wso2.carbon.identity.organization.management.role.mgt.core.constants.DatabaseConstants.SQLConstants.DELETE_ALL_ORGANIZATION_USER_ROLE_MAPPINGS_BY_USERID;
 import static org.wso2.carbon.identity.organization.management.role.mgt.core.constants.DatabaseConstants.SQLConstants.DELETE_ORGANIZATION_USER_ROLE_MAPPINGS_ASSIGNED_AT_ORG_LEVEL;
 import static org.wso2.carbon.identity.organization.management.role.mgt.core.constants.DatabaseConstants.SQLConstants.DELETE_ORGANIZATION_USER_ROLE_MAPPING_VALUES;
@@ -318,7 +318,7 @@ public class OrganizationUserRoleMgtDAOImpl implements OrganizationUserRoleMgtDA
             mappingsCount = namedJdbcTemplate
                     .fetchSingleRecord(buildIsRoleMappingExistsQuery(assignedLevel, true),
                             (resultSet, rowNumber) ->
-                                    resultSet.getInt(COUNT_COLUMN_NAME),
+                                    resultSet.getInt(COUNT_COLUMN_INDEX),
                             namedPreparedStatement -> {
                                 namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_USER_ID, userId);
                                 namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_ROLE_ID, roleId);
@@ -355,7 +355,7 @@ public class OrganizationUserRoleMgtDAOImpl implements OrganizationUserRoleMgtDA
                              * mapping on params organizationId, userId, roleId, tenantId and assignedLevel
                              * */
                             (resultSet, rowNumber) ->
-                                    resultSet.getInt(COUNT_COLUMN_NAME) > 0,
+                                    resultSet.getInt(COUNT_COLUMN_INDEX) > 0,
                             namedPreparedStatement -> {
                                 namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_USER_ID, userId);
                                 namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_ROLE_ID, roleId);

--- a/components/org.wso2.carbon.identity.organization.management.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/management/role/mgt/core/dao/OrganizationUserRoleMgtDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.mgt.core/src/main/java/org/wso2/carbon/identity/organization/management/role/mgt/core/dao/OrganizationUserRoleMgtDAOImpl.java
@@ -48,7 +48,6 @@ import java.util.stream.Collectors;
 
 import static org.wso2.carbon.identity.organization.management.role.mgt.core.constants.DatabaseConstants.SQLConstants.AND;
 import static org.wso2.carbon.identity.organization.management.role.mgt.core.constants.DatabaseConstants.SQLConstants.ASSIGNED_AT_ADDING;
-import static org.wso2.carbon.identity.organization.management.role.mgt.core.constants.DatabaseConstants.SQLConstants.COUNT_COLUMN_INDEX;
 import static org.wso2.carbon.identity.organization.management.role.mgt.core.constants.DatabaseConstants.SQLConstants.DELETE_ALL_ORGANIZATION_USER_ROLE_MAPPINGS_BY_USERID;
 import static org.wso2.carbon.identity.organization.management.role.mgt.core.constants.DatabaseConstants.SQLConstants.DELETE_ORGANIZATION_USER_ROLE_MAPPINGS_ASSIGNED_AT_ORG_LEVEL;
 import static org.wso2.carbon.identity.organization.management.role.mgt.core.constants.DatabaseConstants.SQLConstants.DELETE_ORGANIZATION_USER_ROLE_MAPPING_VALUES;
@@ -318,7 +317,7 @@ public class OrganizationUserRoleMgtDAOImpl implements OrganizationUserRoleMgtDA
             mappingsCount = namedJdbcTemplate
                     .fetchSingleRecord(buildIsRoleMappingExistsQuery(assignedLevel, true),
                             (resultSet, rowNumber) ->
-                                    resultSet.getInt(COUNT_COLUMN_INDEX),
+                                    resultSet.getInt(1),
                             namedPreparedStatement -> {
                                 namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_USER_ID, userId);
                                 namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_ROLE_ID, roleId);
@@ -355,7 +354,7 @@ public class OrganizationUserRoleMgtDAOImpl implements OrganizationUserRoleMgtDA
                              * mapping on params organizationId, userId, roleId, tenantId and assignedLevel
                              * */
                             (resultSet, rowNumber) ->
-                                    resultSet.getInt(COUNT_COLUMN_INDEX) > 0,
+                                    resultSet.getInt(1) > 0,
                             namedPreparedStatement -> {
                                 namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_USER_ID, userId);
                                 namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_ROLE_ID, roleId);

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/SQLConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/SQLConstants.java
@@ -157,7 +157,7 @@ public class SQLConstants {
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_ASSIGNED_AT + "%1$d;,:" +
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_FORCED + "%1$d;)";
 
-    public static final String COUNT_COLUMN = "COUNT(1)";
+    public static final int COUNT_COLUMN = 1;
 
     /**
      * SQL Placeholders

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/SQLConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/SQLConstants.java
@@ -157,8 +157,6 @@ public class SQLConstants {
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_ASSIGNED_AT + "%1$d;,:" +
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_FORCED + "%1$d;)";
 
-    public static final int COUNT_COLUMN = 1;
-
     /**
      * SQL Placeholders
      */

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/impl/OrganizationManagementDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/impl/OrganizationManagementDAOImpl.java
@@ -91,7 +91,6 @@ import static org.wso2.carbon.identity.organization.management.service.constant.
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.CHECK_ORGANIZATION_ATTRIBUTE_KEY_EXIST;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.CHECK_ORGANIZATION_EXIST_BY_ID;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.CHECK_ORGANIZATION_EXIST_BY_NAME;
-import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.COUNT_COLUMN;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.DELETE_ORGANIZATION_ATTRIBUTE;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.DELETE_ORGANIZATION_ATTRIBUTES_BY_ID;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.DELETE_ORGANIZATION_BY_ID;
@@ -227,7 +226,7 @@ public class OrganizationManagementDAOImpl implements OrganizationManagementDAO 
         NamedJdbcTemplate namedJdbcTemplate = Utils.getNewTemplate();
         try {
             int orgCount = namedJdbcTemplate.fetchSingleRecord(checkOrganizationExistQuery,
-                    (resultSet, rowNumber) -> resultSet.getInt(COUNT_COLUMN), namedPreparedStatement -> {
+                    (resultSet, rowNumber) -> resultSet.getInt(1), namedPreparedStatement -> {
                         namedPreparedStatement.setInt(DB_SCHEMA_COLUMN_NAME_TENANT_ID, tenantId);
                         namedPreparedStatement.setString(dbSchemaColumnNameId, organization);
                     });
@@ -351,7 +350,7 @@ public class OrganizationManagementDAOImpl implements OrganizationManagementDAO 
         NamedJdbcTemplate namedJdbcTemplate = Utils.getNewTemplate();
         try {
             List<Integer> childOrganizationIds = namedJdbcTemplate.executeQuery(CHECK_CHILD_ORGANIZATIONS_EXIST,
-                    (resultSet, rowNumber) -> resultSet.getInt(COUNT_COLUMN), namedPreparedStatement -> {
+                    (resultSet, rowNumber) -> resultSet.getInt(1), namedPreparedStatement -> {
                         namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_PARENT_ID, organizationId);
                     });
             return childOrganizationIds.get(0) > 0;
@@ -415,7 +414,7 @@ public class OrganizationManagementDAOImpl implements OrganizationManagementDAO 
         NamedJdbcTemplate namedJdbcTemplate = Utils.getNewTemplate();
         try {
             int attrCount = namedJdbcTemplate.fetchSingleRecord(CHECK_ORGANIZATION_ATTRIBUTE_KEY_EXIST,
-                    (resultSet, rowNumber) -> resultSet.getInt(COUNT_COLUMN), namedPreparedStatement -> {
+                    (resultSet, rowNumber) -> resultSet.getInt(1), namedPreparedStatement -> {
                         namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_ID, organizationId);
                         namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_KEY, attributeKey);
                     });


### PR DESCRIPTION
## Purpose
> With H2 DB 2.x COUNT(1) returns a result with column name COUNT(*) (result column name was COUNT(1) in H2 DB 1.x) referring the Column by index make it independent of the column name.