### PR TITLE
Add Organization switching grant type

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.oauth2.grant/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.oauth2.grant/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.organization.management</groupId>
         <artifactId>identity-organization-management</artifactId>
-        <version>1.0.38-SNAPSHOT</version>
+        <version>1.0.45-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -50,6 +50,14 @@
         <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.authz.service</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
         </dependency>
     </dependencies>
 

--- a/components/org.wso2.carbon.identity.organization.management.oauth2.grant/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.oauth2.grant/pom.xml
@@ -22,14 +22,14 @@
     <parent>
         <groupId>org.wso2.carbon.identity.organization.management</groupId>
         <artifactId>identity-organization-management</artifactId>
-        <version>1.0.47-SNAPSHOT</version>
+        <version>1.0.49-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.carbon.identity.organization.management.oauth2.grant</artifactId>
     <name>WSO2 - Organization Management Organization Switch Grant</name>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
 
     <dependencies>
         <dependency>
@@ -62,16 +62,46 @@
         </dependency>
     </dependencies>
 
-
     <build>
-        <sourceDirectory>src/main/java</sourceDirectory>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Bundle-Description>Organization Switch Grant Bundle</Bundle-Description>
+                        <Private-Package>org.wso2.carbon.identity.organization.management.oauth2.grant.internal
+                        </Private-Package>
+                        <Export-Package>
+                            !org.wso2.carbon.identity.organization.management.oauth2.grant.internal,
+                            org.wso2.carbon.identity.organization.management.oauth2.grant.*; version="${project.version}"
+                        </Export-Package>
+                        <Import-Package>
+                            org.apache.commons.lang;version="${org.apache.commons.lang.imp.pkg.version.range}",
+                            org.apache.commons.logging;version="${org.apache.commons.logging.imp.pkg.version.range}",
+                            org.apache.oltu.oauth2.common.validators; version="${oltu.oauth2.client.version.range}",
+                            org.wso2.carbon.identity.application.authentication.framework.exception; version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.application.authentication.framework.model; version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.application.common.model; version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.core.util; version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.oauth2; version="${identity.inbound.auth.oauth.version}",
+                            org.wso2.carbon.identity.oauth2.dto; version="${identity.inbound.auth.oauth.version}",
+                            org.wso2.carbon.identity.oauth2.model; version="${identity.inbound.auth.oauth.version}",
+                            org.wso2.carbon.identity.oauth2.token; version="${identity.inbound.auth.oauth.version}",
+                            org.wso2.carbon.identity.oauth2.token.handlers.grant; version="${identity.inbound.auth.oauth.version}",
+                            org.wso2.carbon.identity.organization.management.authz.service; version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.management.authz.service.exception; version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.management.service; version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.management.service.constant; version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.management.service.exception; version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.management.service.util; version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
+                            org.wso2.carbon.user.api;version="${carbon.user.api.imp.pkg.version.range}",
+                            org.wso2.carbon.user.core.service;version="${carbon.kernel.package.import.version.range}",
+                        </Import-Package>
+                    </instructions>
                 </configuration>
             </plugin>
         </plugins>

--- a/components/org.wso2.carbon.identity.organization.management.oauth2.grant/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.oauth2.grant/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <parent>
+        <groupId>org.wso2.carbon.identity.organization.management</groupId>
+        <artifactId>identity-organization-management</artifactId>
+        <version>1.0.38-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.carbon.identity.organization.management.oauth2.grant</artifactId>
+    <packaging>jar</packaging>
+    <name>WSO2 - Organization Management Organization Switch Grant</name>
+    <url>http://maven.apache.org</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.oltu.oauth2</groupId>
+            <artifactId>org.apache.oltu.oauth2.client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
+            <artifactId>org.wso2.carbon.identity.oauth</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.logging</groupId>
+            <artifactId>pax-logging-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.user.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>src/main/java</sourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/components/org.wso2.carbon.identity.organization.management.oauth2.grant/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.oauth2.grant/pom.xml
@@ -15,20 +15,19 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.wso2.carbon.identity.organization.management</groupId>
         <artifactId>identity-organization-management</artifactId>
