### PR TITLE
Enabling B2B main application to use local subject identifier in claim config for provisioned users.

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManagerImpl.java
@@ -127,7 +127,7 @@ public class OrgApplicationManagerImpl implements OrgApplicationManager {
 
         if (!filteredChildOrgs.isEmpty()) {
             // Adding Organization login IDP to the root application.
-            addOrganizationAuthenticatorToApp(rootApplication, ownerTenantDomain);
+            modifyRootApplication(rootApplication, ownerTenantDomain);
         }
 
         for (BasicOrganization child : filteredChildOrgs) {
@@ -252,7 +252,11 @@ public class OrgApplicationManagerImpl implements OrgApplicationManager {
                 .orElseThrow(() -> handleClientException(ERROR_CODE_INVALID_APPLICATION, applicationId));
     }
 
-    private void addOrganizationAuthenticatorToApp(ServiceProvider rootApplication, String tenantDomain)
+    /**
+     * This method will update the root application by adding the organization login authenticator and updating the
+     * claim configurations to enable use of local subject identifier for JIT provisioned users.
+     */
+    private void modifyRootApplication(ServiceProvider rootApplication, String tenantDomain)
             throws OrganizationManagementServerException {
 
         LocalAndOutboundAuthenticationConfig outboundAuthenticationConfig =
@@ -306,6 +310,9 @@ public class OrgApplicationManagerImpl implements OrgApplicationManager {
         newAuthSteps[0] = first;
         outboundAuthenticationConfig.setAuthenticationSteps(newAuthSteps);
         rootApplication.setLocalAndOutBoundAuthenticationConfig(outboundAuthenticationConfig);
+
+        // Enabling use of local subject id for provisioned users.
+        rootApplication.getClaimConfig().setAlwaysSendMappedLocalSubjectId(true);
         try {
             getApplicationManagementService().updateApplication(rootApplication, tenantDomain,
                     getAuthenticatedUsername());


### PR DESCRIPTION
## Purpose
Enabling root application and the fragment applications to use mapped local subject identifier for JIT provisioned users.

When an enterprise IDP is used to login to the application and user is required to have organization roles attach, local subject identifier should be used as the user identifier. 
