### PR TITLE
Add initial event firing mechanism

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.ext/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.ext/pom.xml
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>org.wso2.carbon.identity.organization.management</groupId>
+        <artifactId>identity-organization-management</artifactId>
+        <version>1.1.16-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.carbon.identity.organization.management.ext</artifactId>
+    <name>WSO2 - Organization Management Extensions</name>
+    <packaging>bundle</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.ops4j.pax.logging</groupId>
+            <artifactId>pax-logging-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.event</artifactId>
+        </dependency>
+
+        <!--Test Dependencies-->
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Private-Package>
+                            org.wso2.carbon.identity.organization.management.ext.internal
+                        </Private-Package>
+                        <Export-Package>
+                            !org.wso2.carbon.identity.organization.management.ext.internal,
+                            org.wso2.carbon.identity.organization.management.ext.*; version="${project.version}"
+                        </Export-Package>
+                        <Import-Package>
+                            javax.sql,
+                            org.apache.commons.logging; version="${org.apache.commons.logging.imp.pkg.version.range}",
+                            org.apache.commons.collections; version="${org.apache.commons.collections.imp.pkg.version.range}",
+                            org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
+                            org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.management.service; version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.management.service.constant; version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.management.service.exception; version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.management.service.model; version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.management.service.util; version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.management.service.listener; version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.event.*; version="${carbon.identity.package.import.version.range}"
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <executions>
+                    <execution>
+                        <id>default-instrument</id>
+                        <goals>
+                            <goal>instrument</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-restore-instrumented-classes</id>
+                        <goals>
+                            <goal>restore-instrumented-classes</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report-integration</id>
+                        <goals>
+                            <goal>report-integration</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/org.wso2.carbon.identity.organization.management.ext/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.ext/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.organization.management</groupId>
         <artifactId>identity-organization-management</artifactId>
-        <version>1.1.16-SNAPSHOT</version>
+        <version>1.1.18-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.organization.management.ext/src/main/java/org/wso2/carbon/identity/organization/management/ext/Constants.java
+++ b/components/org.wso2.carbon.identity.organization.management.ext/src/main/java/org/wso2/carbon/identity/organization/management/ext/Constants.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.management.ext;
+
+/**
+ * Organization management extensions constants.
+ */
+public class Constants {
+
+    public static final String EVENT_PROP_ORGANIZATION = "ORGANIZATION";
+    public static final String EVENT_PROP_ORGANIZATION_ID = "ORGANIZATION_ID";
+    public static final String EVENT_PRE_ADD_ORGANIZATION = "PRE_ADD_ORGANIZATION";
+    public static final String EVENT_POST_ADD_ORGANIZATION = "POST_ADD_ORGANIZATION";
+    public static final String EVENT_PRE_GET_ORGANIZATION = "PRE_GET_ORGANIZATION";
+    public static final String EVENT_POST_GET_ORGANIZATION = "POST_GET_ORGANIZATION";
+    public static final String EVENT_PRE_DELETE_ORGANIZATION = "PRE_DELETE_ORGANIZATION";
+    public static final String EVENT_POST_DELETE_ORGANIZATION = "POST_DELETE_ORGANIZATION";
+    public static final String EVENT_PRE_PATCH_ORGANIZATION = "PRE_PATCH_ORGANIZATION";
+    public static final String EVENT_POST_PATCH_ORGANIZATION = "POST_PATCH_ORGANIZATION";
+    public static final String EVENT_PRE_UPDATE_ORGANIZATION = "PRE_UPDATE_ORGANIZATION";
+    public static final String EVENT_POST_UPDATE_ORGANIZATION = "POST_UPDATE_ORGANIZATION";
+    public static final String EVENT_PROP_PATCH_OPERATIONS = "PATCH_OPERATIONS";
+}

