### PR TITLE
Fix setting database query attributes considering proper datatype

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/dao/RoleManagementDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/dao/RoleManagementDAOImpl.java
@@ -1084,7 +1084,6 @@ public class RoleManagementDAOImpl implements RoleManagementDAO {
             throws OrganizationManagementServerException {
 
         NamedJdbcTemplate namedJdbcTemplate = getNewTemplate();
-        int numberOfGroups = valueList.size();
         ErrorMessages errorMessage;
         String columnName = StringUtils.EMPTY;
         switch (attribute) {
@@ -1110,13 +1109,13 @@ public class RoleManagementDAOImpl implements RoleManagementDAO {
                 template.executeInsert(query,
                         namedPreparedStatement -> {
                             if (DB_SCHEMA_COLUMN_NAME_UM_PERMISSION_ID.equals(finalColumnName)) {
-                                for (int i = 0; i < numberOfGroups; i++) {
+                                for (int i = 0; i < valueList.size(); i++) {
                                     namedPreparedStatement.setInt(finalColumnName + i,
                                             Integer.parseInt(valueList.get(i)));
                                     namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_UM_ROLE_ID + i, roleId);
                                 }
                             } else {
-                                for (int i = 0; i < numberOfGroups; i++) {
+                                for (int i = 0; i < valueList.size(); i++) {
                                     namedPreparedStatement.setString(finalColumnName + i, valueList.get(i));
                                     namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_UM_ROLE_ID + i, roleId);
                                 }

--- a/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/dao/RoleManagementDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/dao/RoleManagementDAOImpl.java
@@ -1109,10 +1109,17 @@ public class RoleManagementDAOImpl implements RoleManagementDAO {
             namedJdbcTemplate.withTransaction(template -> {
                 template.executeInsert(query,
                         namedPreparedStatement -> {
-                            for (int i = 0; i < numberOfGroups; i++) {
-                                namedPreparedStatement.setString(finalColumnName + i, valueList.get(i));
-                                namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_UM_ROLE_ID + i,
-                                        roleId);
+                            if (DB_SCHEMA_COLUMN_NAME_UM_PERMISSION_ID.equals(finalColumnName)) {
+                                for (int i = 0; i < numberOfGroups; i++) {
+                                    namedPreparedStatement.setInt(finalColumnName + i,
+                                            Integer.parseInt(valueList.get(i)));
+                                    namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_UM_ROLE_ID + i, roleId);
+                                }
+                            } else {
+                                for (int i = 0; i < numberOfGroups; i++) {
+                                    namedPreparedStatement.setString(finalColumnName + i, valueList.get(i));
+                                    namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_UM_ROLE_ID + i, roleId);
+                                }
                             }
                         }, valueList, false);
                 return null;


### PR DESCRIPTION
## Purpose
- Fix setting `UM_PERMISION_ID` as an integer when building database query to map permissions to roles.