### PR TITLE
Assign org mgt and role mgt permissions for the org creator role

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.tenant.association/src/main/java/org/wso2/carbon/identity/organization/management/tenant/association/Constants.java
+++ b/components/org.wso2.carbon.identity.organization.management.tenant.association/src/main/java/org/wso2/carbon/identity/organization/management/tenant/association/Constants.java
@@ -24,6 +24,6 @@ package org.wso2.carbon.identity.organization.management.tenant.association;
 public class Constants {
 
     public static final String ORG_CREATOR_ROLE = "org-creator";
-    public static final String ORG_CREATOR_ROLE_ASSIGNED_PERMISSION =
-            "/permission/admin/manage/identity/organizationmgt";
+    public static final String ORG_MGT_PERMISSION = "/permission/admin/manage/identity/organizationmgt";
+    public static final String ORG_ROLE_MGT_PERMISSION = "/permission/admin/manage/identity/rolemgt";
 }

--- a/components/org.wso2.carbon.identity.organization.management.tenant.association/src/main/java/org/wso2/carbon/identity/organization/management/tenant/association/listeners/TenantAssociationManagementListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.tenant.association/src/main/java/org/wso2/carbon/identity/organization/management/tenant/association/listeners/TenantAssociationManagementListener.java
@@ -32,6 +32,7 @@ import org.wso2.carbon.user.api.Tenant;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.service.RealmService;
 
+import java.util.ArrayList;
 import java.util.Collections;
 
 /**
@@ -91,8 +92,11 @@ public class TenantAssociationManagementListener extends AbstractIdentityTenantM
         organizationCreatorRole.setDisplayName(Constants.ORG_CREATOR_ROLE);
         User orgCreator = new User(adminUUID);
         organizationCreatorRole.setUsers(Collections.singletonList(orgCreator));
-        organizationCreatorRole.setPermissions(
-                Collections.singletonList(Constants.ORG_CREATOR_ROLE_ASSIGNED_PERMISSION));
+        // Set permissions for org-creator role.
+        ArrayList<String> orgCreatorRolePermissions = new ArrayList<>();
+        orgCreatorRolePermissions.add(Constants.ORG_MGT_PERMISSION);
+        orgCreatorRolePermissions.add(Constants.ORG_ROLE_MGT_PERMISSION);
+        organizationCreatorRole.setPermissions(orgCreatorRolePermissions);
         return organizationCreatorRole;
     }
 }


### PR DESCRIPTION
## Purpose
The current access control, the architecture supports having one permission for each resource endpoint. A combination of scopes can be defined for permission.
Even though multiple permissions can be configured for a resource endpoint via  identity.xml file authz handler / JDBC authorization manager are not supported for multiple permission handling. If we allow that there can be several options.
(someone may want to define one resource endpoint needs either one of the defined permissions/someone may want to define one resource endpoint needs all of the defined permissions)

So without changing the current architecture of resource access control, we decided to add `/permission/admin/manage/identity/rolemgt permission` for organization role management 
https://github.com/wso2/carbon-identity-framework/pull/4079/files

Therefore, org-cretor role should have both permissions:

- "/permission/admin/manage/identity/organizationmgt"
- "/permission/admin/manage/identity/rolemgt"