### PR TITLE
Refactor resolveUserFromResidentOrganization logic to avoid returning incorrect user object

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverServiceImpl.java
@@ -73,7 +73,7 @@ public class OrganizationUserResidentResolverServiceImpl implements Organization
                         } else if (userId != null && userStoreManager.isExistingUserWithID(userId)) {
                             user = userStoreManager.getUser(userId, null);
                         } else {
-                            return Optional.ofNullable(resolvedUser);
+                            return Optional.empty();
                         }
                         // Check whether user has any association against the org the user is trying to access.
                         boolean userHasAccessPermissions =
@@ -81,6 +81,7 @@ public class OrganizationUserResidentResolverServiceImpl implements Organization
                                         .hasUserOrgAssociation(user.getUserID(), accessedOrganizationId);
                         if (userHasAccessPermissions) {
                             resolvedUser = user;
+                            break;
                         }
                     }
                 }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
@@ -235,7 +235,9 @@ public class OrganizationManagementConstants {
                 "Organization with name %s not found"),
         ERROR_CODE_ORGANIZATION_NOT_FOUND_FOR_TENANT("60054", "Organization not found for the tenant",
                 "Organization for the tenant domain %s not found."),
-
+        ERROR_CODE_NO_USERNAME_OR_ID_TO_RESOLVE_USER_FROM_RESIDENT_ORG("60055",
+                "Both userId and UserName cannot be null.",
+                "Either userId or UserName is required to resolve user from resident organization."),
         // Server errors.
         ERROR_CODE_UNEXPECTED("65001", "Unexpected processing error",
                 "Server encountered an error while serving the request."),


### PR DESCRIPTION
## Purpose
$Subject
`userStoreManager.getUser(userId, userName);` will return a user object created with the provided username and user id. If the given two values are not matched to a same user, the returned user is incorrect/ may be not existing user
