### PR TITLE
Fix a bug in org user resolver

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/OrganizationUserResidentResolverServiceImpl.java
@@ -73,7 +73,7 @@ public class OrganizationUserResidentResolverServiceImpl implements Organization
                         } else if (userId != null && userStoreManager.isExistingUserWithID(userId)) {
                             user = userStoreManager.getUser(userId, null);
                         } else {
-                            return Optional.empty();
+                            continue;
                         }
                         // Check whether user has any association against the org the user is trying to access.
                         boolean userHasAccessPermissions =


### PR DESCRIPTION
## Purpose
The current code return empty if the user does not exist in the first checked org.
