### PR TITLE
Add improvements

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.endpoint/src/gen/java/org/wso2/carbon/identity/organization/management/endpoint/model/GetOrganizationResponse.java
+++ b/components/org.wso2.carbon.identity.organization.management.endpoint/src/gen/java/org/wso2/carbon/identity/organization/management/endpoint/model/GetOrganizationResponse.java
@@ -110,7 +110,6 @@ public enum TypeEnum {
 }
 
     private TypeEnum type;
-    private String domain;
     private ParentOrganization parent;
     private List<ChildOrganization> children = null;
 
@@ -243,33 +242,16 @@ public enum TypeEnum {
         return this;
     }
     
-    @ApiModelProperty(example = "TENANT", value = "")
+    @ApiModelProperty(example = "TENANT", required = true, value = "")
     @JsonProperty("type")
     @Valid
+    @NotNull(message = "Property type cannot be null.")
+
     public TypeEnum getType() {
         return type;
     }
     public void setType(TypeEnum type) {
         this.type = type;
-    }
-
-    /**
-    * Defines the tenant domain of tenant type organization.
-    **/
-    public GetOrganizationResponse domain(String domain) {
-
-        this.domain = domain;
-        return this;
-    }
-    
-    @ApiModelProperty(example = "abc.com", value = "Defines the tenant domain of tenant type organization.")
-    @JsonProperty("domain")
-    @Valid
-    public String getDomain() {
-        return domain;
-    }
-    public void setDomain(String domain) {
-        this.domain = domain;
     }
 
     /**
@@ -361,7 +343,6 @@ public enum TypeEnum {
             Objects.equals(this.created, getOrganizationResponse.created) &&
             Objects.equals(this.lastModified, getOrganizationResponse.lastModified) &&
             Objects.equals(this.type, getOrganizationResponse.type) &&
-            Objects.equals(this.domain, getOrganizationResponse.domain) &&
             Objects.equals(this.parent, getOrganizationResponse.parent) &&
             Objects.equals(this.children, getOrganizationResponse.children) &&
             Objects.equals(this.attributes, getOrganizationResponse.attributes);
@@ -369,7 +350,7 @@ public enum TypeEnum {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, description, status, created, lastModified, type, domain, parent, children, attributes);
+        return Objects.hash(id, name, description, status, created, lastModified, type, parent, children, attributes);
     }
 
     @Override
@@ -385,7 +366,6 @@ public enum TypeEnum {
         sb.append("    created: ").append(toIndentedString(created)).append("\n");
         sb.append("    lastModified: ").append(toIndentedString(lastModified)).append("\n");
         sb.append("    type: ").append(toIndentedString(type)).append("\n");
-        sb.append("    domain: ").append(toIndentedString(domain)).append("\n");
         sb.append("    parent: ").append(toIndentedString(parent)).append("\n");
         sb.append("    children: ").append(toIndentedString(children)).append("\n");
         sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");

--- a/components/org.wso2.carbon.identity.organization.management.endpoint/src/gen/java/org/wso2/carbon/identity/organization/management/endpoint/model/OrganizationPOSTRequest.java
+++ b/components/org.wso2.carbon.identity.organization.management.endpoint/src/gen/java/org/wso2/carbon/identity/organization/management/endpoint/model/OrganizationPOSTRequest.java
@@ -71,7 +71,6 @@ public enum TypeEnum {
 }
 
     private TypeEnum type;
-    private String domain;
     private String parentId;
     private List<Attribute> attributes = null;
 
@@ -135,25 +134,6 @@ public enum TypeEnum {
     }
 
     /**
-    * Defines the tenant domain. This attribute should only be present for tenant type organization.
-    **/
-    public OrganizationPOSTRequest domain(String domain) {
-
-        this.domain = domain;
-        return this;
-    }
-    
-    @ApiModelProperty(example = "abc.com", value = "Defines the tenant domain. This attribute should only be present for tenant type organization.")
-    @JsonProperty("domain")
-    @Valid
-    public String getDomain() {
-        return domain;
-    }
-    public void setDomain(String domain) {
-        this.domain = domain;
-    }
-
-    /**
     * If the parentId is not present, the ROOT will be taken as the parent organization.
     **/
     public OrganizationPOSTRequest parentId(String parentId) {
@@ -213,14 +193,13 @@ public enum TypeEnum {
         return Objects.equals(this.name, organizationPOSTRequest.name) &&
             Objects.equals(this.description, organizationPOSTRequest.description) &&
             Objects.equals(this.type, organizationPOSTRequest.type) &&
-            Objects.equals(this.domain, organizationPOSTRequest.domain) &&
             Objects.equals(this.parentId, organizationPOSTRequest.parentId) &&
             Objects.equals(this.attributes, organizationPOSTRequest.attributes);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, description, type, domain, parentId, attributes);
+        return Objects.hash(name, description, type, parentId, attributes);
     }
 
     @Override
