### PR TITLE
Fix issue of updating the user attributes in fragment app when updating the main app

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/constant/SQLConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/constant/SQLConstants.java
@@ -42,6 +42,10 @@ public class SQLConstants {
             "WHERE OWNER_ORG_ID = :" + SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_OWNER_ORG_ID + "; AND MAIN_APP_ID = :" +
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_MAIN_APP_ID + ";";
 
+    public static final String GET_MAIN_APPLICATION = "SELECT MAIN_APP_ID, OWNER_ORG_ID FROM SP_SHARED_APP WHERE " +
+            "SHARED_APP_ID = :" + SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_SHARED_APP_ID + "; AND SHARED_ORG_ID = :" +
+            SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_SHARED_ORG_ID + ";";
+
     private SQLConstants() {
 
     }

--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/dao/OrgApplicationMgtDAO.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/dao/OrgApplicationMgtDAO.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.organization.management.application.dao;
 
+import org.wso2.carbon.identity.organization.management.application.model.MainApplicationDO;
 import org.wso2.carbon.identity.organization.management.application.model.SharedApplicationDO;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 
@@ -50,6 +51,17 @@ public interface OrgApplicationMgtDAO {
      * @throws OrganizationManagementException the server exception is thrown in a failure to create the entry.
      */
     List<SharedApplicationDO> getSharedApplications(String organizationId, String applicationId)
+            throws OrganizationManagementException;
+
+    /**
+     * Retrieve main application for a given shared application.
+     *
+     * @param sharedAppId Unique identifier of the shared application.
+     * @param sharedOrgId The unique ID of the organization, to whom the application is shared.
+     * @return {@link MainApplicationDO} for a given shared application.
+     * @throws OrganizationManagementException
+     */
+    Optional<MainApplicationDO> getMainApplication(String sharedAppId, String sharedOrgId)
             throws OrganizationManagementException;
 
     /**

--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/dao/OrgApplicationMgtDAO.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/dao/OrgApplicationMgtDAO.java
@@ -59,7 +59,7 @@ public interface OrgApplicationMgtDAO {
      * @param sharedAppId Unique identifier of the shared application.
      * @param sharedOrgId The unique ID of the organization, to whom the application is shared.
      * @return {@link MainApplicationDO} for a given shared application.
-     * @throws OrganizationManagementException
+     * @throws OrganizationManagementException the server exception is thrown in a failure to retrieve the entry.
      */
     Optional<MainApplicationDO> getMainApplication(String sharedAppId, String sharedOrgId)
             throws OrganizationManagementException;

--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/dao/impl/OrgApplicationMgtDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/dao/impl/OrgApplicationMgtDAOImpl.java
@@ -95,9 +95,8 @@ public class OrgApplicationMgtDAOImpl implements OrgApplicationMgtDAO {
             throws OrganizationManagementException {
 
         NamedJdbcTemplate namedJdbcTemplate = getNewTemplate();
-        MainApplicationDO mainApplicationDO;
         try {
-            mainApplicationDO = namedJdbcTemplate.fetchSingleRecord(GET_MAIN_APPLICATION,
+            MainApplicationDO mainApplicationDO = namedJdbcTemplate.fetchSingleRecord(GET_MAIN_APPLICATION,
                     (resultSet, rowNumber) -> new MainApplicationDO(
                             resultSet.getString(DB_SCHEMA_COLUMN_NAME_OWNER_ORG_ID),
                             resultSet.getString(DB_SCHEMA_COLUMN_NAME_MAIN_APP_ID)),

--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
@@ -104,8 +104,6 @@ public class FragmentApplicationMgtListener extends AbstractApplicationMgtListen
                     ServiceProvider mainApplication = getApplicationByResourceId
                             (mainApplicationDO.get().getMainApplicationId(), mainApplicationTenantDomain);
                     serviceProvider.setClaimConfig(mainApplication.getClaimConfig());
-                    serviceProvider.getClaimConfig().setAlwaysSendMappedLocalSubjectId
-                            (mainApplication.getClaimConfig().isAlwaysSendMappedLocalSubjectId());
                     serviceProvider.getLocalAndOutBoundAuthenticationConfig().setUseTenantDomainInLocalSubjectIdentifier
                             (mainApplication.getLocalAndOutBoundAuthenticationConfig()
                                     .isUseTenantDomainInLocalSubjectIdentifier());
@@ -118,7 +116,7 @@ public class FragmentApplicationMgtListener extends AbstractApplicationMgtListen
                 }
             } catch (OrganizationManagementException e) {
                 throw new IdentityApplicationManagementException
-                        ("Error when retrieving the main app id using shared app id.", e);
+                        ("Error while retrieving the fragment application details.", e);
             }
         }
 

--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
@@ -97,8 +97,9 @@ public class FragmentApplicationMgtListener extends AbstractApplicationMgtListen
                         .getMainApplication(serviceProvider.getApplicationResourceId(), sharedOrgId);
 
                 if (mainApplicationDO.isPresent()) {
-                    // Add User Attribute Section related configurations from the
-                    // main application to the shared application
+                    /* Add User Attribute Section related configurations from the
+                    main application to the shared application
+                     */
                     String mainApplicationTenantDomain = getOrganizationManager()
                             .resolveTenantDomain(mainApplicationDO.get().getOrganizationId());
                     ServiceProvider mainApplication = getApplicationByResourceId

--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
@@ -87,7 +87,7 @@ public class FragmentApplicationMgtListener extends AbstractApplicationMgtListen
     public boolean doPostGetServiceProvider(ServiceProvider serviceProvider, String applicationName,
                                             String tenantDomain) throws IdentityApplicationManagementException {
 
-        // If the application is a shared application, updates to the application are allowed
+        // If the application is a shared application, retrieving some data from the main application is allowed.
         if (Arrays.stream(serviceProvider.getSpProperties())
                 .anyMatch(p -> IS_FRAGMENT_APP.equalsIgnoreCase(p.getName()) && Boolean.parseBoolean(p.getValue()))) {
             Optional<MainApplicationDO> mainApplicationDO;
@@ -105,15 +105,20 @@ public class FragmentApplicationMgtListener extends AbstractApplicationMgtListen
                     ServiceProvider mainApplication = getApplicationByResourceId
                             (mainApplicationDO.get().getMainApplicationId(), mainApplicationTenantDomain);
                     serviceProvider.setClaimConfig(mainApplication.getClaimConfig());
-                    serviceProvider.getLocalAndOutBoundAuthenticationConfig().setUseTenantDomainInLocalSubjectIdentifier
-                            (mainApplication.getLocalAndOutBoundAuthenticationConfig()
-                                    .isUseTenantDomainInLocalSubjectIdentifier());
-                    serviceProvider.getLocalAndOutBoundAuthenticationConfig()
-                            .setUseUserstoreDomainInLocalSubjectIdentifier
-                                    (mainApplication.getLocalAndOutBoundAuthenticationConfig()
-                                            .isUseUserstoreDomainInLocalSubjectIdentifier());
-                    serviceProvider.getLocalAndOutBoundAuthenticationConfig().setUseUserstoreDomainInRoles
-                            (mainApplication.getLocalAndOutBoundAuthenticationConfig().isUseUserstoreDomainInRoles());
+                    if (serviceProvider.getLocalAndOutBoundAuthenticationConfig() != null
+                            && mainApplication.getLocalAndOutBoundAuthenticationConfig() != null) {
+                        serviceProvider.getLocalAndOutBoundAuthenticationConfig()
+                                .setUseTenantDomainInLocalSubjectIdentifier(mainApplication
+                                        .getLocalAndOutBoundAuthenticationConfig()
+                                        .isUseTenantDomainInLocalSubjectIdentifier());
+                        serviceProvider.getLocalAndOutBoundAuthenticationConfig()
+                                .setUseUserstoreDomainInLocalSubjectIdentifier(mainApplication
+                                        .getLocalAndOutBoundAuthenticationConfig()
+                                        .isUseUserstoreDomainInLocalSubjectIdentifier());
+                        serviceProvider.getLocalAndOutBoundAuthenticationConfig()
+                                .setUseUserstoreDomainInRoles(mainApplication
+                                        .getLocalAndOutBoundAuthenticationConfig().isUseUserstoreDomainInRoles());
+                    }
                 }
             } catch (OrganizationManagementException e) {
                 throw new IdentityApplicationManagementException

--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/model/MainApplicationDO.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/model/MainApplicationDO.java
@@ -24,7 +24,6 @@ package org.wso2.carbon.identity.organization.management.application.model;
 public class MainApplicationDO {
 
     String organizationId;
-
     String mainApplicationId;
 
     public MainApplicationDO(String organizationId, String mainApplicationId) {

--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/model/MainApplicationDO.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/model/MainApplicationDO.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.management.application.model;
+
+/**
+ * This class contains the main application id and its organization id.
+ */
+public class MainApplicationDO {
+
+    String organizationId;
+
+    String mainApplicationId;
+
+    public MainApplicationDO(String organizationId, String mainApplicationId) {
+
+        this.organizationId = organizationId;
+        this.mainApplicationId = mainApplicationId;
+    }
+
+    public String getOrganizationId() {
+
+        return organizationId;
+    }
+
+    public String getMainApplicationId() {
+
+        return mainApplicationId;
+    }
+}

--- a/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.service/src/main/java/org/wso2/carbon/identity/organization/management/service/constant/OrganizationManagementConstants.java
@@ -433,7 +433,10 @@ public class OrganizationManagementConstants {
                 "Error while updating the authentication details of the application: %s"),
         ERROR_CODE_ERROR_CHECKING_APPLICATION_HAS_FRAGMENTS("65083",
                 "Unable to check whether the application has fragments.",
-                "Server encountered an error when checking whether the application: %s already has fragments.");
+                "Server encountered an error when checking whether the application: %s already has fragments."),
+        ERROR_CODE_ERROR_RESOLVING_MAIN_APPLICATION("65084", "Unable to resolve the main application",
+                "Server encountered an error while resolving the main application for " +
+                        "shared application: %s in shared organization: %s.");
 
         private final String code;
         private final String message;


### PR DESCRIPTION
## Purpose
> The configured user attributes of the main application are not shared with the fragment application.

## Goals
> Without updating the fragment application, retrieve the main application user claims instead. Since this section is already hidden in the fragment application. If we have updated the fragment apps, when updating the main app, it'll lead to a performance issue if we had so many shared apps bound to the main app.

## Approach
> Used listeners to update the fragment app object with necessary properties using the main application, when retrieving the app.

## User stories
> Can test the flow by configuring the [playground2 app](https://is.docs.wso2.com/en/5.11.0/learn/deploying-the-sample-app/#deploying-the-playground2-webapp) with OIDC protocol. Decode and check the jwt id token

## Related Issues
> * https://github.com/wso2-enterprise/identity-org-mgt-connector/issues/28