### PR TITLE
Add authentication context param to store org information in organization login flow

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.authn/src/main/java/org/wso2/carbon/identity/organization/management/authn/OrganizationAuthenticator.java
+++ b/components/org.wso2.carbon.identity.organization.management.authn/src/main/java/org/wso2/carbon/identity/organization/management/authn/OrganizationAuthenticator.java
@@ -158,7 +158,7 @@ public class OrganizationAuthenticator extends OpenIDConnectAuthenticator {
             String application = context.getServiceProviderName();
             String ownerTenantDomain = context.getTenantDomain();
 
-            if (!context.getParameters().containsKey(ORG_PARAMETER) || !context.getParameters()
+            if (!context.getProperties().containsKey(ORG_PARAMETER) || !context.getProperties()
                     .containsKey(ORG_ID_PARAMETER)) {
                 throw handleAuthFailures(ERROR_CODE_ORG_PARAMETERS_NOT_RESOLVED);
             }
@@ -234,7 +234,7 @@ public class OrganizationAuthenticator extends OpenIDConnectAuthenticator {
             }
         }
 
-        if (!context.getParameters().containsKey(ORG_PARAMETER)) {
+        if (!context.getProperties().containsKey(ORG_PARAMETER)) {
             redirectToOrgNameCapture(response, context);
             return AuthenticatorFlowStatus.INCOMPLETE;
         }

--- a/components/org.wso2.carbon.identity.organization.management.authn/src/test/java/org/wso2/carbon/identity/organization/management/authn/OrganizationAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.authn/src/test/java/org/wso2/carbon/identity/organization/management/authn/OrganizationAuthenticatorTest.java
@@ -139,7 +139,7 @@ public class OrganizationAuthenticatorTest extends PowerMockTestCase {
         Tenant tenant = mock(Tenant.class);
         when(mockRealmService.getTenantManager().getTenant(anyInt())).thenReturn(tenant);
         when(tenant.getAssociatedOrganizationUUID()).thenReturn(orgId);
-        when(mockAuthenticationContext.getParameters()).thenReturn(mockContextParam);
+        when(mockAuthenticationContext.getProperties()).thenReturn(mockContextParam);
     }
 
     private void mockServiceURLBuilder() {

--- a/components/org.wso2.carbon.identity.organization.management.authn/src/test/java/org/wso2/carbon/identity/organization/management/authn/OrganizationAuthenticatorTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.authn/src/test/java/org/wso2/carbon/identity/organization/management/authn/OrganizationAuthenticatorTest.java
@@ -90,6 +90,7 @@ public class OrganizationAuthenticatorTest extends PowerMockTestCase {
 
     private static Map<String, String> authenticatorParamProperties;
     private static Map<String, String> authenticatorProperties;
+    private static Map<String, Object> mockContextParam;
 
     @Mock
     private HttpServletRequest mockServletRequest;
@@ -124,6 +125,7 @@ public class OrganizationAuthenticatorTest extends PowerMockTestCase {
         organizationAuthenticator = new OrganizationAuthenticator();
         authenticatorParamProperties = new HashMap<>();
         authenticatorProperties = new HashMap<>();
+        mockContextParam = new HashMap<>();
 
         authenticatorDataHolder = spy(new AuthenticatorDataHolder());
         mockStatic(AuthenticatorDataHolder.class);
@@ -137,6 +139,7 @@ public class OrganizationAuthenticatorTest extends PowerMockTestCase {
         Tenant tenant = mock(Tenant.class);
         when(mockRealmService.getTenantManager().getTenant(anyInt())).thenReturn(tenant);
         when(tenant.getAssociatedOrganizationUUID()).thenReturn(orgId);
+        when(mockAuthenticationContext.getParameters()).thenReturn(mockContextParam);
     }
 
     private void mockServiceURLBuilder() {
@@ -295,6 +298,7 @@ public class OrganizationAuthenticatorTest extends PowerMockTestCase {
         when(mockAuthenticationContext.getTenantDomain()).thenReturn(saasAppOwnedTenant);
         when(authenticatorDataHolder.getOrganizationManager().resolveOrganizationId(anyString()))
                 .thenReturn(saasAppOwnedOrgId);
+        setMockContextParamForValidOrganization();
         when(authenticatorDataHolder.getOrgApplicationManager()
                 .resolveSharedApplication(anyString(), anyString(), anyString())).thenReturn(mockServiceProvider);
         when(mockServiceProvider.getInboundAuthenticationConfig()).thenReturn(mockInboundAuthenticationConfig);
@@ -332,6 +336,7 @@ public class OrganizationAuthenticatorTest extends PowerMockTestCase {
     @Test(expectedExceptions = {AuthenticationFailedException.class})
     public void testInitiateAuthenticationRequestNoSharedApp() throws Exception {
 
+        setMockContextParamForValidOrganization();
         authenticatorParamProperties.put(ORG_PARAMETER, orgId);
         when(organizationAuthenticator.getRuntimeParams(mockAuthenticationContext))
                 .thenReturn(authenticatorParamProperties);
@@ -354,6 +359,7 @@ public class OrganizationAuthenticatorTest extends PowerMockTestCase {
     @Test(expectedExceptions = {AuthenticationFailedException.class})
     public void testInitiateAuthenticationRequestInvalidSharedAppInbound() throws Exception {
 
+        setMockContextParamForValidOrganization();
         authenticatorParamProperties.put(ORG_PARAMETER, orgId);
         when(organizationAuthenticator.getRuntimeParams(mockAuthenticationContext))
                 .thenReturn(authenticatorParamProperties);
@@ -377,6 +383,7 @@ public class OrganizationAuthenticatorTest extends PowerMockTestCase {
     @Test(expectedExceptions = {AuthenticationFailedException.class})
     public void testInitiateAuthenticationRequestInvalidSharedApp() throws Exception {
 
+        setMockContextParamForValidOrganization();
         authenticatorParamProperties.put(ORG_PARAMETER, orgId);
         when(organizationAuthenticator.getRuntimeParams(mockAuthenticationContext))
                 .thenReturn(authenticatorParamProperties);
@@ -394,5 +401,13 @@ public class OrganizationAuthenticatorTest extends PowerMockTestCase {
 
         organizationAuthenticator.initiateAuthenticationRequest(mockServletRequest, mockServletResponse,
                 mockAuthenticationContext);
+    }
+
+    private void setMockContextParamForValidOrganization() {
+
+        mockContextParam.put(ORG_PARAMETER, org);
+        when(mockAuthenticationContext.getProperty(ORG_PARAMETER)).thenReturn(org);
+        mockContextParam.put(ORG_ID_PARAMETER, orgId);
+        when(mockAuthenticationContext.getProperty(ORG_ID_PARAMETER)).thenReturn(orgId);
     }
 }

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
@@ -190,8 +190,6 @@ public class OrganizationManagementConstants {
         ERROR_CODE_INVALID_ORGANIZATION_TYPE("60034", "Invalid organization type.", "The organization " +
                 "type should be 'TENANT' or 'STRUCTURAL'."),
         ERROR_CODE_INVALID_APPLICATION("60035", "Invalid application", "The requested application %s is invalid."),
-        ERROR_CODE_ORG_PARAMETER_NOT_FOUND("60036", "Organization parameter could not be found.", "The organization " +
-                "parameter for shared application authentication is not found."),
         ERROR_CODE_APPLICATION_NOT_SHARED("60037", "Application not shared with organization.", "The " +
                 "application %s is not shared with organization with ID %s."),
         ERROR_CODE_REMOVING_REQUIRED_ATTRIBUTE("60038", "Unable to remove a required attribute.",
@@ -415,7 +413,9 @@ public class OrganizationManagementConstants {
                         "organization: %s."),
         ERROR_CODE_ERROR_REMOVING_OAUTH_APP("65076", "Unable to share the application",
                 "Server encountered an error when removing oauth consumer app: % for fragment application: %s in " +
-                        "organization: %s.");
+                        "organization: %s."),
+        ERROR_CODE_ORG_PARAMETERS_NOT_RESOLVED("65075", "Organization name or organization id is not " +
+                "resolved.", "The organization information has not resolved before the authentication.");
 
         private final String code;
         private final String message;


### PR DESCRIPTION
## Purpose

Previously used `getRuntimeParams` method returns unmodifiable map when the organization login adaptive script is not configured. The reasoning is the adaptive script creates a runtime parameter map called `common` as shown below figure and  no parameter map created if adaptive script is not used. But there can be scenarios where organization login is only required and hence the adaptive script is not necessary. In those cases, the organization login failed with exception. As a fix, the organization information like orgId and org name is stored in authentication context and retrieved when necessary.

![Untitled Diagram (8)](https://user-images.githubusercontent.com/35717390/180704962-f294c8d1-5413-4f51-9354-550e14bde03a.jpg)

### Related Issues
https://github.com/wso2/product-is/issues/14383