--- a/components/org.wso2.carbon.identity.organization.management.ext/src/main/java/org/wso2/carbon/identity/organization/management/ext/OrganizationManagerListenerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.ext/src/main/java/org/wso2/carbon/identity/organization/management/ext/OrganizationManagerListenerImpl.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.management.ext;
+
+import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.event.event.Event;
+import org.wso2.carbon.identity.event.services.IdentityEventService;
+import org.wso2.carbon.identity.organization.management.ext.internal.OrganizationManagementExtDataHolder;
+import org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementServerException;
+import org.wso2.carbon.identity.organization.management.service.listener.OrganizationManagerListener;
+import org.wso2.carbon.identity.organization.management.service.model.Organization;
+import org.wso2.carbon.identity.organization.management.service.model.PatchOperation;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Listener implementation for organization management operations.
+ */
+public class OrganizationManagerListenerImpl implements OrganizationManagerListener {
+
+    @Override
+    public void preAddOrganization(Organization organization) throws OrganizationManagementException {
+
+        Map<String, Object> eventProperties = new HashMap<>();
+        eventProperties.put(Constants.EVENT_PROP_ORGANIZATION, organization);
+        fireEvent(Constants.EVENT_PRE_ADD_ORGANIZATION, eventProperties);
+    }
+
+    @Override
+    public void postAddOrganization(Organization organization) throws OrganizationManagementException {
+
+        Map<String, Object> eventProperties = new HashMap<>();
+        eventProperties.put(Constants.EVENT_PROP_ORGANIZATION, organization);
+        fireEvent(Constants.EVENT_POST_ADD_ORGANIZATION, eventProperties);
+    }
+
+    @Override
+    public void preGetOrganization(String organizationId) throws OrganizationManagementException {
+
+        Map<String, Object> eventProperties = new HashMap<>();
+        eventProperties.put(Constants.EVENT_PROP_ORGANIZATION_ID, organizationId);
+        fireEvent(Constants.EVENT_PRE_GET_ORGANIZATION, eventProperties);
+    }
+
+    @Override
+    public void postGetOrganization(String organizationId, Organization organization)
+            throws OrganizationManagementException {
+
+        Map<String, Object> eventProperties = new HashMap<>();
+        eventProperties.put(Constants.EVENT_PROP_ORGANIZATION_ID, organizationId);
+        eventProperties.put(Constants.EVENT_PROP_ORGANIZATION, organization);
+        fireEvent(Constants.EVENT_POST_GET_ORGANIZATION, eventProperties);
+    }
+
+    @Override
+    public void preDeleteOrganization(String organizationId) throws OrganizationManagementException {
+
+        Map<String, Object> eventProperties = new HashMap<>();
+        eventProperties.put(Constants.EVENT_PROP_ORGANIZATION_ID, organizationId);
+        fireEvent(Constants.EVENT_PRE_DELETE_ORGANIZATION, eventProperties);
+    }
+
+    @Override
+    public void postDeleteOrganization(String organizationId) throws OrganizationManagementException {
+
+        Map<String, Object> eventProperties = new HashMap<>();
+        eventProperties.put(Constants.EVENT_PROP_ORGANIZATION_ID, organizationId);
+        fireEvent(Constants.EVENT_POST_DELETE_ORGANIZATION, eventProperties);
+    }
+
+    @Override
+    public void prePatchOrganization(String organizationId, List<PatchOperation> patchOperations)
+            throws OrganizationManagementException {
+
+        Map<String, Object> eventProperties = new HashMap<>();
+        eventProperties.put(Constants.EVENT_PROP_ORGANIZATION_ID, organizationId);
+        eventProperties.put(Constants.EVENT_PROP_PATCH_OPERATIONS, patchOperations);
+        fireEvent(Constants.EVENT_PRE_PATCH_ORGANIZATION, eventProperties);
+    }
+
+    @Override
+    public void postPatchOrganization(String organizationId, List<PatchOperation> patchOperations)
+            throws OrganizationManagementException {
+
+        Map<String, Object> eventProperties = new HashMap<>();
+        eventProperties.put(Constants.EVENT_PROP_ORGANIZATION_ID, organizationId);
+        eventProperties.put(Constants.EVENT_PROP_PATCH_OPERATIONS, patchOperations);
+        fireEvent(Constants.EVENT_POST_PATCH_ORGANIZATION, eventProperties);
+    }
+
+    @Override
+    public void preUpdateOrganization(String organizationId, Organization organization)
+            throws OrganizationManagementException {
+
+        Map<String, Object> eventProperties = new HashMap<>();
+        eventProperties.put(Constants.EVENT_PROP_ORGANIZATION_ID, organizationId);
+        eventProperties.put(Constants.EVENT_PROP_ORGANIZATION, organization);
+        fireEvent(Constants.EVENT_PRE_UPDATE_ORGANIZATION, eventProperties);
+    }
+
+    @Override
+    public void postUpdateOrganization(String organizationId, Organization organization)
+            throws OrganizationManagementException {
+
+        Map<String, Object> eventProperties = new HashMap<>();
+        eventProperties.put(Constants.EVENT_PROP_ORGANIZATION_ID, organizationId);
+        eventProperties.put(Constants.EVENT_PROP_ORGANIZATION, organization);
+        fireEvent(Constants.EVENT_POST_UPDATE_ORGANIZATION, eventProperties);
+    }
+
+    private void fireEvent(String eventName, Map<String, Object> eventProperties)
+            throws OrganizationManagementServerException {
+
+        IdentityEventService eventService = OrganizationManagementExtDataHolder.getInstance().getIdentityEventService();
+        try {
+            Event event = new Event(eventName, eventProperties);
+            eventService.handleEvent(event);
+
+        } catch (IdentityEventException e) {
+            throw new OrganizationManagementServerException(
+                    OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_FIRING_EVENTS.getMessage(),
+                    OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_FIRING_EVENTS.getCode(), e);
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.organization.management.ext/src/main/java/org/wso2/carbon/identity/organization/management/ext/OrganizationManagerListenerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.ext/src/main/java/org/wso2/carbon/identity/organization/management/ext/OrganizationManagerListenerImpl.java
@@ -135,7 +135,6 @@ public class OrganizationManagerListenerImpl implements OrganizationManagerListe
         try {
             Event event = new Event(eventName, eventProperties);
             eventService.handleEvent(event);
-
         } catch (IdentityEventException e) {
             throw new OrganizationManagementServerException(
                     OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_FIRING_EVENTS.getMessage(),

--- a/components/org.wso2.carbon.identity.organization.management.ext/src/main/java/org/wso2/carbon/identity/organization/management/ext/internal/OrganizationManagementExtDataHolder.java
+++ b/components/org.wso2.carbon.identity.organization.management.ext/src/main/java/org/wso2/carbon/identity/organization/management/ext/internal/OrganizationManagementExtDataHolder.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.management.ext.internal;
+
+import org.wso2.carbon.identity.event.services.IdentityEventService;
+
+/**
+ * Organization management ext data holder.
+ */
+public class OrganizationManagementExtDataHolder {
+
+    private static final OrganizationManagementExtDataHolder instance = new OrganizationManagementExtDataHolder();
+
+    private IdentityEventService identityEventService;
+
+    /**
+     * Get {@link IdentityEventService}.
+     *
+     * @return IdentityEventService.
+     */
+    public IdentityEventService getIdentityEventService() {
+
+        return identityEventService;
+    }
+
+    /**
+     * Set {@link IdentityEventService}.
+     *
+     * @param identityEventService Instance of {@link IdentityEventService}.
+     */
+    public void setIdentityEventService(IdentityEventService identityEventService) {
+
+        this.identityEventService = identityEventService;
+    }
+
+    public static OrganizationManagementExtDataHolder getInstance() {
+
+        return instance;
+    }
+}

--- a/components/org.wso2.carbon.identity.organization.management.ext/src/main/java/org/wso2/carbon/identity/organization/management/ext/internal/OrganizationManagementExtServiceComponent.java
+++ b/components/org.wso2.carbon.identity.organization.management.ext/src/main/java/org/wso2/carbon/identity/organization/management/ext/internal/OrganizationManagementExtServiceComponent.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.management.ext.internal;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.wso2.carbon.identity.event.services.IdentityEventService;
+import org.wso2.carbon.identity.organization.management.ext.OrganizationManagerListenerImpl;
+import org.wso2.carbon.identity.organization.management.service.listener.OrganizationManagerListener;
+
+/**
+ * Organization management ext service component.
+ */
+@Component(
+        name = "identity.organization.application.management.ext.component",
+        immediate = true
+)
+public class OrganizationManagementExtServiceComponent {
+
+    private static final Log log = LogFactory.getLog(OrganizationManagementExtServiceComponent.class);
+
+    /**
+     * Register the organization mgt listener implementation in the OSGI context.
+     *
+     * @param componentContext OSGi service component context.
+     */
+    @Activate
+    protected void activate(ComponentContext componentContext) {
+
+        try {
+            BundleContext bundleContext = componentContext.getBundleContext();
+            bundleContext.registerService(OrganizationManagerListener.class.getName(),
+                    new OrganizationManagerListenerImpl(), null);
+
+            if (log.isDebugEnabled()) {
+                log.debug("Organization management ext component activated successfully.");
+            }
+        } catch (Throwable e) {
+            log.error("Error while activating organization management ext module.", e);
+        }
+    }
+
+    @Reference(
+            name = "identity.event.service",
+            service = IdentityEventService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetIdentityEventService"
+    )
+    protected void setIdentityEventService(IdentityEventService identityEventService) {
+
+        OrganizationManagementExtDataHolder.getInstance().setIdentityEventService(identityEventService);
+        if (log.isDebugEnabled()) {
+            log.debug("IdentityEventService set in Central logger.");
+        }
+    }
+
+    protected void unsetIdentityEventService(IdentityEventService identityEventService) {
+
+        OrganizationManagementExtDataHolder.getInstance().setIdentityEventService(null);
+    }
+}

--- a/features/org.wso2.carbon.identity.organization.management.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.organization.management.server.feature/pom.xml
@@ -51,6 +51,10 @@
             <groupId>org.wso2.carbon.identity.organization.management</groupId>
             <artifactId>org.wso2.carbon.identity.organization.management.tomcat.ext.tenant.resolver</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.ext</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -80,6 +84,7 @@
                                 <bundleDef>org.wso2.carbon.identity.organization.management:org.wso2.carbon.identity.organization.management.role.management.service</bundleDef>
                                 <bundleDef>org.wso2.carbon.identity.organization.management:org.wso2.carbon.identity.organization.management.tenant.association</bundleDef>
                                 <bundleDef>org.wso2.carbon.identity.organization.management:org.wso2.carbon.identity.organization.management.tomcat.ext.tenant.resolver</bundleDef>
+                                <bundleDef>org.wso2.carbon.identity.organization.management:org.wso2.carbon.identity.organization.management.ext</bundleDef>
                             </bundles>
                             <importFeatures>
                                 <importFeatureDef>org.wso2.carbon.core:compatible:${carbon.kernel.feature.version}</importFeatureDef>

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
         <module>components/org.wso2.carbon.identity.organization.management.application</module>
         <module>components/org.wso2.carbon.identity.organization.management.tenant.association</module>
         <module>components/org.wso2.carbon.identity.organization.management.tomcat.ext.tenant.resolver</module>
+        <module>components/org.wso2.carbon.identity.organization.management.ext</module>
         <module>features/org.wso2.carbon.identity.organization.management.server.feature</module>
     </modules>
 
@@ -60,63 +61,6 @@
                 <artifactId>org.eclipse.osgi.services</artifactId>
                 <version>${version.equinox.osgi.services}</version>
             </dependency>
-            <dependency>
-                <groupId>org.apache.cxf</groupId>
-                <artifactId>cxf-rt-frontend-jaxrs</artifactId>
-                <version>${cxf-bundle.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.cxf</groupId>
-                <artifactId>cxf-rt-rs-service-description</artifactId>
-                <version>${cxf-bundle.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-web</artifactId>
-                <version>${spring-web.version}</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
-                <groupId>javax.ws.rs</groupId>
-                <artifactId>javax.ws.rs-api</artifactId>
-                <version>${javax.ws.rs-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.swagger</groupId>
-                <artifactId>swagger-jaxrs</artifactId>
-                <version>${swagger-jaxrs.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>com.fasterxml.jackson.core</groupId>
-                        <artifactId>jackson-databind</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.fasterxml.jackson.core</groupId>
-                        <artifactId>jackson-annotations</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.fasterxml.jackson.core</groupId>
-                        <artifactId>jackson-core</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.fasterxml.jackson.dataformat</groupId>
-                        <artifactId>jackson-dataformat-yaml</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>javax.ws.rs</groupId>
-                        <artifactId>jsr311-api</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>com.google.guava</groupId>
-                        <artifactId>guava</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.jaxrs</groupId>
-                <artifactId>jackson-jaxrs-json-provider</artifactId>
-                <version>${jackson-jaxrs-json-provider.version}</version>
-            </dependency>
 
             <dependency>
                 <groupId>org.apache.felix</groupId>
@@ -130,11 +74,6 @@
             </dependency>
 
             <!-- Kernel Dependencies -->
-            <dependency>
-                <groupId>org.wso2.carbon</groupId>
-                <artifactId>org.wso2.carbon.core</artifactId>
-                <version>${carbon.kernel.version}</version>
-            </dependency>
             <dependency>
                 <groupId>org.wso2.carbon</groupId>
                 <artifactId>org.wso2.carbon.user.core</artifactId>
@@ -180,6 +119,12 @@
                 <version>${project.version}</version>
                 <scope>provided</scope>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.organization.management</groupId>
+                <artifactId>org.wso2.carbon.identity.organization.management.ext</artifactId>
+                <version>${project.version}</version>
+                <scope>provided</scope>
+            </dependency>
 
             <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
@@ -187,9 +132,9 @@
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wso2.carbon.identity.auth.rest</groupId>
-                <artifactId>org.wso2.carbon.identity.auth.service</artifactId>
-                <version>${carbon.identity.auth.version}</version>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.event</artifactId>
+                <version>${carbon.identity.framework.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.auth.rest</groupId>
@@ -208,22 +153,6 @@
                 <version>${carbon.database.utils.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wso2.carbon.multitenancy</groupId>
-                <artifactId>org.wso2.carbon.tenant.mgt</artifactId>
-                <version>${carbon.multitenancy.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wso2.carbon.identity.framework</groupId>
-                <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
-                <version>${carbon.identity.framework.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.wso2.carbon.identity.framework</groupId>
-                <artifactId>org.wso2.carbon.identity.application.common</artifactId>
-                <version>${carbon.identity.framework.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.identity.application.mgt</artifactId>
                 <version>${carbon.identity.framework.version}</version>
@@ -239,34 +168,9 @@
                 <version>${identity.inbound.auth.oauth.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.wso2.carbon.identity.outbound.auth.oidc</groupId>
-                <artifactId>org.wso2.carbon.identity.application.authenticator.oidc</artifactId>
-                <version>${identity.outbound.auth.oidc.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.oltu.oauth2</groupId>
-                <artifactId>org.apache.oltu.oauth2.client</artifactId>
-                <version>${oltu.oauth2.client.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.wso2.carbon</groupId>
                 <artifactId>org.wso2.carbon.utils</artifactId>
                 <version>${carbon.kernel.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.wso2.carbon</groupId>
-                <artifactId>org.wso2.carbon.core.services</artifactId>
-                <version>${carbon.kernel.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.wso2.carbon</groupId>
-                <artifactId>org.wso2.carbon.user.api</artifactId>
-                <version>${carbon.kernel.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.wso2.carbon.extension.identity.authenticator.utils</groupId>
-                <artifactId>org.wso2.carbon.extension.identity.helper</artifactId>
-                <version>${identity.extension.utils.version}</version>
             </dependency>
 
             <dependency>
@@ -294,18 +198,6 @@
                 <artifactId>h2</artifactId>
                 <version>${h2database.version}</version>
                 <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-core</artifactId>
-                <version>${mockito-core.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.wso2.carbon.identity.framework</groupId>
-                <artifactId>org.wso2.carbon.identity.testutil</artifactId>
-                <scope>test</scope>
-                <version>${carbon.identity.framework.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -501,7 +393,7 @@
         <org.wso2.identity.organization.mgt.imp.pkg.version.range>[1.0.0,2.0.0)
         </org.wso2.identity.organization.mgt.imp.pkg.version.range>
 
-        <identity.organization.management.core.version>1.0.3</identity.organization.management.core.version>
+        <identity.organization.management.core.version>1.0.4-SNAPSHOT</identity.organization.management.core.version>
         <org.wso2.identity.organization.mgt.core.imp.pkg.version.range>[1.0.0,2.0.0)
         </org.wso2.identity.organization.mgt.core.imp.pkg.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -393,7 +393,7 @@
         <org.wso2.identity.organization.mgt.imp.pkg.version.range>[1.0.0,2.0.0)
         </org.wso2.identity.organization.mgt.imp.pkg.version.range>
 
-        <identity.organization.management.core.version>1.0.4-SNAPSHOT</identity.organization.management.core.version>
+        <identity.organization.management.core.version>1.0.6</identity.organization.management.core.version>
         <org.wso2.identity.organization.mgt.core.imp.pkg.version.range>[1.0.0,2.0.0)
         </org.wso2.identity.organization.mgt.core.imp.pkg.version.range>
 


### PR DESCRIPTION
## Purpose
> Since this component sits higher than the carbon-identity-framework component in the dependency hierarchy, there is no way to fire events. This PR add a listener so that we can implement the listener in lower level of the dependency hierarchy and fire events.

Depends on https://github.com/wso2-extensions/identity-organization-management-core/pull/11