### PR TITLE
Set domain qualified user as the fragment app owner

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManagerImpl.java
@@ -356,22 +356,19 @@ public class OrgApplicationManagerImpl implements OrgApplicationManager {
             try {
                 String adminUserId =
                         getRealmService().getTenantUserRealm(tenantId).getRealmConfiguration().getAdminUserId();
-                if (StringUtils.isNotBlank(adminUserId)) {
-                    String sharedOrgAdminUsername = getRealmService().getTenantUserRealm(tenantId)
-                            .getRealmConfiguration().getAdminUserName();
-                    PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(sharedOrgAdminUsername);
-                } else {
+                if (StringUtils.isBlank(adminUserId)) {
                     // If realms were not migrated after https://github.com/wso2/product-is/issues/14001.
-                    String sharedOrgAdmin = getRealmService().getTenantUserRealm(tenantId)
+                    adminUserId = getRealmService().getTenantUserRealm(tenantId)
                             .getRealmConfiguration().getAdminUserName();
-                    User user = OrgApplicationMgtDataHolder.getInstance()
-                            .getOrganizationUserResidentResolverService()
-                            .resolveUserFromResidentOrganization(null, sharedOrgAdmin, sharedOrgId)
-                            .orElseThrow(
-                                    () -> handleServerException(ERROR_CODE_ERROR_ADMIN_USER_NOT_FOUND_FOR_ORGANIZATION,
-                                            null, sharedOrgAdmin));
-                    PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(user.getUsername());
                 }
+                String finalAdminUserId = adminUserId;
+                User user = OrgApplicationMgtDataHolder.getInstance()
+                        .getOrganizationUserResidentResolverService()
+                        .resolveUserFromResidentOrganization(null, adminUserId, sharedOrgId)
+                        .orElseThrow(
+                                () -> handleServerException(ERROR_CODE_ERROR_ADMIN_USER_NOT_FOUND_FOR_ORGANIZATION,
+                                        null, finalAdminUserId));
+                PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(user.getDomainQualifiedUsername());
             } catch (UserStoreException e) {
                 throw handleServerException(ERROR_CODE_ERROR_SHARING_APPLICATION, e,
                         mainApplication.getApplicationResourceId(), sharedOrgId);


### PR DESCRIPTION
## Purpose
- With B2B organization management feature, the (tenant) admin of the sub organization will resides in a parent organization. That admin user can be resides in primary or secondary user stores of the parent organizations (ex- asgardeo business users with admin access). 

- The SP_APP table keep track of the service provider apps and its owners information. In current setup, when fragment app is created, the org admin (who resides in a parent org) will be assigned as the app owner (it is the default behaviour). The app owner setting logic is further improved by passing user store domain also and the improvement is displayed in below figure.

Here the  "zoom.sadil@wso2.com" is a business user who has admin accesses and who is the owner of the organization where the SaaS app is shared.

![Untitled Diagram-Page-16](https://user-images.githubusercontent.com/35717390/192477770-20d924e7-9140-4e76-a18f-8de67192bb8b.jpg)