### PR TITLE
Improve Tenant type organization creation without creating a tenant admin inside the tenant

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.role.management.endpoint/src/main/java/org/wso2/carbon/identity/organization/management/role/management/endpoint/service/RoleManagementService.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.management.endpoint/src/main/java/org/wso2/carbon/identity/organization/management/role/management/endpoint/service/RoleManagementService.java
@@ -67,7 +67,6 @@ import static org.wso2.carbon.identity.organization.management.service.constant.
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.PATCH_OP_ADD;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.PATCH_OP_REMOVE;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.PATCH_OP_REPLACE;
-import static org.wso2.carbon.identity.organization.management.service.util.Utils.generateUniqueID;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.handleClientException;
 
 /**
@@ -249,7 +248,6 @@ public class RoleManagementService {
     private Role generateRoleFromPostRequest(RolePostRequest rolePostRequest) {
 
         Role role = new Role();
-        role.setId(generateUniqueID());
         role.setDisplayName(StringUtils.strip(rolePostRequest.getDisplayName()));
         if (CollectionUtils.isNotEmpty(rolePostRequest.getUsers())) {
             role.setUsers(rolePostRequest.getUsers().stream().map(RolePostRequestUser::getValue)

--- a/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/RoleManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/RoleManagerImpl.java
@@ -72,7 +72,9 @@ public class RoleManagerImpl implements RoleManager {
         role.setId(generateUniqueID());
         validateOrganizationId(organizationId);
         validateRoleNameNotExist(organizationId, role.getDisplayName());
-        // todo: skip user existence check atm, this user can be from any org.
+        // skip user existence check atm, this user can be from any org. Fix this through
+        // https://github.com/wso2-extensions/identity-organization-management/issues/50
+
 //        if (CollectionUtils.isNotEmpty(role.getUsers())) {
 //            List<String> userIdList = role.getUsers().stream().map(User::getId).collect(Collectors.toList());
 //            if (CollectionUtils.isNotEmpty(userIdList)) {

--- a/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/RoleManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/RoleManagerImpl.java
@@ -55,6 +55,7 @@ import static org.wso2.carbon.identity.organization.management.service.constant.
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ROLE_DISPLAY_NAME_MULTIPLE_VALUES;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ROLE_DISPLAY_NAME_NULL;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.PATCH_OP_REMOVE;
+import static org.wso2.carbon.identity.organization.management.service.util.Utils.generateUniqueID;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.getTenantId;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.handleClientException;
 
@@ -68,14 +69,16 @@ public class RoleManagerImpl implements RoleManager {
     @Override
     public Role createRole(String organizationId, Role role) throws OrganizationManagementException {
 
+        role.setId(generateUniqueID());
         validateOrganizationId(organizationId);
         validateRoleNameNotExist(organizationId, role.getDisplayName());
-        if (CollectionUtils.isNotEmpty(role.getUsers())) {
-            List<String> userIdList = role.getUsers().stream().map(User::getId).collect(Collectors.toList());
-            if (CollectionUtils.isNotEmpty(userIdList)) {
-                validateUsers(userIdList, getTenantId());
-            }
-        }
+        // todo: skip user existence check atm, this user can be from any org.
+//        if (CollectionUtils.isNotEmpty(role.getUsers())) {
+//            List<String> userIdList = role.getUsers().stream().map(User::getId).collect(Collectors.toList());
+//            if (CollectionUtils.isNotEmpty(userIdList)) {
+//                validateUsers(userIdList, getTenantId());
+//            }
+//        }
         if (CollectionUtils.isNotEmpty(role.getGroups())) {
             List<String> groupIdList = role.getGroups().stream().map(Group::getGroupId).collect(Collectors.toList());
             if (CollectionUtils.isNotEmpty(groupIdList)) {

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
@@ -722,6 +722,7 @@ public class OrganizationManagerImpl implements OrganizationManager {
         tenant.setActive(true);
         tenant.setDomain(domain);
         tenant.setAdminName(orgCreatorID);
+        tenant.setAdminUserId(orgCreatorID);
         tenant.setEmail("dummyadmin@email.com");
         // set the password as domain for now to avoid findbugs detecting it as a hardcoded value.
         tenant.setAdminPassword(domain);

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
@@ -141,14 +141,14 @@ public class OrganizationManagerImpl implements OrganizationManager {
     @Override
     public Organization addOrganization(Organization organization) throws OrganizationManagementException {
 
-        int tenantId;
         validateAddOrganizationRequest(organization);
         setParentOrganization(organization);
         setCreatedAndLastModifiedTime(organization);
-        if (StringUtils.equals(TENANT.toString(), organization.getType())) {
-            createTenant(organization.getId());
-        }
         organizationManagementDAO.addOrganization(organization);
+        String orgCreatorID = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUserId();
+        if (StringUtils.equals(TENANT.toString(), organization.getType())) {
+            createTenant(organization.getId(), orgCreatorID);
+        }
         return organization;
     }
 
@@ -229,14 +229,15 @@ public class OrganizationManagerImpl implements OrganizationManager {
         }
         validateOrganizationDelete(organizationId);
         Organization organization = organizationManagementDAO.getOrganization(organizationId);
-
-        organizationManagementDAO.deleteOrganization(organizationId);
         if (StringUtils.equals(TENANT.toString(), organization.getType())) {
-           /*
-            TODO : deactivate the tenant. The respective tenant retrieval will be resolved in next PR
-            https://github.com/wso2-extensions/identity-organization-management/pull/42
-            */
+            String tenantID = organizationManagementDAO.getAssociatedTenantUUIDForOrganization(organizationId);
+            try {
+                getTenantMgtService().deactivateTenant(tenantID);
+            } catch (TenantMgtException e) {
+                throw handleServerException(ERROR_CODE_ERROR_DEACTIVATING_ORGANIZATION_TENANT, e, organizationId);
+            }
         }