@@ -232,7 +211,6 @@ public enum TypeEnum {
         sb.append("    name: ").append(toIndentedString(name)).append("\n");
         sb.append("    description: ").append(toIndentedString(description)).append("\n");
         sb.append("    type: ").append(toIndentedString(type)).append("\n");
-        sb.append("    domain: ").append(toIndentedString(domain)).append("\n");
         sb.append("    parentId: ").append(toIndentedString(parentId)).append("\n");
         sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");
         sb.append("}");

--- a/components/org.wso2.carbon.identity.organization.management.endpoint/src/gen/java/org/wso2/carbon/identity/organization/management/endpoint/model/OrganizationResponse.java
+++ b/components/org.wso2.carbon.identity.organization.management.endpoint/src/gen/java/org/wso2/carbon/identity/organization/management/endpoint/model/OrganizationResponse.java
@@ -109,7 +109,6 @@ public enum TypeEnum {
 }
 
     private TypeEnum type;
-    private String domain;
     private ParentOrganization parent;
     private List<Attribute> attributes = null;
 
@@ -240,33 +239,16 @@ public enum TypeEnum {
         return this;
     }
     
-    @ApiModelProperty(example = "TENANT", value = "")
+    @ApiModelProperty(example = "TENANT", required = true, value = "")
     @JsonProperty("type")
     @Valid
+    @NotNull(message = "Property type cannot be null.")
+
     public TypeEnum getType() {
         return type;
     }
     public void setType(TypeEnum type) {
         this.type = type;
-    }
-
-    /**
-    * Defines the domain of tenant type organization.
-    **/
-    public OrganizationResponse domain(String domain) {
-
-        this.domain = domain;
-        return this;
-    }
-    
-    @ApiModelProperty(example = "abc.com", value = "Defines the domain of tenant type organization.")
-    @JsonProperty("domain")
-    @Valid
-    public String getDomain() {
-        return domain;
-    }
-    public void setDomain(String domain) {
-        this.domain = domain;
     }
 
     /**
@@ -332,14 +314,13 @@ public enum TypeEnum {
             Objects.equals(this.created, organizationResponse.created) &&
             Objects.equals(this.lastModified, organizationResponse.lastModified) &&
             Objects.equals(this.type, organizationResponse.type) &&
-            Objects.equals(this.domain, organizationResponse.domain) &&
             Objects.equals(this.parent, organizationResponse.parent) &&
             Objects.equals(this.attributes, organizationResponse.attributes);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, description, status, created, lastModified, type, domain, parent, attributes);
+        return Objects.hash(id, name, description, status, created, lastModified, type, parent, attributes);
     }
 
     @Override
@@ -355,7 +336,6 @@ public enum TypeEnum {
         sb.append("    created: ").append(toIndentedString(created)).append("\n");
         sb.append("    lastModified: ").append(toIndentedString(lastModified)).append("\n");
         sb.append("    type: ").append(toIndentedString(type)).append("\n");
-        sb.append("    domain: ").append(toIndentedString(domain)).append("\n");
         sb.append("    parent: ").append(toIndentedString(parent)).append("\n");
         sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");
         sb.append("}");

--- a/components/org.wso2.carbon.identity.organization.management.endpoint/src/main/java/org/wso2/carbon/identity/organization/management/endpoint/service/OrganizationManagementService.java
+++ b/components/org.wso2.carbon.identity.organization.management.endpoint/src/main/java/org/wso2/carbon/identity/organization/management/endpoint/service/OrganizationManagementService.java
@@ -217,7 +217,6 @@ public class OrganizationManagementService {
         organization.setStatus(OrganizationManagementConstants.OrganizationStatus.ACTIVE.toString());
         OrganizationPOSTRequest.TypeEnum type = organizationPOSTRequest.getType();
         organization.setType(type != null ? type.toString() : null);
-        organization.setDomain(organizationPOSTRequest.getDomain());
         String parentId = organizationPOSTRequest.getParentId();
         if (StringUtils.isNotBlank(parentId)) {
             organization.getParent().setId(parentId);
@@ -253,7 +252,6 @@ public class OrganizationManagementService {
         String type = organization.getType();
         if (StringUtils.equals(type, OrganizationResponse.TypeEnum.TENANT.toString())) {
             organizationResponse.setType(OrganizationResponse.TypeEnum.TENANT);
-            organizationResponse.setDomain(organization.getDomain());
         } else {
             organizationResponse.setType(OrganizationResponse.TypeEnum.STRUCTURAL);
         }
@@ -290,11 +288,9 @@ public class OrganizationManagementService {
         String type = organization.getType();
         if (StringUtils.equals(type, GetOrganizationResponse.TypeEnum.TENANT.toString())) {
             organizationResponse.setType(GetOrganizationResponse.TypeEnum.TENANT);
-            organizationResponse.setDomain(organization.getDomain());
         } else {
             organizationResponse.setType(GetOrganizationResponse.TypeEnum.STRUCTURAL);
         }
-
 
         ParentOrganizationDO parentOrganizationDO = organization.getParent();
         if (parentOrganizationDO != null) {
@@ -379,7 +375,7 @@ public class OrganizationManagementService {
 
         OrganizationsResponse organizationsResponse = new OrganizationsResponse();
 
-        if (CollectionUtils.isNotEmpty(organizations)) {
+        if (limit != 0 && CollectionUtils.isNotEmpty(organizations)) {
             boolean hasMoreItems = organizations.size() > limit;
             boolean needsReverse = StringUtils.isNotBlank(before);
             boolean isFirstPage = (StringUtils.isBlank(before) && StringUtils.isBlank(after)) ||

--- a/components/org.wso2.carbon.identity.organization.management.endpoint/src/main/resources/org.wso2.carbon.identity.organization.management.yaml
+++ b/components/org.wso2.carbon.identity.organization.management.endpoint/src/main/resources/org.wso2.carbon.identity.organization.management.yaml
@@ -315,10 +315,6 @@ components:
           enum:
             - TENANT
             - STRUCTURAL
-        domain:
-          type: string
-          example: "abc.com"
-          description: Defines the tenant domain. This attribute should only be present for tenant type organization.
         parentId:
           type: string
           example: "b4526d91-a8bf-43d2-8b14-c548cf73065b"
@@ -415,6 +411,7 @@ components:
         - status
         - created
         - lastModified
+        - type
       properties:
         id:
           type: string
@@ -441,10 +438,6 @@ components:
           enum:
             - TENANT
             - STRUCTURAL
-        domain:
-          type: string
-          example: "abc.com"
-          description: Defines the domain of tenant type organization.
         parent:
           $ref: '#/components/schemas/ParentOrganization'
         attributes:
@@ -459,6 +452,7 @@ components:
         - status
         - created
         - lastModified
+        - type
       properties:
         id:
           type: string
@@ -485,10 +479,6 @@ components:
           enum:
             - TENANT
             - STRUCTURAL
-        domain:
-          type: string
-          example: "abc.com"
-          description: Defines the tenant domain of tenant type organization.
         parent:
           $ref: '#/components/schemas/ParentOrganization'
         children:

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
@@ -96,9 +96,6 @@ import static org.wso2.carbon.identity.organization.management.service.constant.
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_PATCH_REQUEST_REPLACE_NON_EXISTING_ATTRIBUTE;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_PATCH_REQUEST_VALUE_UNDEFINED;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_REQUIRED_FIELDS_MISSING;
-import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_TENANT_TYPE_ORGANIZATION_DOMAIN_EXTENSION_MISSING;
-import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_TENANT_TYPE_ORGANIZATION_DOMAIN_UNAVAILABLE;
-import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_TENANT_TYPE_ORGANIZATION_REQUIRED_FIELDS_MISSING;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_UNSUPPORTED_COMPLEX_QUERY_IN_FILTER;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_UNSUPPORTED_FILTER_ATTRIBUTE;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_UNSUPPORTED_ORGANIZATION_STATUS;
@@ -132,8 +129,6 @@ import static org.wso2.carbon.identity.organization.management.service.util.Util
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.getUserId;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.handleClientException;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.handleServerException;
-import static org.wso2.carbon.stratos.common.constants.TenantConstants.ErrorMessage.ERROR_CODE_EMPTY_EXTENSION;
-import static org.wso2.carbon.stratos.common.constants.TenantConstants.ErrorMessage.ERROR_CODE_EXISTING_DOMAIN;
 
 /**
  * This class implements the {@link OrganizationManager} interface.
@@ -151,7 +146,7 @@ public class OrganizationManagerImpl implements OrganizationManager {
         setCreatedAndLastModifiedTime(organization);
         if (StringUtils.equals(TENANT.toString(),
                 organization.getType())) {
-            tenantDomain = organization.getDomain();
+            tenantDomain = organization.getId();
             tenantId = createTenant(tenantDomain);
         }
         getOrganizationManagementDAO().addOrganization(tenantId, tenantDomain, organization);
@@ -350,17 +345,10 @@ public class OrganizationManagerImpl implements OrganizationManager {
         if (StringUtils.isBlank(organizationType)) {
             throw handleClientException(ERROR_CODE_ORGANIZATION_TYPE_UNDEFINED);
         }
-        if (StringUtils.equals(organizationType, TENANT.toString())) {
-            validateAddOrganizationTenantType(organization.getDomain());
-        } else if (!StringUtils.equals(organizationType, STRUCTURAL.toString())) {
+
+        if (!StringUtils.equals(organizationType, STRUCTURAL.toString()) &&
+                !StringUtils.equals(organizationType, TENANT.toString())) {
             throw handleClientException(ERROR_CODE_INVALID_ORGANIZATION_TYPE);
-        }
-    }
-
-    private void validateAddOrganizationTenantType(String domain) throws OrganizationManagementClientException {
-
-        if (StringUtils.isBlank(domain)) {
-            throw handleClientException(ERROR_CODE_TENANT_TYPE_ORGANIZATION_REQUIRED_FIELDS_MISSING);
         }
     }
 
@@ -728,13 +716,7 @@ public class OrganizationManagerImpl implements OrganizationManager {
             getTenantMgtService().addTenant(createTenantInfoBean(domain));
         } catch (TenantMgtException e) {
             if (e instanceof TenantManagementClientException) {
-                if (ERROR_CODE_EMPTY_EXTENSION.getCode().equals(e.getErrorCode())) {
-                    throw handleClientException(ERROR_CODE_TENANT_TYPE_ORGANIZATION_DOMAIN_EXTENSION_MISSING);
-                } else if (ERROR_CODE_EXISTING_DOMAIN.getCode().equals(e.getErrorCode())) {
-                    throw handleClientException(ERROR_CODE_TENANT_TYPE_ORGANIZATION_DOMAIN_UNAVAILABLE);
-                } else {
-                    throw handleClientException(ERROR_CODE_INVALID_TENANT_TYPE_ORGANIZATION);
-                }
+                throw handleClientException(ERROR_CODE_INVALID_TENANT_TYPE_ORGANIZATION);
             } else {
                 throw handleServerException(ERROR_CODE_ERROR_ADDING_TENANT_TYPE_ORGANIZATION, e);
             }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
@@ -181,18 +181,12 @@ public class OrganizationManagementConstants {
                 "To set the child organization status as active, parent organization should be in active status."),
         ERROR_CODE_CREATE_REQUEST_PARENT_ORGANIZATION_IS_DISABLED("60031", "Parent organization is disabled.",
                 "To create a child organization in organization with ID: %s, it should be in active status."),
-        ERROR_CODE_TENANT_TYPE_ORGANIZATION_DOMAIN_EXTENSION_MISSING("60032", "Invalid field",
-                "An extension for the domain is required for tenant type organization."),
-        ERROR_CODE_INVALID_TENANT_TYPE_ORGANIZATION("60033", "Unable to create the organization.",
+        ERROR_CODE_INVALID_TENANT_TYPE_ORGANIZATION("60032", "Unable to create the organization.",
                 "Invalid request body for tenant type organization."),
-        ERROR_CODE_ORGANIZATION_TYPE_UNDEFINED("60034", "Unable to create the organization.",
+        ERROR_CODE_ORGANIZATION_TYPE_UNDEFINED("60033", "Unable to create the organization.",
                 "Organization type should be defined."),
-        ERROR_CODE_INVALID_ORGANIZATION_TYPE("60035", "Invalid organization type.", "The organization " +
+        ERROR_CODE_INVALID_ORGANIZATION_TYPE("60034", "Invalid organization type.", "The organization " +
                 "type should be 'TENANT' or 'STRUCTURAL'."),
-        ERROR_CODE_TENANT_TYPE_ORGANIZATION_REQUIRED_FIELDS_MISSING("60036", "Invalid request body.",
-                "Missing required field(s) for tenant type organization."),
-        ERROR_CODE_TENANT_TYPE_ORGANIZATION_DOMAIN_UNAVAILABLE("60037", "Unable to create the organization.",
-                "A tenant with the provided domain already exists. Please provide a different domain name."),
 
         // Server errors.
         ERROR_CODE_UNEXPECTED("65001", "Unexpected processing error",

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/impl/OrganizationManagementDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/impl/OrganizationManagementDAOImpl.java
@@ -26,7 +26,6 @@ import org.wso2.carbon.database.utils.jdbc.NamedJdbcTemplate;
 import org.wso2.carbon.database.utils.jdbc.exceptions.DataAccessException;
 import org.wso2.carbon.database.utils.jdbc.exceptions.TransactionException;
 import org.wso2.carbon.identity.core.model.ExpressionNode;
-import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants;
 import org.wso2.carbon.identity.organization.management.service.dao.OrganizationManagementDAO;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementServerException;
@@ -642,12 +641,7 @@ public class OrganizationManagementDAOImpl implements OrganizationManagementDAO 
                 organization.setId(collector.getId());
                 organization.setName(collector.getName());
                 organization.setDescription(collector.getDescription());
-                String type = collector.getType();
                 organization.setType(collector.getType());
-                if (StringUtils.equals(OrganizationManagementConstants.OrganizationTypes.TENANT.toString(), type)) {
-                    String tenantDomain = IdentityTenantUtil.getTenantDomain(collector.getTenantId());
-                    organization.setDomain(tenantDomain);
-                }
                 organization.getParent().setId(collector.getParentId());
                 organization.setCreated(collector.getCreated());
                 organization.setLastModified(collector.getLastModified());

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/model/Organization.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/model/Organization.java
@@ -32,7 +32,6 @@ public class Organization {
     private String description;
     private String status;
     private String type;
-    private String domain;
     private ParentOrganizationDO parent = new ParentOrganizationDO();
     private Instant lastModified;
     private Instant created;
@@ -137,15 +136,5 @@ public class Organization {
     public void setType(String type) {
 
         this.type = type;
-    }
-
-    public String getDomain() {
-
-        return domain;
-    }
-
-    public void setDomain(String domain) {
-
-        this.domain = domain;
     }
 }


### PR DESCRIPTION
With this improvement, the domain is no longer required for the tenant type organization create request. The tenant domain will be persisted as organization id. By default, the product requires the tenant domain to have an extension but with this improvement a uuid can also be a tenant domain. To achieve this, the following config should be added.

```
[multi_tenancy.stratos]
public_cloud_setup=false
```

Also this PR addresses the issue with encountering a server exception when the limit is set 0 in the list orgs API call.