### PR TITLE
Set application name in oauth consumer app for fragment app.

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
@@ -409,7 +409,13 @@ public class OrganizationManagementConstants {
                 "Server encountered an error while retrieving organizations with name: %s."),
         ERROR_CODE_ERROR_ADMIN_USER_NOT_FOUND_FOR_ORGANIZATION("65074", "Unable to retrieve " +
                 "admin user for the organization.", "Server encountered an error while retrieving " +
-                "organization user with id: %s.");
+                "organization user with id: %s."),
+        ERROR_CODE_ERROR_CREATING_OAUTH_APP("65075", "Unable create oauth consumer app for fragment application",
+                "Server encountered an error when creating oauth consumer app for fragment application: %s in " +
+                        "organization: %s."),
+        ERROR_CODE_ERROR_REMOVING_OAUTH_APP("65076", "Unable to share the application",
+                "Server encountered an error when removing oauth consumer app: % for fragment application: %s in " +
+                        "organization: %s.");
 
         private final String code;
         private final String message;


### PR DESCRIPTION
## Purpose
> At the time of the application sharing, new fragment application is created in child org with oauth inbound application to redirect the user login to child organization. Application name wasn't set in the consumer app result in failure when redirecting to consent URL. Also the consumer app has to be removed if the fragment app creation fails.