### PR TITLE
Set org qualify callback url for fragment apps

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManagerImpl.java
@@ -329,6 +329,7 @@ public class OrgApplicationManagerImpl implements OrgApplicationManager {
             String sharedTenantDomain = getOrganizationManager().resolveTenantDomain(sharedOrgId);
             PrivilegedCarbonContext.startTenantFlow();
             PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(sharedTenantDomain, true);
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setOrganizationId(sharedOrgId);
             int tenantId = IdentityTenantUtil.getTenantId(sharedTenantDomain);
 
             try {


### PR DESCRIPTION
## Purpose

> The service url builder is improved to build organization qualified urls when organization id is set in the carbon context.
https://github.com/wso2/carbon-identity-framework/pull/4229. While the fragment app is created, a tenant flow is started against the tenant domain of the application shared tenant (organization). Therefore the corresponding organization id also set in the carbon context to build correct service urls. 

### Alternative approach

Instead of adding organization id in the carbon context, the organization id can be passed along with the subsequent methods and generate service url as follows. 

`ServiceURLBuilder.create().addPath(o/<org-domain>/commonauth).build().getRelativePublicURL()`

### Depends on

- https://github.com/wso2-extensions/identity-carbon-auth-rest/pull/205