### PR TITLE
Use separate SQL constant for IS_FRAGMENT_APPLICATION to be used in H2 DB

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/constant/SQLConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/constant/SQLConstants.java
@@ -54,6 +54,11 @@ public class SQLConstants {
 
     public static final String IS_FRAGMENT_APPLICATION = "SELECT COUNT(1) FROM SP_METADATA WHERE " +
             "SP_ID = :" + SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_SP_ID + "; AND NAME = :" +
+            SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_METADATA_NAME + "; AND VALUE = :" +
+            SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_METADATA_VALUE + ";";
+
+    public static final String IS_FRAGMENT_APPLICATION_H2 = "SELECT COUNT(1) FROM SP_METADATA WHERE " +
+            "SP_ID = :" + SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_SP_ID + "; AND NAME = :" +
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_METADATA_NAME + "; AND `VALUE` = :" +
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_METADATA_VALUE + ";";
 

--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/dao/impl/OrgApplicationMgtDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/dao/impl/OrgApplicationMgtDAOImpl.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.organization.management.application.dao.impl;
 import org.wso2.carbon.database.utils.jdbc.NamedJdbcTemplate;
 import org.wso2.carbon.database.utils.jdbc.exceptions.DataAccessException;
 import org.wso2.carbon.database.utils.jdbc.exceptions.TransactionException;
+import org.wso2.carbon.identity.core.util.JdbcUtils;
 import org.wso2.carbon.identity.organization.management.application.dao.OrgApplicationMgtDAO;
 import org.wso2.carbon.identity.organization.management.application.model.MainApplicationDO;
 import org.wso2.carbon.identity.organization.management.application.model.SharedApplicationDO;
@@ -37,6 +38,7 @@ import static org.wso2.carbon.identity.organization.management.application.const
 import static org.wso2.carbon.identity.organization.management.application.constant.SQLConstants.HAS_FRAGMENT_APPS;
 import static org.wso2.carbon.identity.organization.management.application.constant.SQLConstants.INSERT_SHARED_APP;
 import static org.wso2.carbon.identity.organization.management.application.constant.SQLConstants.IS_FRAGMENT_APPLICATION;
+import static org.wso2.carbon.identity.organization.management.application.constant.SQLConstants.IS_FRAGMENT_APPLICATION_H2;
 import static org.wso2.carbon.identity.organization.management.application.constant.SQLConstants.SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_MAIN_APP_ID;
 import static org.wso2.carbon.identity.organization.management.application.constant.SQLConstants.SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_METADATA_NAME;
 import static org.wso2.carbon.identity.organization.management.application.constant.SQLConstants.SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_METADATA_VALUE;
@@ -188,7 +190,8 @@ public class OrgApplicationMgtDAOImpl implements OrgApplicationMgtDAO {
 
         NamedJdbcTemplate namedJdbcTemplate = getNewTemplate();
         try {
-            int isFragment = namedJdbcTemplate.fetchSingleRecord(IS_FRAGMENT_APPLICATION,
+            String prepStmt = JdbcUtils.isH2DB() ? IS_FRAGMENT_APPLICATION_H2 : IS_FRAGMENT_APPLICATION;
+            int isFragment = namedJdbcTemplate.fetchSingleRecord(prepStmt,
                     (resultSet, rowNumber) -> resultSet.getInt(1), namedPreparedStatement -> {
                         namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_SP_ID, Integer.toString(applicationId));
                         namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_METADATA_NAME, IS_FRAGMENT_APP);

--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/OrganizationCreationHandler.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/OrganizationCreationHandler.java
@@ -65,7 +65,7 @@ public class OrganizationCreationHandler extends AbstractEventHandler {
             try {
                 addSharedApplicationsToOrganization(organization);
             } catch (IdentityApplicationManagementException | OrganizationManagementException e) {
-                throw new IdentityEventException("An error occured while creating shared applications in the new " +
+                throw new IdentityEventException("An error occurred while creating shared applications in the new " +
                         "organization", e);
             }
         }


### PR DESCRIPTION
## Purpose
$Subject and fix the error that occurred when sharing application in other DB types

Column name VALUE in SP_METADATA table should be handled as \`VALUE\` only for H2.
So use a separate SQL constant `IS_FRAGMENT_APPLICATION_H2` for H2 DB usage.