### PR TITLE
Remove the restriction for requesting to get application shared organizations only from the application reside organization.

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManagerImpl.java
@@ -247,11 +247,6 @@ public class OrgApplicationManagerImpl implements OrgApplicationManager {
     public List<BasicOrganization> getApplicationSharedOrganizations(String organizationId, String applicationId)
             throws OrganizationManagementException {
 
-        String requestInvokingOrganizationId = getOrganizationId();
-        if (requestInvokingOrganizationId == null) {
-            requestInvokingOrganizationId = SUPER_ORG_ID;
-        }
-        validateApplicationShareAccess(requestInvokingOrganizationId, organizationId);
         ServiceProvider application = getOrgApplication(applicationId, getTenantDomain());
         List<SharedApplicationDO> sharedApps =
                 getOrgApplicationMgtDAO().getSharedApplications(organizationId, application.getApplicationResourceId());


### PR DESCRIPTION
## Purpose
>  With [this](https://github.com/wso2-extensions/identity-auth-organization-login/pull/13) approach, the application shared organizations are listed and filtered the duplicate organizations which doesn't get shared the application. Listing  the application shared organization has to be done through the same organization where the application resides. The request invoked organization ID is resolved by the `getOrganizationId()` method and it get the organizationID set in the carbon context. For IDAAS deployments even 1st level organizations resource access happen through `t/<tenant-domain>` hence the organization ID is not set in the context.

There are two possible approaches for this case,

- Remove this check due to allowing to list the shared organizations would be less harmful.
- Improve the `getOrganizationId()` method to return the organization ID in case of the carbon context has null value by resolving the organizationId from the tenant domain which is set in the carbon context.