-        <version>1.0.45-SNAPSHOT</version>
+        <version>1.0.47-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>org.wso2.carbon.identity.organization.management.oauth2.grant</artifactId>
-    <packaging>jar</packaging>
     <name>WSO2 - Organization Management Organization Switch Grant</name>
-    <url>http://maven.apache.org</url>
+    <packaging>jar</packaging>
 
     <dependencies>
         <dependency>
@@ -60,6 +59,7 @@
             <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
         </dependency>
     </dependencies>
+
 
     <build>
         <sourceDirectory>src/main/java</sourceDirectory>

--- a/components/org.wso2.carbon.identity.organization.management.oauth2.grant/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.oauth2.grant/pom.xml
@@ -1,18 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+  ~ Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com).
   ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
   ~ http://www.apache.org/licenses/LICENSE-2.0
   ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/OrganizationSwitchGrant.java
+++ b/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/OrganizationSwitchGrant.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.management.oauth2.grant;
+
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.application.common.model.User;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+import org.wso2.carbon.identity.oauth2.OAuth2TokenValidationService;
+import org.wso2.carbon.identity.oauth2.dto.OAuth2ClientApplicationDTO;
+import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationRequestDTO;
+import org.wso2.carbon.identity.oauth2.dto.OAuth2TokenValidationResponseDTO;
+import org.wso2.carbon.identity.oauth2.model.RequestParameter;
+import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
+import org.wso2.carbon.identity.oauth2.token.handlers.grant.AbstractAuthorizationGrantHandler;
+import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
+import org.wso2.carbon.identity.organization.management.oauth2.grant.util.Constants;
+
+import java.util.Arrays;
+
+/**
+ * Implements the AuthorizationGrantHandler for the OrganizationSwitch grant type.
+ */
+public class OrganizationSwitchGrant extends AbstractAuthorizationGrantHandler  {
+
+    private static final Log LOG = LogFactory.getLog(OrganizationSwitchGrant.class);
+
+
+    public static final String MOBILE_GRANT_PARAM = "mobileNumber";
+
+    @Override
+    public boolean validateGrant(OAuthTokenReqMessageContext tokReqMsgCtx)  throws IdentityOAuth2Exception {
+
+        super.validateGrant(tokReqMsgCtx);
+
+        String token = extractParameter(Constants.Params.TOKEN_PARAM, tokReqMsgCtx);
+        String organization = extractParameter(Constants.Params.ORG_PARAM, tokReqMsgCtx);
+
+        OAuth2TokenValidationResponseDTO validationResponseDTO = validateToken(token);
+
+        if (!validationResponseDTO.isValid()) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Access token validation failed.");
+            }
+
+            throw new IdentityOAuth2Exception("Invalid token received.");
+        }
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Access token validation success.");
+        }
+
+        User authorizedUser = User.getUserFromUserName(validationResponseDTO.getAuthorizedUser());
+
+        String currentOrganizationId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getOrganizationId();
+
+        boolean isValidCollaborator = validateCollaboratorAssociation(authorizedUser);
+
+        if (!isValidCollaborator) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Authorized user: " + authorizedUser.toFullQualifiedUsername() + " does not have " +
+                        "permission for the current organization");
+            }
+//            ResponseHeader responseHeader = new ResponseHeader();
+//            responseHeader.setKey("error-description");
+//            responseHeader.setValue("Associated user is invalid.");
+//            tokReqMsgCtx.addProperty("RESPONSE_HEADERS", new ResponseHeader[]{responseHeader});
+
+            return false;
+        }
+
+        User currentUser = new User();
+        currentUser.setUserName(authorizedUser.getUserName());
+        currentUser.setUserStoreDomain(authorizedUser.getUserStoreDomain());
+        currentUser.setTenantDomain(convertOrgToTenant(currentOrganizationId));
+
+        tokReqMsgCtx.setAuthorizedUser(
+                OAuth2Util.getUserFromUserName(currentUser.toFullQualifiedUsername()));
+
+        //This is commented to support account switching capability.
+        //https://github.com/wso2/product-is/issues/7385
+        //String[] allowedScopes =  getAllowedScopes(validationResponseDTO.getScope(),
+        //tokReqMsgCtx.getOauth2AccessTokenReqDTO().getScope());
+        String[] allowedScopes = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getScope();
+        tokReqMsgCtx.setScope(allowedScopes);
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Issuing an access token for user: " + currentUser + " with scopes: " +
+                    Arrays.toString(tokReqMsgCtx.getScope()));
+        }
+
+        return true;
+    }
+
+    private boolean validateCollaboratorAssociation(User authorizedUser) {
+
+        //TODO implement
+        return true;
+    }
+
+    private String convertOrgToTenant(String currentOrganizationId) {
+
+        //TODO implement
+        return currentOrganizationId;
+    }
+
+    private String extractParameter(String param, OAuthTokenReqMessageContext tokReqMsgCtx) {
+
+        RequestParameter[] parameters = tokReqMsgCtx.getOauth2AccessTokenReqDTO().getRequestParameters();
+
+        if (parameters != null) {
+            for (RequestParameter parameter : parameters) {
+                if (param.equals(parameter.getKey())) {
+                    if (ArrayUtils.isNotEmpty(parameter.getValue())) {
+                        return parameter.getValue()[0];
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Validate access token.
+     * @param accessToken
+     * @return OAuth2TokenValidationResponseDTO of the validated token
+     */
+    private OAuth2TokenValidationResponseDTO validateToken(String accessToken) {
+
+        OAuth2TokenValidationService oAuth2TokenValidationService = new OAuth2TokenValidationService();
+        OAuth2TokenValidationRequestDTO requestDTO = new OAuth2TokenValidationRequestDTO();
+        OAuth2TokenValidationRequestDTO.OAuth2AccessToken token = requestDTO.new OAuth2AccessToken();
+
+        token.setIdentifier(accessToken);
+        token.setTokenType("bearer");
+        requestDTO.setAccessToken(token);
+
+        //TODO: If these values are not set, validation will fail giving an NPE. Need to see why that happens
+        OAuth2TokenValidationRequestDTO.TokenValidationContextParam contextParam = requestDTO.new
+                TokenValidationContextParam();
+        contextParam.setKey("dummy");
+        contextParam.setValue("dummy");
+
+        OAuth2TokenValidationRequestDTO.TokenValidationContextParam[] contextParams = {contextParam};
+        requestDTO.setContext(contextParams);
+
+        //TODO check if we can validate a token from different tenant
+        OAuth2ClientApplicationDTO clientApplicationDTO = oAuth2TokenValidationService
+                .findOAuthConsumerIfTokenIsValid
+                        (requestDTO);
+        return clientApplicationDTO.getAccessTokenValidationResponse();
+    }
+
+}

--- a/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/OrganizationSwitchGrant.java
+++ b/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/OrganizationSwitchGrant.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
@@ -149,6 +149,7 @@ public class OrganizationSwitchGrant extends AbstractAuthorizationGrantHandler  
 
     /**
      * Validate access token.
+     *
      * @param accessToken
      * @return OAuth2TokenValidationResponseDTO of the validated token
      */

--- a/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/OrganizationSwitchGrantValidator.java
+++ b/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/OrganizationSwitchGrantValidator.java
@@ -19,7 +19,7 @@
 package org.wso2.carbon.identity.organization.management.oauth2.grant;
 
 import org.apache.oltu.oauth2.common.validators.AbstractValidator;
-import org.wso2.carbon.identity.organization.management.oauth2.grant.util.Constants;
+import org.wso2.carbon.identity.organization.management.oauth2.grant.util.OrganizationSwitchGrantConstants;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -32,7 +32,6 @@ public class OrganizationSwitchGrantValidator extends AbstractValidator<HttpServ
 
     public OrganizationSwitchGrantValidator() {
 
-        requiredParams.add(Constants.Params.TOKEN_PARAM);
-        requiredParams.add(Constants.Params.ORG_PARAM);
+        requiredParams.add(OrganizationSwitchGrantConstants.Params.TOKEN_PARAM);
     }
 }

--- a/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/OrganizationSwitchGrantValidator.java
+++ b/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/OrganizationSwitchGrantValidator.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at

--- a/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/OrganizationSwitchGrantValidator.java
+++ b/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/OrganizationSwitchGrantValidator.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.management.oauth2.grant;
+
+import org.apache.oltu.oauth2.common.validators.AbstractValidator;
+import org.wso2.carbon.identity.organization.management.oauth2.grant.util.Constants;
+
+import javax.servlet.http.HttpServletRequest;
+
+
+/**
+ * This validates the organization switch grant request.
+ */
+public class OrganizationSwitchGrantValidator extends AbstractValidator<HttpServletRequest> {
+
+
+    public OrganizationSwitchGrantValidator() {
+
+        requiredParams.add(Constants.Params.TOKEN_PARAM);
+        requiredParams.add(Constants.Params.ORG_PARAM);
+    }
+}

--- a/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/exception/OrganizationSwitchGrantClientException.java
+++ b/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/exception/OrganizationSwitchGrantClientException.java
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
  *
- *  WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an

--- a/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/exception/OrganizationSwitchGrantClientException.java
+++ b/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/exception/OrganizationSwitchGrantClientException.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at

--- a/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/exception/OrganizationSwitchGrantClientException.java
+++ b/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/exception/OrganizationSwitchGrantClientException.java
@@ -16,19 +16,15 @@
  * under the License.
  */
 
-package org.wso2.carbon.identity.organization.management.oauth2.grant.util;
+package org.wso2.carbon.identity.organization.management.oauth2.grant.exception;
 
 /**
- Organization switch grant constants.
+ * This exception class is to represent client side errors in the requests.
  */
-public class Constants {
+public class OrganizationSwitchGrantClientException extends OrganizationSwitchGrantException {
 
-    /**
-     * Constants related to request parameters.
-     */
-    public static class Params {
-
-        public static final String TOKEN_PARAM = "token";
-        public static final String ORG_PARAM = "organization";
+    public OrganizationSwitchGrantClientException(String message, String description, String errorCode) {
+        super(message, description, errorCode);
     }
+
 }

--- a/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/exception/OrganizationSwitchGrantException.java
+++ b/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/exception/OrganizationSwitchGrantException.java
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
  *
- *  WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an

--- a/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/exception/OrganizationSwitchGrantException.java
+++ b/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/exception/OrganizationSwitchGrantException.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at

--- a/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/exception/OrganizationSwitchGrantException.java
+++ b/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/exception/OrganizationSwitchGrantException.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.management.oauth2.grant.exception;
+
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+
+/**
+ * Base exception class for organization switch grant.
+ */
+public class OrganizationSwitchGrantException extends IdentityOAuth2Exception {
+
+    private final String errorCode;
+    private String description;
+
+    public OrganizationSwitchGrantException(String message, String description, String errorCode) {
+
+        super(errorCode, message);
+        this.errorCode = errorCode;
+        this.description = description;
+    }
+
+    public OrganizationSwitchGrantException(String message, String errorCode, Throwable cause) {
+
+        super(errorCode, message, cause);
+        this.errorCode = errorCode;
+    }
+
+    public OrganizationSwitchGrantException(String message, String description, String errorCode, Throwable cause) {
+
+        super(errorCode, message, cause);
+        this.errorCode = errorCode;
+        this.description = description;
+    }
+
+    public String getErrorCode() {
+
+        return errorCode;
+    }
+
+    public String getDescription() {
+
+        return description;
+    }
+}

--- a/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/exception/OrganizationSwitchGrantServerException.java
+++ b/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/exception/OrganizationSwitchGrantServerException.java
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
  *
- *  WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an

--- a/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/exception/OrganizationSwitchGrantServerException.java
+++ b/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/exception/OrganizationSwitchGrantServerException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.management.oauth2.grant.exception;
+
+/**
+ * This exception class is to represent server side errors in the requests.
+ */
+public class OrganizationSwitchGrantServerException extends OrganizationSwitchGrantException {
+
+    public OrganizationSwitchGrantServerException(String message, String errorCode, Throwable e) {
+
+        super(message, errorCode, e);
+    }
+
+    public OrganizationSwitchGrantServerException(String message, String description, String errorCode, Throwable e) {
+
+        super(message, description, errorCode, e);
+    }
+}

--- a/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/exception/OrganizationSwitchGrantServerException.java
+++ b/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/exception/OrganizationSwitchGrantServerException.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at

--- a/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/internal/OrganizationSwitchGrantDataHolder.java
+++ b/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/internal/OrganizationSwitchGrantDataHolder.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.management.oauth2.grant.internal;
+
+import org.wso2.carbon.user.core.service.RealmService;
+
+/**
+ * This class acts as a data holder to the organization switch grant service.
+ */
+public class OrganizationSwitchGrantDataHolder {
+
+    private static final OrganizationSwitchGrantDataHolder instance = new OrganizationSwitchGrantDataHolder();
+
+    private RealmService realmService;
+
+    public static OrganizationSwitchGrantDataHolder getInstance() {
+
+        return instance;
+    }
+
+    public RealmService getRealmService() {
+
+        return realmService;
+    }
+
+    public void setRealmService(RealmService realmService) {
+
+        this.realmService = realmService;
+    }
+}

--- a/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/internal/OrganizationSwitchGrantDataHolderServiceComponent.java
+++ b/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/internal/OrganizationSwitchGrantDataHolderServiceComponent.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.management.oauth2.grant.internal;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.wso2.carbon.user.core.service.RealmService;
+
+/**
+ * This class contains the service component of the organization switching grant type.
+ */
+@Component(
+        name = "identity.organization.management.oauth2.grant.component",
+        immediate = true
+)
+public class OrganizationSwitchGrantDataHolderServiceComponent {
+
+    private static final Log log = LogFactory.getLog(OrganizationSwitchGrantDataHolderServiceComponent.class);
+
+    @Reference(
+            name = "realm.service",
+            service = RealmService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetRealmService")
+    protected void setRealmService(RealmService realmService) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Setting the Realm Service");
+        }
+        OrganizationSwitchGrantDataHolder.getInstance().setRealmService(realmService);
+    }
+
+    protected void unsetRealmService(RealmService realmService) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Unset the Realm Service.");
+        }
+        OrganizationSwitchGrantDataHolder.getInstance().setRealmService(null);
+    }
+}

--- a/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/util/Constants.java
+++ b/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/util/Constants.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.management.oauth2.grant.util;
+
+/**
+ Organization switch grant constants.
+ */
+public class Constants {
+
+    /**
+     * Constants related to request parameters.
+     */
+    public static class Params {
+
+        public static final String TOKEN_PARAM = "token";
+        public static final String ORG_PARAM = "organization";
+    }
+}

--- a/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/util/OrganizationSwitchGrantConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/util/OrganizationSwitchGrantConstants.java
@@ -24,6 +24,7 @@ package org.wso2.carbon.identity.organization.management.oauth2.grant.util;
 public class OrganizationSwitchGrantConstants {
 
     public static final String ORG_SWITCH_PERMISSION = "/permission/admin/manage/identity/organizationmgt/view";
+    public static final String ORG_SWITCH_PERMISSION_FOR_ROOT = "/permission/admin";
 
     /**
      * Constants related to request parameters.

--- a/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/util/OrganizationSwitchGrantConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/util/OrganizationSwitchGrantConstants.java
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
  *
- *  WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an

--- a/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/util/OrganizationSwitchGrantConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/util/OrganizationSwitchGrantConstants.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at

--- a/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/util/OrganizationSwitchGrantConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/util/OrganizationSwitchGrantConstants.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.management.oauth2.grant.util;
+
+/**
+ Organization switch grant constants.
+ */
+public class OrganizationSwitchGrantConstants {
+
+    public static final String ORG_SWITCH_PERMISSION = "/permission/admin/manage/identity/organizationmgt/view";
+
+    /**
+     * Constants related to request parameters.
+     */
+    public static class Params {
+
+        public static final String TOKEN_PARAM = "token";
+    }
+}

--- a/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/util/OrganizationSwitchGrantUtil.java
+++ b/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/util/OrganizationSwitchGrantUtil.java
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
  *
- *  WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an

--- a/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/util/OrganizationSwitchGrantUtil.java
+++ b/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/util/OrganizationSwitchGrantUtil.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.management.oauth2.grant.util;
+
+import org.apache.commons.lang.ArrayUtils;
+import org.wso2.carbon.identity.organization.management.oauth2.grant.exception.OrganizationSwitchGrantClientException;
+import org.wso2.carbon.identity.organization.management.oauth2.grant.exception.OrganizationSwitchGrantServerException;
+import org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants;
+
+/**
+ * This class provides utility functions for the Organization Switch grant.
+ */
+public class OrganizationSwitchGrantUtil {
+
+    public static OrganizationSwitchGrantClientException handleClientException(
+            OrganizationManagementConstants.ErrorMessages error, String...  data) {
+
+        String description = error.getDescription();
+        if (ArrayUtils.isNotEmpty(data)) {
+            description = String.format(description, data);
+        }
+        return new OrganizationSwitchGrantClientException(error.getMessage(), description, error.getCode());
+    }
+
+    public static OrganizationSwitchGrantServerException handleServerException(
+            OrganizationManagementConstants.ErrorMessages error, Throwable  e) {
+
+        return new OrganizationSwitchGrantServerException(error.getMessage(), error.getCode(), e);
+    }
+
+    public static OrganizationSwitchGrantServerException handleServerException(
+            OrganizationManagementConstants.ErrorMessages error, Throwable  e, String... data) {
+
+        String description = error.getDescription();
+        if (ArrayUtils.isNotEmpty(data)) {
+            description = String.format(description, data);
+        }
+
+        return new OrganizationSwitchGrantServerException(error.getMessage(), description, error.getCode(), e);
+    }
+}

--- a/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/util/OrganizationSwitchGrantUtil.java
+++ b/components/org.wso2.carbon.identity.organization.management.oauth2.grant/src/main/java/org/wso2/carbon/identity/organization/management/oauth2/grant/util/OrganizationSwitchGrantUtil.java
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com).
  *
- * WSO2 Inc. licenses this file to you under the Apache License,
+ * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManager.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManager.java
@@ -136,6 +136,15 @@ public interface OrganizationManager {
     String resolveTenantDomain(String organizationId) throws OrganizationManagementException;
 
     /**
+     * Derive the organization id of the given tenant.
+     *
+     * @param tenantDomain The tenant domain.
+     * @return organization id.
+     * @throws OrganizationManagementException The exception thrown when retrieving the organization id of a tenant.
+     */
+    String resolveOrganizationId(String tenantDomain) throws OrganizationManagementException;
+
+    /**
      * Get ancestor organization ids (including itself) of a given organization.
      *
      * @param organizationId Organization id.

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
@@ -61,7 +61,6 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -331,12 +330,8 @@ public class OrganizationManagerImpl implements OrganizationManager {
         if (StringUtils.equals(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME, tenantDomain)) {
             return OrganizationManagementConstants.ROOT_ORG_ID;
         } else {
-            Optional<String> optional = organizationManagementDAO.resolveOrganizationId(tenantDomain);
-            if (optional.isPresent()) {
-                return optional.get();
-            } else {
-                throw handleClientException(ERROR_CODE_ORGANIZATION_NOT_FOUND_FOR_TENANT, tenantDomain);
-            }
+            return organizationManagementDAO.resolveOrganizationId(tenantDomain).orElseThrow(
+                    () -> handleClientException(ERROR_CODE_ORGANIZATION_NOT_FOUND_FOR_TENANT, tenantDomain));
         }
     }
 

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
@@ -397,7 +397,10 @@ public class OrganizationManagementConstants {
                 "Server encountered while retrieving the authenticated user from user store."),
         ERROR_CODE_ERROR_VALIDATING_USER_ASSOCIATION("65069", "Error while validating user association " +
                 "for organization.", "Server encountered when authorizing user against the associated " +
-                "organization.");
+                "organization."),
+        ERROR_CODE_ERROR_VALIDATING_USER_ROOT_ASSOCIATION("65070", "Error while validating user " +
+                "association with root organization.", "Server encountered when authorizing user against the root " +
+                                                             "organization.");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
@@ -30,6 +30,7 @@ import java.util.Map;
 public class OrganizationManagementConstants {
 
     public static final String ROOT = "ROOT";
+    public static final String ROOT_ORG_ID = "10084a8d-113f-4211-a0d5-efe36b082211";
     public static final String PATH_SEPARATOR = "/";
     public static final String V1_API_PATH_COMPONENT = "v1";
     public static final String ORGANIZATION_PATH = "organizations";
@@ -230,6 +231,10 @@ public class OrganizationManagementConstants {
                 "Organization %s can't be renamed."),
         ERROR_CODE_ROLE_IS_UNMODIFIABLE("60052", "Role can't be modified.",
                 "Role %s cannot be updated or deleted."),
+        ERROR_CODE_INVALID_ORGANIZATION_NAME("60053", "Organization not found",
+                "Organization with name %s not found"),
+        ERROR_CODE_ORGANIZATION_NOT_FOUND_FOR_TENANT("60054", "Organization not found for the tenant",
+                "Organization for the tenant domain %s not found."),
 
         // Server errors.
         ERROR_CODE_UNEXPECTED("65001", "Unexpected processing error",
@@ -387,7 +392,12 @@ public class OrganizationManagementConstants {
                 "Error while resolving user: %s from resident organization, to access organization with ID: %s."),
         ERROR_CODE_ERROR_RETRIEVING_USER_ORGANIZATION_ROLES("65067", "Error while retrieving organization roles of " +
                 "the user.", "Server encountered an error while retrieving the organizations roles of organization " +
-                "with ID: %s for user with ID: %s.");
+                "with ID: %s for user with ID: %s."),
+        ERROR_CODE_ERROR_RETRIEVING_AUTHENTICATED_USER("65068", "Error while retrieving authenticated user.",
+                "Server encountered while retrieving the authenticated user from user store."),
+        ERROR_CODE_ERROR_VALIDATING_USER_ASSOCIATION("65069", "Error while validating user association " +
+                "for organization.", "Server encountered when authorizing user against the associated " +
+                "organization.");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/OrganizationManagementDAO.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/OrganizationManagementDAO.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.identity.organization.management.service.model.PatchOpera
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * This interface performs CRUD operations for {@link Organization}
@@ -258,7 +259,7 @@ public interface OrganizationManagementDAO {
      * @throws OrganizationManagementServerException The server exception thrown when retrieving the tenant domain of
      *                                               an organization.
      */
-    String resolveOrganizationId(String tenantDomain) throws OrganizationManagementServerException;
+    Optional<String> resolveOrganizationId(String tenantDomain) throws OrganizationManagementServerException;
 
     /**
      * Get ancestor organization ids (including itself) of a given organization.

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/impl/OrganizationManagementDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/impl/OrganizationManagementDAOImpl.java
@@ -42,6 +42,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.TimeZone;
 
 import static java.time.ZoneOffset.UTC;
@@ -948,14 +949,15 @@ public class OrganizationManagementDAOImpl implements OrganizationManagementDAO 
     }
 
     @Override
-    public String resolveOrganizationId(String tenantDomain) throws OrganizationManagementServerException {
+    public Optional<String> resolveOrganizationId(String tenantDomain) throws OrganizationManagementServerException {
 
         NamedJdbcTemplate namedJdbcTemplate = Utils.getNewTemplate();
         try {
-            return namedJdbcTemplate.fetchSingleRecord(GET_ORGANIZATION_UUID_FROM_TENANT_DOMAIN,
+            String organizationId =  namedJdbcTemplate.fetchSingleRecord(GET_ORGANIZATION_UUID_FROM_TENANT_DOMAIN,
                     (resultSet, rowNumber) -> resultSet.getString(1),
                     namedPreparedStatement -> namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_TENANT_DOMAIN,
                             tenantDomain));
+            return Optional.ofNullable(organizationId);
         } catch (DataAccessException e) {
             throw handleServerException(ERROR_CODE_ERROR_RESOLVING_ORGANIZATION_DOMAIN_FROM_TENANT_DOMAIN, e,
                     tenantDomain);

--- a/pom.xml
+++ b/pom.xml
@@ -532,6 +532,7 @@
         </org.apache.commons.collections.imp.pkg.version.range>
 
         <oltu.oauth2.client.version>1.0.0</oltu.oauth2.client.version>
+        <oltu.oauth2.client.version.range>[1.0.0,1.0.3)</oltu.oauth2.client.version.range>
 
         <org.powermock.version>1.7.4</org.powermock.version>
         <jacoco.version>0.8.2</jacoco.version>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
         <module>components/org.wso2.carbon.identity.organization.management.authn</module>
         <module>components/org.wso2.carbon.identity.organization.management.tenant.association</module>
         <module>components/org.wso2.carbon.identity.organization.management.tomcat.ext.tenant.resolver</module>
+        <module>components/org.wso2.carbon.identity.organization.management.oauth2.grant</module>
         <module>features/org.wso2.carbon.identity.organization.management.server.feature</module>
     </modules>
 
@@ -248,6 +249,11 @@
                 <groupId>org.wso2.carbon.identity.outbound.auth.oidc</groupId>
                 <artifactId>org.wso2.carbon.identity.application.authenticator.oidc</artifactId>
                 <version>${identity.outbound.auth.oidc.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.oltu.oauth2</groupId>
+                <artifactId>org.apache.oltu.oauth2.client</artifactId>
+                <version>${oltu.oauth2.client.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon</groupId>
@@ -524,6 +530,8 @@
         <org.apache.commons.logging.imp.pkg.version.range>[1.2,2)</org.apache.commons.logging.imp.pkg.version.range>
         <org.apache.commons.collections.imp.pkg.version.range>[3.2.0,4.0.0)
         </org.apache.commons.collections.imp.pkg.version.range>
+
+        <oltu.oauth2.client.version>1.0.0</oltu.oauth2.client.version>
 
         <org.powermock.version>1.7.4</org.powermock.version>
         <jacoco.version>0.8.2</jacoco.version>


### PR DESCRIPTION
## Purpose
The organization administrators can have access for multiple organizations and able to switch for the authorized organizations. The organization switching grant type implements token exchange mechanism when a valid access token is present. 

## Steps to Enable organization switching grant type

- 1 -Download and put the jar inside ./repository/components/lib


- 2 - Add the following config in deployment.toml to enable the new grant type. 

```
[[oauth.custom_grant_type]]
name="organization_switch"
grant_handler="org.wso2.carbon.identity.organization.management.oauth2.grant.OrganizationSwitchGrant"
grant_validator="org.wso2.carbon.identity.organization.management.oauth2.grant.OrganizationSwitchGrantValidator"

[oauth.custom_grant_type.properties]
IdTokenAllowed=true
```


- 3 - Enable the grant type as allowed grant for the service provider
