### PR TITLE
Fixed bug: Unable to retrieve the organisation list and organisation's role list with MSSQL

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/constant/SQLConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/constant/SQLConstants.java
@@ -218,6 +218,11 @@ public class SQLConstants {
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_ROLE_NAME + "; ORDER BY UM_ROLE_NAME ASC FETCH FIRST :"  +
             SQLPlaceholders.DB_SCHEMA_LIMIT + "; ROWS ONLY";
 
+    public static final String GET_ROLES_FROM_ORGANIZATION_ID_FORWARD_TAIL_MSSQL = "UM_ORG_ID=:" +
+            SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_ORG_ID + "; AND UM_ROLE_NAME > :" +
+            SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_ROLE_NAME + "; ORDER BY UM_ROLE_NAME ASC OFFSET 0 " +
+            "ROWS FETCH NEXT :" + SQLPlaceholders.DB_SCHEMA_LIMIT + "; ROWS ONLY";
+
     public static final String GET_ROLES_FROM_ORGANIZATION_ID_BACKWARD_TAIL = "UM_ORG_ID=:" +
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_ORG_ID + "; AND UM_ROLE_NAME <= :" +
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_ROLE_NAME + "; ORDER BY UM_ROLE_NAME DESC LIMIT :"  +
@@ -227,6 +232,11 @@ public class SQLConstants {
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_ORG_ID + "; AND UM_ROLE_NAME <= :" +
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_ROLE_NAME + "; ORDER BY UM_ROLE_NAME DESC FETCH FIRST :"  +
             SQLPlaceholders.DB_SCHEMA_LIMIT + "; ROWS ONLY) R ORDER BY R.UM_ROLE_NAME ASC";
+
+    public static final String GET_ROLES_FROM_ORGANIZATION_ID_BACKWARD_TAIL_MSSQL = "UM_ORG_ID=:" +
+            SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_ORG_ID + "; AND UM_ROLE_NAME <= :" +
+            SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_ROLE_NAME + "; ORDER BY UM_ROLE_NAME DESC OFFSET 0 " +
+            "ROWS FETCH NEXT :" + SQLPlaceholders.DB_SCHEMA_LIMIT + "; ROWS ONLY) R ORDER BY R.UM_ROLE_NAME ASC";
 
     public static final String GET_ROLES_COUNT_FROM_ORGANIZATION_ID_TAIL = "UM_ORG_ID=:" +
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_ORG_ID + ";";

--- a/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/dao/RoleManagementDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/dao/RoleManagementDAOImpl.java
@@ -121,9 +121,11 @@ import static org.wso2.carbon.identity.organization.management.role.management.s
 import static org.wso2.carbon.identity.organization.management.role.management.service.constant.SQLConstants.GET_ROLES_COUNT_FROM_ORGANIZATION_ID_TAIL;
 import static org.wso2.carbon.identity.organization.management.role.management.service.constant.SQLConstants.GET_ROLES_FROM_ORGANIZATION_ID_BACKWARD;
 import static org.wso2.carbon.identity.organization.management.role.management.service.constant.SQLConstants.GET_ROLES_FROM_ORGANIZATION_ID_BACKWARD_TAIL;
+import static org.wso2.carbon.identity.organization.management.role.management.service.constant.SQLConstants.GET_ROLES_FROM_ORGANIZATION_ID_BACKWARD_TAIL_MSSQL;
 import static org.wso2.carbon.identity.organization.management.role.management.service.constant.SQLConstants.GET_ROLES_FROM_ORGANIZATION_ID_BACKWARD_TAIL_ORACLE;
 import static org.wso2.carbon.identity.organization.management.role.management.service.constant.SQLConstants.GET_ROLES_FROM_ORGANIZATION_ID_FORWARD;
 import static org.wso2.carbon.identity.organization.management.role.management.service.constant.SQLConstants.GET_ROLES_FROM_ORGANIZATION_ID_FORWARD_TAIL;
+import static org.wso2.carbon.identity.organization.management.role.management.service.constant.SQLConstants.GET_ROLES_FROM_ORGANIZATION_ID_FORWARD_TAIL_MSSQL;
 import static org.wso2.carbon.identity.organization.management.role.management.service.constant.SQLConstants.GET_ROLES_FROM_ORGANIZATION_ID_FORWARD_TAIL_ORACLE;
 import static org.wso2.carbon.identity.organization.management.role.management.service.constant.SQLConstants.GET_ROLE_FROM_ID;
 import static org.wso2.carbon.identity.organization.management.role.management.service.constant.SQLConstants.GET_USERS_FROM_ROLE_ID;
@@ -178,6 +180,7 @@ import static org.wso2.carbon.identity.organization.management.service.util.Util
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.getTenantId;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.handleClientException;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.handleServerException;
+import static org.wso2.carbon.identity.organization.management.service.util.Utils.isMSSqlDB;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.isOracleDB;
 
 /**
@@ -292,6 +295,14 @@ public class RoleManagementDAOImpl implements RoleManagementDAO {
             if (StringUtils.equals(BACKWARD.toString(), direction)) {
                 sqlStm = GET_ROLES_FROM_ORGANIZATION_ID_BACKWARD + filterQuery +
                         GET_ROLES_FROM_ORGANIZATION_ID_BACKWARD_TAIL_ORACLE;
+            }
+        } else if (isMSSqlDB()) {
+            sqlStm = GET_ROLES_FROM_ORGANIZATION_ID_FORWARD + filterQuery +
+                    GET_ROLES_FROM_ORGANIZATION_ID_FORWARD_TAIL_MSSQL;
+
+            if (StringUtils.equals(BACKWARD.toString(), direction)) {
+                sqlStm = GET_ROLES_FROM_ORGANIZATION_ID_BACKWARD + filterQuery +
+                        GET_ROLES_FROM_ORGANIZATION_ID_BACKWARD_TAIL_MSSQL;
             }
         } else {
             sqlStm = GET_ROLES_FROM_ORGANIZATION_ID_FORWARD + filterQuery +

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/SQLConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/SQLConstants.java
@@ -26,6 +26,8 @@ public class SQLConstants {
     // Database types
     public static final String ORACLE = "oracle";
 
+    public static final String MICROSOFT = "microsoft";
+
     public static final String PERMISSION_LIST_PLACEHOLDER = "_PERMISSION_LIST_";
 
     public static final String INSERT_ORGANIZATION = "INSERT INTO UM_ORG (UM_ID, UM_ORG_NAME, UM_ORG_DESCRIPTION, " +
@@ -98,6 +100,13 @@ public class SQLConstants {
             "UM_ORG_HIERARCHY OH ON O.UM_ID = OH.UM_ID WHERE OH.UM_PARENT_ID = (SELECT UM_ID FROM UM_ORG WHERE %s) " +
             "AND OH.DEPTH %s) ORDER BY UM_ORG.UM_CREATED_TIME %s FETCH FIRST :" + SQLPlaceholders.DB_SCHEMA_LIMIT +
             "; ROWS ONLY";
+
+    public static final String GET_ORGANIZATIONS_TAIL_MSSQL = "UM_ORG_ROLE_USER.UM_USER_ID = :" +
+            SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_USER_ID + "; AND UM_ORG_PERMISSION.UM_RESOURCE_ID IN (" +
+            PERMISSION_LIST_PLACEHOLDER + ") AND UM_ORG.UM_ID IN (SELECT O.UM_ID FROM UM_ORG O JOIN " +
+            "UM_ORG_HIERARCHY OH ON O.UM_ID = OH.UM_ID WHERE OH.UM_PARENT_ID = (SELECT UM_ID FROM UM_ORG WHERE %s) " +
+            "AND OH.DEPTH %s) ORDER BY UM_ORG.UM_CREATED_TIME %s OFFSET 0 ROWS FETCH NEXT :" +
+            SQLPlaceholders.DB_SCHEMA_LIMIT + "; ROWS ONLY";
 
     public static final String SET_ID = "UM_ID = :" + SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_ID + ";";
 

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/impl/OrganizationManagementDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/dao/impl/OrganizationManagementDAOImpl.java
@@ -125,6 +125,7 @@ import static org.wso2.carbon.identity.organization.management.service.constant.
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.GET_ORGANIZATIONS;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.GET_ORGANIZATIONS_BY_NAME;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.GET_ORGANIZATIONS_TAIL;
+import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.GET_ORGANIZATIONS_TAIL_MSSQL;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.GET_ORGANIZATIONS_TAIL_ORACLE;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.GET_ORGANIZATION_BY_ID;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.GET_ORGANIZATION_NAME_BY_ID;
@@ -162,6 +163,7 @@ import static org.wso2.carbon.identity.organization.management.service.constant.
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.UPDATE_ORGANIZATION_LAST_MODIFIED;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.getUserId;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.handleServerException;
+import static org.wso2.carbon.identity.organization.management.service.util.Utils.isMSSqlDB;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.isOracleDB;
 
 /**
@@ -344,7 +346,13 @@ public class OrganizationManagementDAOImpl implements OrganizationManagementDAO 
         String parentIdFilterQuery = parentIdFilterQueryBuilder.getFilterQuery();
 
         String sqlStmt;
-        String getOrgSqlStmtTail = isOracleDB() ? GET_ORGANIZATIONS_TAIL_ORACLE : GET_ORGANIZATIONS_TAIL;
+        String getOrgSqlStmtTail = GET_ORGANIZATIONS_TAIL;
+
+        if (isOracleDB()) {
+            getOrgSqlStmtTail = GET_ORGANIZATIONS_TAIL_ORACLE;
+        } else if (isMSSqlDB()) {
+            getOrgSqlStmtTail = GET_ORGANIZATIONS_TAIL_MSSQL;
+        }
 
         if (StringUtils.isBlank(parentIdFilterQuery)) {
             sqlStmt = GET_ORGANIZATIONS + filterQueryBuilder.getFilterQuery() +

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/util/Utils.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/util/Utils.java
@@ -39,6 +39,7 @@ import static org.wso2.carbon.identity.organization.management.service.constant.
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.PATH_SEPARATOR;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.SERVER_API_PATH_COMPONENT;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.V1_API_PATH_COMPONENT;
+import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.MICROSOFT;
 import static org.wso2.carbon.identity.organization.management.service.constant.SQLConstants.ORACLE;
 
 /**
@@ -98,10 +99,33 @@ public class Utils {
      * @throws OrganizationManagementServerException If error occurred while checking the DB metadata.
      */
     public static boolean isOracleDB() throws OrganizationManagementServerException {
+
+        return isDBTypeOf(ORACLE);
+    }
+
+    /**
+     * Check whether the string, "microsoft", contains in the driver name or db product name.
+     *
+     * @return true if the database type matches the driver type, false otherwise.
+     * @throws OrganizationManagementServerException If error occurred while checking the DB metadata.
+     */
+    public static boolean isMSSqlDB() throws OrganizationManagementServerException {
+
+        return isDBTypeOf(MICROSOFT);
+    }
+
+    /**
+     * Check whether the DB type string contains in the driver name or db product name.
+     *
+     * @param dbType database type string.
+     * @return true if the database type matches the driver type, false otherwise.
+     * @throws OrganizationManagementServerException If error occurred while checking the DB metadata.
+     */
+    private static boolean isDBTypeOf(String dbType) throws OrganizationManagementServerException {
         try {
             NamedJdbcTemplate jdbcTemplate = getNewTemplate();
-            return jdbcTemplate.getDriverName().toLowerCase().contains(ORACLE) ||
-                    jdbcTemplate.getDatabaseProductName().toLowerCase().contains(ORACLE);
+            return jdbcTemplate.getDriverName().toLowerCase().contains(dbType) ||
+                    jdbcTemplate.getDatabaseProductName().toLowerCase().contains(dbType);
         } catch (DataAccessException e) {
             throw handleServerException(ERROR_CODE_ERROR_CHECKING_DB_METADATA, e);
         }


### PR DESCRIPTION
## Purpose
> Fixing the bug of OrganizationManagementServerException: Unable to retrieve the organizations. when Navigating to Organizations Section against MSSQL 2019
> Fixing the bug of being unable to retrieve organizations' role list with MSSQL DB

## Goals
> Properly retrieve the organization list when working with the MSSQL database
> Properly retrieve the organization's role list when working with the MSSQL database

## Approach
> The problem was using an incorrect keyword called 'Limit' in the SQL query.
> Fixed by setting the offset to 0 and fetching the next result set.

## User stories
> Retrieve the organization list from the new console.
> Retrieve the organization's role list from the new console.

## Test environment
> MSSQL Azure Edge
> Oracle JDK 11
> IS 6.0.0 alpha 3
> macOS m1 chip
 
## Related Issues
> * https://github.com/wso2/product-is/issues/14365
> * https://github.com/wso2/product-is/issues/14467