### PR TITLE
Add organization switch role

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.role.management.endpoint/src/main/java/org/wso2/carbon/identity/organization/management/role/management/endpoint/service/RoleManagementService.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.management.endpoint/src/main/java/org/wso2/carbon/identity/organization/management/role/management/endpoint/service/RoleManagementService.java
@@ -227,8 +227,10 @@ public class RoleManagementService {
 
             Role role = RoleManagementEndpointUtils.getRoleManager().putRole(organizationId, roleId,
                     new Role(roleId, displayName,
-                            groups.stream().map(group -> new Group(group.getValue())).collect(Collectors.toList()),
-                            users.stream().map(user -> new User(user.getValue())).collect(Collectors.toList()),
+                            (groups != null ? groups.stream().map(group -> new Group(group.getValue()))
+                                    .collect(Collectors.toList()) : null),
+                            (users != null ? users.stream().map(user -> new User(user.getValue()))
+                                    .collect(Collectors.toList()) : null),
                             permissions));
             URI roleURI = RoleManagementEndpointUtils.getUri(organizationId, roleId, ROLE_PATH,
                     ERROR_CODE_ERROR_BUILDING_ROLE_URI);

--- a/components/org.wso2.carbon.identity.organization.management.role.management.service/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.role.management.service/pom.xml
@@ -85,6 +85,7 @@
                             org.wso2.carbon.identity.core.util; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.database.utils.jdbc;version="${org.wso2.carbon.database.utils.version.range}",
                             org.wso2.carbon.database.utils.jdbc.exceptions;version="${org.wso2.carbon.database.utils.version.range}",
+                            org.wso2.carbon.identity.organization.management.authz.service.util;version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
                             org.wso2.carbon.identity.organization.management.service;version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
                             org.wso2.carbon.identity.organization.management.service.constant;version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
                             org.wso2.carbon.identity.organization.management.service.dao;version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",

--- a/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/constant/RoleManagementConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/constant/RoleManagementConstants.java
@@ -41,6 +41,7 @@ public class RoleManagementConstants {
     public static final String COMMA_SEPARATOR = ",";
 
     public static final String ORG_CREATOR_ROLE = "org-creator";
+    public static final String ORG_SWITCHER_ROLE = "org-switcher";
 
     /**
      * Enum for cursor based pagination direction.

--- a/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/constant/SQLConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/constant/SQLConstants.java
@@ -107,6 +107,10 @@ public class SQLConstants {
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_ROLE_ID + "; AND UM_ORG_ID=:" +
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_ORG_ID + ";";
 
+    public static final String GET_ROLE_ID_FROM_NAME = "SELECT UM_ROLE_ID FROM UM_ORG_ROLE WHERE UM_ROLE_NAME = :" +
+            SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_ROLE_NAME + "; AND UM_ORG_ID=:" +
+            SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_ORG_ID + ";";
+
     public static final String GET_USERS_FROM_ROLE_ID = "SELECT * FROM UM_ORG_ROLE_USER WHERE UM_ROLE_ID=:" +
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_ROLE_ID + ";";
 

--- a/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/dao/RoleManagementDAO.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/dao/RoleManagementDAO.java
@@ -53,6 +53,16 @@ public interface RoleManagementDAO {
     Role getRoleById(String organizationId, String roleId) throws OrganizationManagementServerException;
 
     /**
+     * Retrieve role ID by the given role name and organization ID.
+     *
+     * @param organizationId The organization ID.
+     * @param roleName       The role name.
+     * @return the role ID.
+     * @throws OrganizationManagementServerException The server exception thrown when retrieving the role ID.
+     */
+    String getRoleIdByName(String organizationId, String roleName) throws OrganizationManagementServerException;
+
+    /**
      * Get all the {@link Role}s of an organization.
      *
      * @param organizationId  The ID of the organization.

--- a/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/dao/RoleManagementDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/dao/RoleManagementDAOImpl.java
@@ -451,7 +451,7 @@ public class RoleManagementDAOImpl implements RoleManagementDAO {
 
         NamedJdbcTemplate namedJdbcTemplate = getNewTemplate();
         try {
-            return namedJdbcTemplate.withTransaction(template -> {
+            namedJdbcTemplate.withTransaction(template -> {
                 for (PatchOperation patchOp : patchOperations) {
                     if (StringUtils.equalsIgnoreCase(patchOp.getOp(), PATCH_OP_ADD)) {
                         patchOperationAdd(roleId, patchOp.getPath(), patchOp.getValues());
@@ -463,7 +463,7 @@ public class RoleManagementDAOImpl implements RoleManagementDAO {
                         patchOperationReplace(roleId, patchOp.getPath(), patchOp.getValues());
                     }
                 }
-                return getRoleById(organizationId, roleId);
+                return null;
             });
         } catch (TransactionException e) {
             Throwable cause = e.getCause() != null ? e.getCause() : e;
@@ -478,6 +478,7 @@ public class RoleManagementDAOImpl implements RoleManagementDAO {
             }
             throw handleServerException(ERROR_CODE_PATCHING_ROLE, e, organizationId);
         }
+        return getRoleById(organizationId, roleId);
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/dao/RoleManagementDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/dao/RoleManagementDAOImpl.java
@@ -105,6 +105,7 @@ import static org.wso2.carbon.identity.organization.management.role.management.s
 import static org.wso2.carbon.identity.organization.management.role.management.service.constant.SQLConstants.GET_ROLES_FROM_ORGANIZATION_ID_FORWARD;
 import static org.wso2.carbon.identity.organization.management.role.management.service.constant.SQLConstants.GET_ROLES_FROM_ORGANIZATION_ID_FORWARD_TAIL;
 import static org.wso2.carbon.identity.organization.management.role.management.service.constant.SQLConstants.GET_ROLE_FROM_ID;
+import static org.wso2.carbon.identity.organization.management.role.management.service.constant.SQLConstants.GET_ROLE_ID_FROM_NAME;
 import static org.wso2.carbon.identity.organization.management.role.management.service.constant.SQLConstants.GET_USERS_FROM_ROLE_ID;
 import static org.wso2.carbon.identity.organization.management.role.management.service.constant.SQLConstants.GET_USER_IDS_FROM_ROLE_ID;
 import static org.wso2.carbon.identity.organization.management.role.management.service.constant.SQLConstants.GET_USER_ORGANIZATION_PERMISSIONS;
@@ -132,6 +133,7 @@ import static org.wso2.carbon.identity.organization.management.service.constant.
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ADDING_ROLE_TO_ORGANIZATION;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ADDING_USER_TO_ROLE;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_RETRIEVING_ORGANIZATION_PERMISSIONS;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_RETRIEVING_ROLE_ID_BY_NAME;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_RETRIEVING_USER_ORGANIZATION_ROLES;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_GETTING_GROUPS_USING_ROLE_ID;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_GETTING_PERMISSIONS_USING_ROLE_ID;
@@ -255,6 +257,23 @@ public class RoleManagementDAOImpl implements RoleManagementDAO {
         UserRealm tenantUserRealm = realmService.getTenantUserRealm(tenantId);
 
         return (AbstractUserStoreManager) tenantUserRealm.getUserStoreManager();
+    }
+
+    @Override
+    public String getRoleIdByName(String organizationId, String roleName) throws
+            OrganizationManagementServerException {
+
+        NamedJdbcTemplate namedJdbcTemplate = getNewTemplate();
+        try {
+            return namedJdbcTemplate.fetchSingleRecord(GET_ROLE_ID_FROM_NAME,
+                    (resultSet, rowNumber) -> resultSet.getString(DB_SCHEMA_COLUMN_NAME_UM_ROLE_ID),
+                    namedPreparedStatement -> {
+                        namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_UM_ROLE_NAME, roleName);
+                        namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_UM_ORG_ID, organizationId);
+                    });
+        } catch (DataAccessException e) {
+            throw handleServerException(ERROR_CODE_ERROR_RETRIEVING_ROLE_ID_BY_NAME, e, roleName, organizationId);
+        }
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/internal/RoleManagementDataHolder.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/internal/RoleManagementDataHolder.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.organization.management.role.management.service.internal;
 
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.organization.management.service.OrganizationUserResidentResolverService;
 import org.wso2.carbon.user.core.service.RealmService;
 
 /**
@@ -28,6 +29,7 @@ public class RoleManagementDataHolder {
 
     private static final RoleManagementDataHolder ROLE_MANAGEMENT_DATA_HOLDER = new RoleManagementDataHolder();
     private OrganizationManager organizationManager;
+    private OrganizationUserResidentResolverService organizationUserResidentResolverService;
     private RealmService realmService;
 
     public static RoleManagementDataHolder getInstance() {
@@ -43,6 +45,17 @@ public class RoleManagementDataHolder {
     public void setOrganizationManager(OrganizationManager organizationManager) {
 
         this.organizationManager = organizationManager;
+    }
+
+    public OrganizationUserResidentResolverService getOrganizationUserResidentResolverService() {
+
+        return organizationUserResidentResolverService;
+    }
+
+    public void setOrganizationUserResidentResolverService(OrganizationUserResidentResolverService
+                                                                   organizationUserResidentResolverService) {
+
+        this.organizationUserResidentResolverService = organizationUserResidentResolverService;
     }
 
     public RealmService getRealmService() {

--- a/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/internal/RoleManagementServiceComponent.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/internal/RoleManagementServiceComponent.java
@@ -30,6 +30,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.identity.organization.management.role.management.service.RoleManager;
 import org.wso2.carbon.identity.organization.management.role.management.service.RoleManagerImpl;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.organization.management.service.OrganizationUserResidentResolverService;
 import org.wso2.carbon.user.core.service.RealmService;
 
 /**
@@ -101,5 +102,31 @@ public class RoleManagementServiceComponent {
             LOG.debug("Unset organization management service.");
         }
         RoleManagementDataHolder.getInstance().setOrganizationManager(null);
+    }
+
+    @Reference(
+            name = "organization.user.resident.resolver.service",
+            service = OrganizationUserResidentResolverService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetOrganizationUserResidentResolverService"
+    )
+    protected void setOrganizationUserResidentResolverService(OrganizationUserResidentResolverService
+                                                                          organizationUserResidentResolverService) {
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Setting the organization user resolver service.");
+        }
+        RoleManagementDataHolder.getInstance().setOrganizationUserResidentResolverService
+                (organizationUserResidentResolverService);
+    }
+
+    protected void unsetOrganizationUserResidentResolverService(OrganizationUserResidentResolverService
+                                                                        organizationUserResidentResolverService) {
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Unset organization user resolver service.");
+        }
+        RoleManagementDataHolder.getInstance().setOrganizationUserResidentResolverService(null);
     }
 }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManager.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManager.java
@@ -155,11 +155,11 @@ public interface OrganizationManager {
     /**
      * Get ancestor organization ids (including itself) of an organization up to the given ancestor organization.
      *
-     * @param childOrgId             The child organization ID.
+     * @param currentOrganizationId  The current organization ID.
      * @param ancestorOrganizationId The ancestor organization ID.
      * @return List of ancestor organization ids including itself.
      */
-    List<String> getAncestorOrganizationIdsUpToGivenAncestorOrganization(String childOrgId,
+    List<String> getAncestorOrganizationIdsUpToGivenAncestorOrganization(String currentOrganizationId,
                                                                          String ancestorOrganizationId)
             throws OrganizationManagementException;
 }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManager.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManager.java
@@ -151,4 +151,15 @@ public interface OrganizationManager {
      * @return List of ancestor organization ids including itself.
      */
     List<String> getAncestorOrganizationIds(String organizationId) throws OrganizationManagementServerException;
+
+    /**
+     * Get ancestor organization ids (including itself) of an organization up to the given ancestor organization.
+     *
+     * @param childOrgId             The child organization ID.
+     * @param ancestorOrganizationId The ancestor organization ID.
+     * @return List of ancestor organization ids including itself.
+     */
+    List<String> getAncestorOrganizationIdsUpToGivenAncestorOrganization(String childOrgId,
+                                                                         String ancestorOrganizationId)
+            throws OrganizationManagementException;
 }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
@@ -342,11 +342,11 @@ public class OrganizationManagerImpl implements OrganizationManager {
     }
 
     @Override
-    public List<String> getAncestorOrganizationIdsUpToGivenAncestorOrganization(String childOrgId,
+    public List<String> getAncestorOrganizationIdsUpToGivenAncestorOrganization(String currentOrganizationId,
                                                                                 String ancestorOrganizationId)
             throws OrganizationManagementException {
 
-        return organizationManagementDAO.getAncestorOrganizationIdsUpToGivenOrganization(childOrgId,
+        return organizationManagementDAO.getAncestorOrganizationIdsUpToGivenOrganization(currentOrganizationId,
                 ancestorOrganizationId);
     }
 

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationManagerImpl.java
@@ -341,6 +341,15 @@ public class OrganizationManagerImpl implements OrganizationManager {
         return organizationManagementDAO.getAncestorOrganizationIds(organizationId);
     }
 
+    @Override
+    public List<String> getAncestorOrganizationIdsUpToGivenAncestorOrganization(String childOrgId,
+                                                                                String ancestorOrganizationId)
+            throws OrganizationManagementException {
+
+        return organizationManagementDAO.getAncestorOrganizationIdsUpToGivenOrganization(childOrgId,
+                ancestorOrganizationId);
+    }
+
     private void updateTenantStatus(String status, String organizationId) throws OrganizationManagementServerException {
 
         if (StringUtils.equals(ACTIVE.toString(), status)) {

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverService.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverService.java
@@ -39,4 +39,16 @@ public interface OrganizationUserResidentResolverService {
      */
     Optional<User> resolveUserFromResidentOrganization(String userName, String userId, String accessedOrganizationId)
             throws OrganizationManagementException;
+
+    /**
+     * Retrieve user's resident organization by traversing through the ancestor organizations from a given child
+     * organization.
+     *
+     * @param userId         The user ID.
+     * @param organizationId The given child organization in the hierarchy.
+     * @return user's resident organization.
+     * @throws OrganizationManagementException Error occurred while resolving resident org of the user.
+     */
+    Optional<String> resolveResidentOrganization(String userId, String organizationId)
+            throws OrganizationManagementException;
 }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverServiceImpl.java
@@ -37,6 +37,7 @@ import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 import java.util.List;
 import java.util.Optional;
 
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_WHILE_RESOLVING_RESIDENT_ORG;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_WHILE_RESOLVING_USER_FROM_RESIDENT_ORG;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.handleServerException;
 
@@ -83,6 +84,32 @@ public class OrganizationUserResidentResolverServiceImpl implements Organization
                     accessedOrganizationId);
         }
         return Optional.ofNullable(resolvedUser);
+    }
+
+    @Override
+    public Optional<String> resolveResidentOrganization(String userId, String accessedOrganizationId)
+            throws OrganizationManagementException {
+
+        String residentOrgId = null;
+        try {
+            List<String> ancestorOrganizationIds =
+                    organizationManagementDAO.getAncestorOrganizationIds(accessedOrganizationId);
+            if (ancestorOrganizationIds != null) {
+                for (String organizationId : ancestorOrganizationIds) {
+                    String associatedTenantDomainForOrg = resolveTenantDomainForOrg(organizationId);
+                    if (associatedTenantDomainForOrg != null) {
+                        AbstractUserStoreManager userStoreManager = getUserStoreManager(associatedTenantDomainForOrg);
+                        if (userStoreManager.isExistingUserWithID(userId)) {
+                            residentOrgId = organizationId;
+                            break;
+                        }
+                    }
+                }
+            }
+        } catch (UserStoreException e) {
+            throw handleServerException(ERROR_CODE_ERROR_WHILE_RESOLVING_RESIDENT_ORG, e, userId);
+        }
+        return Optional.ofNullable(residentOrgId);
     }
 
     private String resolveTenantDomainForOrg(String organizationId) throws OrganizationManagementServerException {

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverServiceImpl.java
@@ -97,12 +97,13 @@ public class OrganizationUserResidentResolverServiceImpl implements Organization
             if (ancestorOrganizationIds != null) {
                 for (String organizationId : ancestorOrganizationIds) {
                     String associatedTenantDomainForOrg = resolveTenantDomainForOrg(organizationId);
-                    if (associatedTenantDomainForOrg != null) {
-                        AbstractUserStoreManager userStoreManager = getUserStoreManager(associatedTenantDomainForOrg);
-                        if (userStoreManager.isExistingUserWithID(userId)) {
-                            residentOrgId = organizationId;
-                            break;
-                        }
+                    if (StringUtils.isBlank(associatedTenantDomainForOrg)) {
+                        continue;
+                    }
+                    AbstractUserStoreManager userStoreManager = getUserStoreManager(associatedTenantDomainForOrg);
+                    if (userStoreManager.isExistingUserWithID(userId)) {
+                        residentOrgId = organizationId;
+                        break;
                     }
                 }
             }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
@@ -80,7 +80,7 @@ public class OrganizationManagementConstants {
     public static final String DELETE_ORGANIZATION_PERMISSION = "/permission/admin/manage/identity/organizationmgt/" +
             "delete";
     public static final String SWITCH_ORGANIZATION_PERMISSION = "/permission/admin/manage/identity/organizationmgt/" +
-            "switch";
+            "view/switch";
     public static final List<String> ALL_ORGANIZATION_PERMISSIONS = Collections.unmodifiableList(Arrays
             .asList(CREATE_ORGANIZATION_PERMISSION, VIEW_ORGANIZATION_PERMISSION, UPDATE_ORGANIZATION_PERMISSION,
                     DELETE_ORGANIZATION_PERMISSION, SWITCH_ORGANIZATION_PERMISSION));

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
@@ -79,10 +79,11 @@ public class OrganizationManagementConstants {
             "update";
     public static final String DELETE_ORGANIZATION_PERMISSION = "/permission/admin/manage/identity/organizationmgt/" +
             "delete";
-
+    public static final String SWITCH_ORGANIZATION_PERMISSION = "/permission/admin/manage/identity/organizationmgt/" +
+            "switch";
     public static final List<String> ALL_ORGANIZATION_PERMISSIONS = Collections.unmodifiableList(Arrays
             .asList(CREATE_ORGANIZATION_PERMISSION, VIEW_ORGANIZATION_PERMISSION, UPDATE_ORGANIZATION_PERMISSION,
-                    DELETE_ORGANIZATION_PERMISSION));
+                    DELETE_ORGANIZATION_PERMISSION, SWITCH_ORGANIZATION_PERMISSION));
 
     public static final String EQ = "eq";
     public static final String CO = "co";
@@ -229,12 +230,16 @@ public class OrganizationManagementConstants {
                 "Organization %s can't be disabled or deleted."),
         ERROR_CODE_ROOT_ORG_RENAME("60051", "ROOT organization can't be renamed.",
                 "Organization %s can't be renamed."),
-        ERROR_CODE_ROLE_IS_UNMODIFIABLE("60052", "Role can't be modified.",
-                "Role %s cannot be updated or deleted."),
+        ERROR_CODE_ROLE_IS_UNMODIFIABLE("60052", "The role can't be modified.",
+                "The role with ID: %s is not allowed to be updated or deleted."),
         ERROR_CODE_INVALID_ORGANIZATION_NAME("60053", "Organization not found",
                 "Organization with name %s not found"),
         ERROR_CODE_ORGANIZATION_NOT_FOUND_FOR_TENANT("60054", "Organization not found for the tenant",
                 "Organization for the tenant domain %s not found."),
+        ERROR_CODE_UNSUPPORTED_ROLE_PATCH("60055", "Unable to patch the role.",
+                "Unsupported patch path/ operation for role with ID: %s."),
+        ERROR_CODE_RESIDENT_ORGANIZATION_NOT_FOUND("60056", "Invalid organization user.",
+                "Resident organization for user with ID: %s is not found."),
 
         // Server errors.
         ERROR_CODE_UNEXPECTED("65001", "Unexpected processing error",
@@ -400,7 +405,12 @@ public class OrganizationManagementConstants {
                 "organization."),
         ERROR_CODE_ERROR_VALIDATING_USER_ROOT_ASSOCIATION("65070", "Error while validating user " +
                 "association with root organization.", "Server encountered when authorizing user against the root " +
-                                                             "organization.");
+                                                             "organization."),
+        ERROR_CODE_ERROR_RETRIEVING_ROLE_ID_BY_NAME("65071", "Unable to retrieve the role name.",
+                "Server encountered an error while retrieving role ID from role name: %s in organization " +
+                        "with ID: %s."),
+        ERROR_CODE_ERROR_WHILE_RESOLVING_RESIDENT_ORG("65072", "Unable to resolve user's resident organization.",
+                "Error while resolving resident organization of user with ID: %s."),;
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/SQLConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/SQLConstants.java
@@ -163,8 +163,9 @@ public class SQLConstants {
 
     public static final String GET_ANCESTORS_OF_ORG_INCLUDING_ITSELF_UP_TO_GIVEN_ANCESTOR =
             "SELECT UM_PARENT_ID FROM UM_ORG_HIERARCHY WHERE UM_ID = :" + SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_ID +
-                    "; AND UM_PARENT_ID NOT IN (SELECT UM_PARENT_ID FROM UM_ORG_HIERARCHY WHERE UM_ID = :" +
-                    SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_PARENT_ID + "; AND DEPTH > 0) ORDER BY DEPTH ASC;";
+            "; AND DEPTH <= (SELECT DEPTH FROM UM_ORG_HIERARCHY WHERE UM_PARENT_ID = :" +
+            SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_PARENT_ID + "; AND UM_ID = :" +
+            SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_ID + ";) ORDER BY DEPTH ASC;";
 
     /**
      * SQL Placeholders.

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/SQLConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/SQLConstants.java
@@ -161,6 +161,11 @@ public class SQLConstants {
             "SELECT UM_PARENT_ID FROM UM_ORG_HIERARCHY WHERE UM_ID = :" + SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_ID +
                     "; ORDER BY DEPTH ASC;";
 
+    public static final String GET_ANCESTORS_OF_ORG_INCLUDING_ITSELF_UP_TO_GIVEN_ANCESTOR =
+            "SELECT UM_PARENT_ID FROM UM_ORG_HIERARCHY WHERE UM_ID = :" + SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_ID +
+                    "; AND UM_PARENT_ID NOT IN (SELECT UM_PARENT_ID FROM UM_ORG_HIERARCHY WHERE UM_ID = :" +
+                    SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_PARENT_ID + "; AND DEPTH > 0) ORDER BY DEPTH ASC;";
+
     /**
      * SQL Placeholders.
      */

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/OrganizationManagementDAO.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/OrganizationManagementDAO.java
@@ -268,4 +268,14 @@ public interface OrganizationManagementDAO {
      * @return List of ancestor organization ids including itself.
      */
     List<String> getAncestorOrganizationIds(String organizationId) throws OrganizationManagementServerException;
+
+    /**
+     * Get ancestor organization ids of an organization (including itself) up to the given ancestor organization.
+     *
+     * @param organizationId The organization ID.
+     * @param ancestorOrgId  The ancestor organization ID.
+     * @return List of ancestor organization ids including itself.
+     */
+    List<String> getAncestorOrganizationIdsUpToGivenOrganization(String organizationId, String ancestorOrgId)
+            throws OrganizationManagementServerException;
 }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/impl/OrganizationManagementDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/impl/OrganizationManagementDAOImpl.java
@@ -1147,9 +1147,6 @@ public class OrganizationManagementDAOImpl implements OrganizationManagementDAO 
 
     private List<String> getListOrganizationsAllowedPermissions() {
 
-        List<String> permissions = getAllowedPermissions(BASE_ORGANIZATION_PERMISSION);
-        permissions.add(VIEW_ORGANIZATION_PERMISSION);
-        permissions.add(SWITCH_ORGANIZATION_PERMISSION);
-        return permissions;
+        return getAllowedPermissions(SWITCH_ORGANIZATION_PERMISSION);
     }
 }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/resources/META-INF/component.xml
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/resources/META-INF/component.xml
@@ -35,5 +35,9 @@
             <DisplayName>Delete</DisplayName>
             <ResourceId>/permission/admin/manage/identity/organizationmgt/delete</ResourceId>
         </ManagementPermission>
+        <ManagementPermission>
+            <DisplayName>Switch</DisplayName>
+            <ResourceId>/permission/admin/manage/identity/organizationmgt/switch</ResourceId>
+        </ManagementPermission>
     </ManagementPermissions>
 </component>

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/resources/META-INF/component.xml
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/resources/META-INF/component.xml
@@ -37,7 +37,7 @@
         </ManagementPermission>
         <ManagementPermission>
             <DisplayName>Switch</DisplayName>
-            <ResourceId>/permission/admin/manage/identity/organizationmgt/switch</ResourceId>
+            <ResourceId>/permission/admin/manage/identity/organizationmgt/view/switch</ResourceId>
         </ManagementPermission>
     </ManagementPermissions>
 </component>

--- a/components/org.wso2.carbon.identity.organization.management.tenant.association/src/main/java/org/wso2/carbon/identity/organization/management/tenant/association/listeners/TenantAssociationManagementListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.tenant.association/src/main/java/org/wso2/carbon/identity/organization/management/tenant/association/listeners/TenantAssociationManagementListener.java
@@ -36,6 +36,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 
 import static org.wso2.carbon.identity.organization.management.role.management.service.constant.RoleManagementConstants.ORG_CREATOR_ROLE;
+import static org.wso2.carbon.identity.organization.management.role.management.service.constant.RoleManagementConstants.ORG_SWITCHER_ROLE;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.SWITCH_ORGANIZATION_PERMISSION;
 
 /**
  * This class contains the implementation of the tenant management listener.  This listener will be used to add tenant
@@ -82,6 +84,8 @@ public class TenantAssociationManagementListener extends AbstractIdentityTenantM
             }
             Role organizationCreatorRole = buildOrgCreatorRole(adminUUID);
             TenantAssociationDataHolder.getRoleManager().createRole(organizationID, organizationCreatorRole);
+            Role organizationSwitcherRole = buildOrgSwitcherRole();
+            TenantAssociationDataHolder.getRoleManager().createRole(organizationID, organizationSwitcherRole);
         } catch (UserStoreException | OrganizationManagementException e) {
             String error = "Error occurred while adding user-tenant association for the tenant id: " + tenantId;
             LOG.error(error, e);
@@ -100,5 +104,16 @@ public class TenantAssociationManagementListener extends AbstractIdentityTenantM
         orgCreatorRolePermissions.add(Constants.ORG_ROLE_MGT_PERMISSION);
         organizationCreatorRole.setPermissions(orgCreatorRolePermissions);
         return organizationCreatorRole;
+    }
+
+    private Role buildOrgSwitcherRole() {
+
+        Role organizationSwitcherRole = new Role();
+        organizationSwitcherRole.setDisplayName(ORG_SWITCHER_ROLE);
+        // Set permissions for org-switcher role.
+        ArrayList<String> orgSwitcherRolePermissions = new ArrayList<>();
+        orgSwitcherRolePermissions.add(SWITCH_ORGANIZATION_PERMISSION);
+        organizationSwitcherRole.setPermissions(orgSwitcherRolePermissions);
+        return organizationSwitcherRole;
     }
 }


### PR DESCRIPTION
Part of the fix for https://github.com/wso2/product-is/issues/14220

With this PR,
- a new permission (/permission/admin/manage/identity/organizationmgt/view/switch) for organization switching is introduced.
- a role for organization switching is created for each organization by default when the organization creation happens.
- when a create role request containing one or more of the given below permissions is invoked, users in that role creation request will automatically be assigned the switcher role in all organizations between the organization where the user is actually residing and the organization where the role is to be created.

```
/
/permission
/permission/admin
/permission/admin/manage
/permission/admin/manage/identity
/permission/admin/manage/identity/organizationmgt
/permission/admin/manage/identity/organizationmgt/create
/permission/admin/manage/identity/organizationmgt/view
/permission/admin/manage/identity/organizationmgt/update
/permission/admin/manage/identity/organizationmgt/delete
/permission/admin/manage/identity/organizationmgt/view/switch
```

Please note that this is only a partial fix to support the organization switcher role. There are pending improvements to be addressed for organization role PUT, PATCH and DELETE requests.