### PR TITLE
Improve sending organizations information to select org from multiple orgs

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.authn/src/main/java/org/wso2/carbon/identity/organization/management/authn/constant/AuthenticatorConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.authn/src/main/java/org/wso2/carbon/identity/organization/management/authn/constant/AuthenticatorConstants.java
@@ -38,8 +38,9 @@ public class AuthenticatorConstants {
     public static final String ORG_PARAMETER = "org";
     public static final String IDP_PARAMETER = "idp";
     public static final String AUTHENTICATOR_PARAMETER = "authenticator";
-    public static final String ORG_LIST_PARAMETER = "orgList";
     public static final String ORG_ID_PARAMETER = "orgId";
+    public static final String ORG_COUNT_PARAMETER = "orgCount";
+    public static final String ORG_DESCRIPTION_PARAMETER = "orgDesc";
 
     public static final String ORGANIZATION_LOGIN_FAILURE = "organizationLoginFailure";
     public static final String ERROR_MESSAGE = "&authFailure=true&authFailureMsg=";


### PR DESCRIPTION
## Purpose
> When multiple organizations with same name identified, the user is prompted to select the intended organization by providing additional information. The information like description, name and id is send to the server pages as  encoded query params without passing comma separated values.