### PR TITLE
[1.2.x] Extending carbon user core version range

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -512,7 +512,7 @@
         <identity.outbound.auth.oidc.import.version.range>[5.7.2, 5.8.0)</identity.outbound.auth.oidc.import.version.range>
 
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
-        <carbon.user.core.imp.pkg.version.range>[4.7.0, 4.8.0)</carbon.user.core.imp.pkg.version.range>
+        <carbon.user.core.imp.pkg.version.range>[4.7.0, 4.9.0)</carbon.user.core.imp.pkg.version.range>
 
         <carbon.database.utils.version>2.0.13</carbon.database.utils.version>
         <org.wso2.carbon.database.utils.version.range>[2.0.0,3.0.0)</org.wso2.carbon.database.utils.version.range>


### PR DESCRIPTION
## Purpose
Extending the carbon user core version range to support carbon kernel 4.8.0-m1