+        organizationManagementDAO.deleteOrganization(organizationId);
     }
 
     @Override
@@ -694,15 +695,17 @@ public class OrganizationManagerImpl implements OrganizationManager {
                 !attributeValue.equalsIgnoreCase(PAGINATION_BEFORE);
     }
 
-    private int createTenant(String domain) throws OrganizationManagementException {
+    private void createTenant(String domain, String orgCreatorID) throws OrganizationManagementException {
 
         try {
             PrivilegedCarbonContext.startTenantFlow();
             PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(MultitenantConstants
                     .SUPER_TENANT_DOMAIN_NAME);
             PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantId(MultitenantConstants.SUPER_TENANT_ID);
-            getTenantMgtService().addTenant(createTenantInfoBean(domain));
+            getTenantMgtService().addTenant(createTenantInfoBean(domain, orgCreatorID));
         } catch (TenantMgtException e) {
+            // Rollback created organization.
+            deleteOrganization(domain);
             if (e instanceof TenantManagementClientException) {
                 throw handleClientException(ERROR_CODE_INVALID_TENANT_TYPE_ORGANIZATION);
             } else {
@@ -711,18 +714,18 @@ public class OrganizationManagerImpl implements OrganizationManager {
         } finally {
             PrivilegedCarbonContext.endTenantFlow();
         }
-        return IdentityTenantUtil.getTenantId(domain);
     }
 
-    private Tenant createTenantInfoBean(String domain) {
+    private Tenant createTenantInfoBean(String domain, String orgCreatorID) {
 
         Tenant tenant = new Tenant();
         tenant.setActive(true);
         tenant.setDomain(domain);
-        tenant.setAdminName("dummyadmin");
+        tenant.setAdminName(orgCreatorID);
         tenant.setEmail("dummyadmin@email.com");
         // set the password as domain for now to avoid findbugs detecting it as a hardcoded value.
         tenant.setAdminPassword(domain);
+        tenant.setAssociatedOrganizationUUID(domain);
         tenant.setProvisioningMethod(StringUtils.EMPTY);
         return tenant;
     }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
@@ -231,10 +231,12 @@ public class OrganizationManagerImpl implements OrganizationManager {
         Organization organization = organizationManagementDAO.getOrganization(organizationId);
         if (StringUtils.equals(TENANT.toString(), organization.getType())) {
             String tenantID = organizationManagementDAO.getAssociatedTenantUUIDForOrganization(organizationId);
-            try {
-                getTenantMgtService().deactivateTenant(tenantID);
-            } catch (TenantMgtException e) {
-                throw handleServerException(ERROR_CODE_ERROR_DEACTIVATING_ORGANIZATION_TENANT, e, organizationId);
+            if (StringUtils.isNotBlank(tenantID)) {
+                try {
+                    getTenantMgtService().deactivateTenant(tenantID);
+                } catch (TenantMgtException e) {
+                    throw handleServerException(ERROR_CODE_ERROR_DEACTIVATING_ORGANIZATION_TENANT, e, organizationId);
+                }
             }
         }
         organizationManagementDAO.deleteOrganization(organizationId);

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
@@ -145,7 +145,7 @@ public class OrganizationManagerImpl implements OrganizationManager {
         setParentOrganization(organization);
         setCreatedAndLastModifiedTime(organization);
         organizationManagementDAO.addOrganization(organization);
-        String orgCreatorID = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUserId();
+        String orgCreatorID = getUserId();
         if (StringUtils.equals(TENANT.toString(), organization.getType())) {
             createTenant(organization.getId(), orgCreatorID);
         }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
@@ -723,6 +723,10 @@ public class OrganizationManagerImpl implements OrganizationManager {
         Tenant tenant = new Tenant();
         tenant.setActive(true);
         tenant.setDomain(domain);
+        /*
+        Set the creator's UUID as the tenant admin name because tenant data model doesn't store the admin uuid,
+        and it is required when creating the org-user association.
+         */
         tenant.setAdminName(orgCreatorID);
         tenant.setAdminUserId(orgCreatorID);
         tenant.setEmail("dummyadmin@email.com");

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
@@ -45,6 +45,7 @@ public class OrganizationManagementConstants {
     public static final String VIEW_ATTR_KEY_COLUMN = "UM_ATTRIBUTE_KEY";
     public static final String VIEW_ATTR_VALUE_COLUMN = "UM_ATTRIBUTE_VALUE";
     public static final String VIEW_TYPE_COLUMN = "UM_ORG_TYPE";
+    public static final String VIEW_TENANT_UUID_COLUMN = "UM_TENANT_UUID";
 
     public static final String PATCH_OP_ADD = "ADD";
     public static final String PATCH_OP_REMOVE = "REMOVE";
@@ -354,7 +355,9 @@ public class OrganizationManagementConstants {
         ERROR_CODE_ERROR_RETRIEVING_ORGANIZATION_PERMISSIONS("65059", "Unable to retrieve organizations permissions.",
                 "Server encountered an error while retrieving the organizations permissions of organization " +
                         "with ID: %s for user with ID: %s."),
-        ;
+        ERROR_CODE_ERROR_RETRIEVING_TENANT_UUID("65060",
+                "Unable to retrieve the associated tenant UUID for the organization.",
+                "Server encountered an error while retrieving the associated tenant UUID for the organization ID: %s.");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/SQLConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/SQLConstants.java
@@ -128,6 +128,9 @@ public class SQLConstants {
             "; AND UM_ORG_ROLE.UM_ORG_ID = :" + SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_ID +
             "; AND UM_ORG_PERMISSION.UM_RESOURCE_ID IN (" + PERMISSION_LIST_PLACEHOLDER + ")";
 
+    public static final String GET_TENANT_UUID_FROM_ORGANIZATION_UUID = "SELECT UM_TENANT_UUID FROM UM_TENANT WHERE " +
+            "UM_ORG_ID = :" + SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_ORG_ID + ";";
+
     /**
      * SQL Placeholders.
      */
@@ -139,12 +142,12 @@ public class SQLConstants {
         public static final String DB_SCHEMA_COLUMN_NAME_TYPE = "TYPE";
         public static final String DB_SCHEMA_COLUMN_NAME_CREATED_TIME = "CREATED_TIME";
         public static final String DB_SCHEMA_COLUMN_NAME_LAST_MODIFIED = "LAST_MODIFIED";
-        public static final String DB_SCHEMA_COLUMN_NAME_TENANT_ID = "TENANT_ID";
         public static final String DB_SCHEMA_COLUMN_NAME_PARENT_ID = "PARENT_ID";
         public static final String DB_SCHEMA_COLUMN_NAME_STATUS = "STATUS";
         public static final String DB_SCHEMA_COLUMN_NAME_KEY = "KEY";
         public static final String DB_SCHEMA_COLUMN_NAME_VALUE = "VALUE";
         public static final String DB_SCHEMA_COLUMN_NAME_USER_ID = "USER_ID";
         public static final String DB_SCHEMA_LIMIT = "LIMIT";
+        public static final String DB_SCHEMA_COLUMN_NAME_UM_ORG_ID = "UM_ORG_ID";
     }
 }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/SQLConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/SQLConstants.java
@@ -129,7 +129,7 @@ public class SQLConstants {
             "; AND UM_ORG_PERMISSION.UM_RESOURCE_ID IN (" + PERMISSION_LIST_PLACEHOLDER + ")";
 
     public static final String GET_TENANT_UUID_FROM_ORGANIZATION_UUID = "SELECT UM_TENANT_UUID FROM UM_TENANT WHERE " +
-            "UM_ORG_UUID = :" + SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_ORG_ID + ";";
+            "UM_ORG_UUID = :" + SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_ID + ";";
 
     /**
      * SQL Placeholders.
@@ -148,6 +148,5 @@ public class SQLConstants {
         public static final String DB_SCHEMA_COLUMN_NAME_VALUE = "VALUE";
         public static final String DB_SCHEMA_COLUMN_NAME_USER_ID = "USER_ID";
         public static final String DB_SCHEMA_LIMIT = "LIMIT";
-        public static final String DB_SCHEMA_COLUMN_NAME_UM_ORG_ID = "UM_ORG_ID";
     }
 }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/SQLConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/SQLConstants.java
@@ -129,7 +129,7 @@ public class SQLConstants {
             "; AND UM_ORG_PERMISSION.UM_RESOURCE_ID IN (" + PERMISSION_LIST_PLACEHOLDER + ")";
 
     public static final String GET_TENANT_UUID_FROM_ORGANIZATION_UUID = "SELECT UM_TENANT_UUID FROM UM_TENANT WHERE " +
-            "UM_ORG_ID = :" + SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_ORG_ID + ";";
+            "UM_ORG_UUID = :" + SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_ORG_ID + ";";
 
     /**
      * SQL Placeholders.

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/OrganizationManagementDAO.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/OrganizationManagementDAO.java
@@ -202,4 +202,13 @@ public interface OrganizationManagementDAO {
      */
     List<String> getOrganizationPermissions(String organizationId, String userId)
             throws OrganizationManagementServerException;
+
+    /**
+     * Retrieve the tenant UUID if the organization is a tenant type organization.
+     *
+     * @param organizationId Organization ID.
+     * @return Associated tenant UUID.
+     * @throws OrganizationManagementServerException The server exception thrown when retrieving the associated tenant.
+     */
+    String getAssociatedTenantUUIDForOrganization(String organizationId) throws OrganizationManagementServerException;
 }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/impl/OrganizationManagementDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/impl/OrganizationManagementDAOImpl.java
@@ -71,6 +71,7 @@ import static org.wso2.carbon.identity.organization.management.service.constant.
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_RETRIEVING_ORGANIZATION_STATUS;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_RETRIEVING_ORGANIZATION_TYPE;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_RETRIEVING_PARENT_ORGANIZATION_STATUS;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_RETRIEVING_TENANT_UUID;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_UPDATING_ORGANIZATION;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.GE;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.GT;
@@ -96,6 +97,7 @@ import static org.wso2.carbon.identity.organization.management.service.constant.
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.VIEW_ORGANIZATION_PERMISSION;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.VIEW_PARENT_ID_COLUMN;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.VIEW_STATUS_COLUMN;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.VIEW_TENANT_UUID_COLUMN;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.VIEW_TYPE_COLUMN;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.CHECK_CHILD_ORGANIZATIONS_EXIST;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.CHECK_CHILD_ORGANIZATIONS_STATUS;
@@ -114,6 +116,7 @@ import static org.wso2.carbon.identity.organization.management.service.constant.
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.GET_ORGANIZATION_STATUS;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.GET_ORGANIZATION_TYPE;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.GET_PARENT_ORGANIZATION_STATUS;
+import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.GET_TENANT_UUID_FROM_ORGANIZATION_UUID;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.INSERT_ATTRIBUTE;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.INSERT_ORGANIZATION;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.PATCH_ORGANIZATION;
@@ -128,6 +131,7 @@ import static org.wso2.carbon.identity.organization.management.service.constant.
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_PARENT_ID;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_STATUS;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_TYPE;
+import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_ORG_ID;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_USER_ID;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_VALUE;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.SQLPlaceholders.DB_SCHEMA_LIMIT;
@@ -530,6 +534,21 @@ public class OrganizationManagementDAOImpl implements OrganizationManagementDAO 
         } catch (DataAccessException e) {
             throw handleServerException(ERROR_CODE_ERROR_RETRIEVING_ORGANIZATION_PERMISSIONS,
                     e, organizationId, userId);
+        }
+    }
+
+    @Override
+    public String getAssociatedTenantUUIDForOrganization(String organizationId)
+            throws OrganizationManagementServerException {
+
+        NamedJdbcTemplate namedJdbcTemplate = Utils.getNewTemplate();
+        try {
+            return namedJdbcTemplate.fetchSingleRecord(GET_TENANT_UUID_FROM_ORGANIZATION_UUID,
+                    (resultSet, rowNumber) -> resultSet.getString(VIEW_TENANT_UUID_COLUMN),
+                    namedPreparedStatement -> namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_UM_ORG_ID,
+                            organizationId));
+        } catch (DataAccessException e) {
+            throw handleServerException(ERROR_CODE_ERROR_RETRIEVING_TENANT_UUID, e, organizationId);
         }
     }
 

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/impl/OrganizationManagementDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/impl/OrganizationManagementDAOImpl.java
@@ -131,7 +131,6 @@ import static org.wso2.carbon.identity.organization.management.service.constant.
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_PARENT_ID;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_STATUS;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_TYPE;
-import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_ORG_ID;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_USER_ID;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_VALUE;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.SQLPlaceholders.DB_SCHEMA_LIMIT;
@@ -545,7 +544,7 @@ public class OrganizationManagementDAOImpl implements OrganizationManagementDAO 
         try {
             return namedJdbcTemplate.fetchSingleRecord(GET_TENANT_UUID_FROM_ORGANIZATION_UUID,
                     (resultSet, rowNumber) -> resultSet.getString(VIEW_TENANT_UUID_COLUMN),
-                    namedPreparedStatement -> namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_UM_ORG_ID,
+                    namedPreparedStatement -> namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_ID,
                             organizationId));
         } catch (DataAccessException e) {
             throw handleServerException(ERROR_CODE_ERROR_RETRIEVING_TENANT_UUID, e, organizationId);

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/model/Organization.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/model/Organization.java
@@ -138,6 +138,7 @@ public class Organization {
 
         this.type = type;
     }
+
     public List<String> getPermissions() {
 
         return permissions;

--- a/components/org.wso2.carbon.identity.organization.management.tenant.association/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.tenant.association/pom.xml
@@ -23,11 +23,12 @@
     <parent>
         <artifactId>identity-organization-management</artifactId>
         <groupId>org.wso2.carbon.identity.organization.management</groupId>
-        <version>1.0.6-SNAPSHOT</version>
+        <version>1.0.14-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
+    <name>WSO2 - Organization's Tenant Association Service</name>
     <artifactId>org.wso2.carbon.identity.organization.management.tenant.association</artifactId>
     <packaging>bundle</packaging>
 

--- a/components/org.wso2.carbon.identity.organization.management.tenant.association/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.tenant.association/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>identity-organization-management</artifactId>
+        <groupId>org.wso2.carbon.identity.organization.management</groupId>
+        <version>1.0.6-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>org.wso2.carbon.identity.organization.management.tenant.association</artifactId>
+    <packaging>bundle</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.role.management.service</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Bundle-Description>User tenant Association Service Bundle</Bundle-Description>
+                        <Private-Package>
+                            org.wso2.carbon.identity.organization.management.tenant.association.internal
+                        </Private-Package>
+                        <Export-Package>
+                            !org.wso2.carbon.identity.organization.management.tenant.association.internal,
+                            org.wso2.carbon.identity.organization.management.tenant.association.*;
+                            version="${identity.organization.management.exp.pkg.version}",
+                        </Export-Package>
+                        <Import-Package>
+                            org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
+                            org.apache.commons.lang;version="${org.apache.commons.lang.imp.pkg.version.range}",
+                            org.apache.commons.logging;version="${org.apache.commons.logging.imp.pkg.version.range}",
+                            org.osgi.service.component;version="${osgi.service.component.imp.pkg.version.range}",
+                            org.wso2.carbon.user.api;version="${carbon.user.api.imp.pkg.version.range}",
+                            org.wso2.carbon.user.core.service;version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.user.core.tenant;version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.stratos.common.beans;version="${carbon.multitenancy.package.import.version.range}",
+                            org.wso2.carbon.stratos.common.listeners;version="${carbon.multitenancy.package.import.version.range}",
+                            org.wso2.carbon.identity.core;version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.organization.management.role.management.service;version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.management.role.management.service.models;version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.management.service.exception;version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/org.wso2.carbon.identity.organization.management.tenant.association/src/main/java/org/wso2/carbon/identity/organization/management/tenant/association/Constants.java
+++ b/components/org.wso2.carbon.identity.organization.management.tenant.association/src/main/java/org/wso2/carbon/identity/organization/management/tenant/association/Constants.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.management.tenant.association;
+
+/**
+ * Constants related to user-tenant association.
+ */
+public class Constants {
+
+    public static final String ORG_CREATOR_ROLE = "org-creator";
+    public static final String ORG_CREATOR_ROLE_PERMISSION = "/permission/admin";
+}

--- a/components/org.wso2.carbon.identity.organization.management.tenant.association/src/main/java/org/wso2/carbon/identity/organization/management/tenant/association/Constants.java
+++ b/components/org.wso2.carbon.identity.organization.management.tenant.association/src/main/java/org/wso2/carbon/identity/organization/management/tenant/association/Constants.java
@@ -24,5 +24,6 @@ package org.wso2.carbon.identity.organization.management.tenant.association;
 public class Constants {
 
     public static final String ORG_CREATOR_ROLE = "org-creator";
-    public static final String ORG_CREATOR_ROLE_PERMISSION = "/permission/admin";
+    public static final String ORG_CREATOR_ROLE_ASSIGNED_PERMISSION =
+            "/permission/admin/manage/identity/organizationmgt";
 }

--- a/components/org.wso2.carbon.identity.organization.management.tenant.association/src/main/java/org/wso2/carbon/identity/organization/management/tenant/association/internal/TenantAssociationDataHolder.java
+++ b/components/org.wso2.carbon.identity.organization.management.tenant.association/src/main/java/org/wso2/carbon/identity/organization/management/tenant/association/internal/TenantAssociationDataHolder.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.management.tenant.association.internal;
+
+import org.wso2.carbon.identity.organization.management.role.management.service.RoleManager;
+import org.wso2.carbon.user.core.service.RealmService;
+
+/**
+ * This class holds the services required for tenant association management services.
+ */
+public class TenantAssociationDataHolder {
+
+    private static RealmService realmService;
+    private static RoleManager roleManager;
+
+    private TenantAssociationDataHolder() {
+
+    }
+
+    /**
+     * Get the RealmService.
+     *
+     * @return RealmService.
+     */
+    public static RealmService getRealmService() {
+
+        if (realmService == null) {
+            throw new RuntimeException("RealmService was not set during the TenantAssociationServiceComponent startup");
+        }
+        return realmService;
+    }
+
+    /**
+     * Set the RealmService.
+     *
+     * @param realmService RealmService.
+     */
+    public static void setRealmService(RealmService realmService) {
+
+        TenantAssociationDataHolder.realmService = realmService;
+    }
+
+    /**
+     * Get the organization role manager service.
+     *
+     * @return Organization role manager service.
+     */
+    public static RoleManager getRoleManager() {
+
+        return roleManager;
+    }
+
+    /**
+     * Set the organization role manager service.
+     *
+     * @param roleManager Organization role manager service.
+     */
+    public static void setRoleManager(RoleManager roleManager) {
+
+        TenantAssociationDataHolder.roleManager = roleManager;
+    }
+}

--- a/components/org.wso2.carbon.identity.organization.management.tenant.association/src/main/java/org/wso2/carbon/identity/organization/management/tenant/association/internal/TenantAssociationServiceComponent.java
+++ b/components/org.wso2.carbon.identity.organization.management.tenant.association/src/main/java/org/wso2/carbon/identity/organization/management/tenant/association/internal/TenantAssociationServiceComponent.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.management.tenant.association.internal;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.wso2.carbon.identity.organization.management.role.management.service.RoleManager;
+import org.wso2.carbon.identity.organization.management.tenant.association.listeners.TenantAssociationManagementListener;
+import org.wso2.carbon.stratos.common.listeners.TenantMgtListener;
+import org.wso2.carbon.user.core.service.RealmService;
+
+/**
+ * This class contains the implementation of the service component of the TenantAssociationManagement.
+ */
+@Component(
+        name = "org.wso2.carbon.identity.organization.management.tenant.association.component",
+        immediate = true
+)
+public class TenantAssociationServiceComponent {
+
+    private static final Log LOG = LogFactory.getLog(TenantAssociationServiceComponent.class);
+
+    @Activate
+    protected void activate(ComponentContext context) {
+
+        TenantAssociationManagementListener tenantManagementListener = new TenantAssociationManagementListener();
+        context.getBundleContext().registerService(TenantMgtListener.class.getName(), tenantManagementListener, null);
+        LOG.info("Organization management related TenantAssociationManagementListener registered successfully.");
+    }
+
+    @Deactivate
+    protected void deactivate(ComponentContext context) {
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Organization management related TenantAssociationManagement bundle is deactivated.");
+        }
+    }
+
+    @Reference(
+            name = "RealmService",
+            service = RealmService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetRealmService")
+    protected void setRealmService(RealmService realmService) {
+
+        TenantAssociationDataHolder.setRealmService(realmService);
+    }
+
+    protected void unsetRealmService(RealmService realmService) {
+
+        TenantAssociationDataHolder.setRealmService(null);
+    }
+
+    @Reference(
+            name = "RoleManager",
+            service = RoleManager.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetRoleManagerService")
+    protected void setRoleManagerService(RoleManager roleManagerService) {
+
+        TenantAssociationDataHolder.setRoleManager(roleManagerService);
+    }
+
+    protected void unsetRoleManagerService(RoleManager roleManagerService) {
+
+        TenantAssociationDataHolder.setRoleManager(null);
+    }
+}

--- a/components/org.wso2.carbon.identity.organization.management.tenant.association/src/main/java/org/wso2/carbon/identity/organization/management/tenant/association/listeners/TenantAssociationManagementListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.tenant.association/src/main/java/org/wso2/carbon/identity/organization/management/tenant/association/listeners/TenantAssociationManagementListener.java
@@ -90,7 +90,8 @@ public class TenantAssociationManagementListener extends AbstractIdentityTenantM
         organizationCreatorRole.setDisplayName(Constants.ORG_CREATOR_ROLE);
         User orgCreator = new User(adminUUID);
         organizationCreatorRole.setUsers(Collections.singletonList(orgCreator));
-        organizationCreatorRole.setPermissions(Collections.singletonList(Constants.ORG_CREATOR_ROLE_PERMISSION));
+        organizationCreatorRole.setPermissions(
+                Collections.singletonList(Constants.ORG_CREATOR_ROLE_ASSIGNED_PERMISSION));
         return organizationCreatorRole;
     }
 }

--- a/components/org.wso2.carbon.identity.organization.management.tenant.association/src/main/java/org/wso2/carbon/identity/organization/management/tenant/association/listeners/TenantAssociationManagementListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.tenant.association/src/main/java/org/wso2/carbon/identity/organization/management/tenant/association/listeners/TenantAssociationManagementListener.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.management.tenant.association.listeners;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.core.AbstractIdentityTenantMgtListener;
+import org.wso2.carbon.identity.organization.management.role.management.service.models.Role;
+import org.wso2.carbon.identity.organization.management.role.management.service.models.User;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.identity.organization.management.tenant.association.Constants;
+import org.wso2.carbon.identity.organization.management.tenant.association.internal.TenantAssociationDataHolder;
+import org.wso2.carbon.stratos.common.beans.TenantInfoBean;
+import org.wso2.carbon.user.api.Tenant;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.core.service.RealmService;
+
+import java.util.Collections;
+
+/**
+ * This class contains the implementation of the tenant management listener.  This listener will be used to add tenant
+ * associations between the tenant creator and tenant, during the tenant creation flow.
+ */
+public class TenantAssociationManagementListener extends AbstractIdentityTenantMgtListener {
+
+    private static final Log LOG = LogFactory.getLog(TenantAssociationManagementListener.class);
+
+    @Override
+    public void onTenantCreate(TenantInfoBean tenantInfo) {
+
+        if (!isEnable()) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Organization management related TenantAssociationManagementListener is not enabled");
+            }
+            return;
+        }
+        int tenantId = tenantInfo.getTenantId();
+        if (LOG.isDebugEnabled()) {
+            LOG.debug(
+                    "Organization management related TenantAssociationManagementListener fired for tenant creation " +
+                            "for Tenant ID: " + tenantId);
+        }
+        try {
+            RealmService realmService = TenantAssociationDataHolder.getRealmService();
+            Tenant tenant = realmService.getTenantManager().getTenant(tenantId);
+            // Association will be created only if the tenant created with an organization id.
+            String organizationID = tenant.getAssociatedOrganizationUUID();
+            if (StringUtils.isBlank(organizationID)) {
+                return;
+            }
+            String adminUUID = realmService.getTenantUserRealm(tenantId).getRealmConfiguration().getAdminUserName();
+            String tenantUuid = tenant.getTenantUniqueID();
+            if (StringUtils.isBlank(tenantUuid)) {
+                LOG.error("Tenant UUID was not found for tenant: " + tenantId + ". Therefore, tenant association " +
+                        "will not set");
+                return;
+            }
+            if (StringUtils.isBlank(adminUUID)) {
+                LOG.error("User UUID is empty. Therefore, tenant association will not set with tenant: " + tenantUuid);
+                return;
+            }
+            Role organizationCreatorRole = buildOrgCreatorRole(adminUUID);
+            TenantAssociationDataHolder.getRoleManager().createRole(organizationID, organizationCreatorRole);
+        } catch (UserStoreException | OrganizationManagementException e) {
+            String error = "Error occurred while adding user-tenant association for the tenant id: " + tenantId;
+            LOG.error(error, e);
+        }
+    }
+
+    private Role buildOrgCreatorRole(String adminUUID) {
+
+        Role organizationCreatorRole = new Role();
+        organizationCreatorRole.setDisplayName(Constants.ORG_CREATOR_ROLE);
+        User orgCreator = new User(adminUUID);
+        organizationCreatorRole.setUsers(Collections.singletonList(orgCreator));
+        organizationCreatorRole.setPermissions(Collections.singletonList(Constants.ORG_CREATOR_ROLE_PERMISSION));
+        return organizationCreatorRole;
+    }
+}

--- a/components/org.wso2.carbon.identity.organization.management.tenant.association/src/main/java/org/wso2/carbon/identity/organization/management/tenant/association/listeners/TenantAssociationManagementListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.tenant.association/src/main/java/org/wso2/carbon/identity/organization/management/tenant/association/listeners/TenantAssociationManagementListener.java
@@ -47,7 +47,7 @@ public class TenantAssociationManagementListener extends AbstractIdentityTenantM
 
         if (!isEnable()) {
             if (LOG.isDebugEnabled()) {
-                LOG.debug("Organization management related TenantAssociationManagementListener is not enabled");
+                LOG.debug("Organization management related TenantAssociationManagementListener is not enabled.");
             }
             return;
         }
@@ -69,11 +69,12 @@ public class TenantAssociationManagementListener extends AbstractIdentityTenantM
             String tenantUuid = tenant.getTenantUniqueID();
             if (StringUtils.isBlank(tenantUuid)) {
                 LOG.error("Tenant UUID was not found for tenant: " + tenantId + ". Therefore, tenant association " +
-                        "will not set");
+                        "will not be set.");
                 return;
             }
             if (StringUtils.isBlank(adminUUID)) {
-                LOG.error("User UUID is empty. Therefore, tenant association will not set with tenant: " + tenantUuid);
+                LOG.error(
+                        "User UUID is empty. Therefore, tenant association will not be set with tenant: " + tenantUuid);
                 return;
             }
             Role organizationCreatorRole = buildOrgCreatorRole(adminUUID);

--- a/features/org.wso2.carbon.identity.organization.management.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.organization.management.server.feature/pom.xml
@@ -55,6 +55,10 @@
             <groupId>org.wso2.carbon.identity.organization.management</groupId>
             <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.tenant.association</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -85,6 +89,7 @@
                                 <bundleDef>org.wso2.carbon.identity.organization.management:org.wso2.carbon.identity.organization.management.authz.valve</bundleDef>
                                 <bundleDef>org.wso2.carbon.identity.organization.management:org.wso2.carbon.identity.organization.management.role.management.service</bundleDef>
                                 <bundleDef>org.wso2.carbon.identity.organization.management:org.wso2.carbon.identity.organization.management.service</bundleDef>
+                                <bundleDef>org.wso2.carbon.identity.organization.management:org.wso2.carbon.identity.organization.management.tenant.association</bundleDef>
                             </bundles>
                             <importFeatures>
                                 <importFeatureDef>org.wso2.carbon.core:compatible:${carbon.kernel.feature.version}</importFeatureDef>

--- a/pom.xml
+++ b/pom.xml
@@ -179,6 +179,12 @@
                 <version>${project.version}</version>
                 <scope>provided</scope>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.organization.management</groupId>
+                <artifactId>org.wso2.carbon.identity.organization.management.tenant.association</artifactId>
+                <version>${project.version}</version>
+                <scope>provided</scope>
+            </dependency>
 
             <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
         <module>components/org.wso2.carbon.identity.organization.management.role.management.endpoint</module>
         <module>components/org.wso2.carbon.identity.organization.management.application</module>
         <module>components/org.wso2.carbon.identity.organization.management.authn</module>
+        <module>components/org.wso2.carbon.identity.organization.management.tenant.association</module>
         <module>features/org.wso2.carbon.identity.organization.management.server.feature</module>
     </modules>
 
@@ -469,7 +470,7 @@
         </org.wso2.identity.organization.mgt.imp.pkg.version.range>
 
         <carbon.multitenancy.version>4.10.1</carbon.multitenancy.version>
-        <carbon.multitenancy.package.import.version.range>[4.9.0,5.0.0)
+        <carbon.multitenancy.package.import.version.range>[4.7.0,5.0.0)
         </carbon.multitenancy.package.import.version.range>
 
         <carbon.identity.framework.version>5.20.267</carbon.identity.framework.version>


### PR DESCRIPTION
## Purpose
- Add the organization creator role against the created organization and org creator during onTenantCreate
- Remove TENANT_ID from UM_ORG data model
- Remove TENANT_ID from UM_ORG_ROLE data model
Part of fix https://github.com/wso2/product-is/issues/13959

## Depends on

- [x] https://github.com/wso2/carbon-kernel/pull/3311
- [x] https://github.com/wso2/carbon-multitenancy/pull/224
- [x] https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/424