### PR TITLE
Set business app owned organization commonauth endpoint as callback url of shared app

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManagerImpl.java
@@ -501,6 +501,7 @@ public class OrgApplicationManagerImpl implements OrgApplicationManager {
                                  boolean shareWithAllChildren) throws OrganizationManagementException {
 
         try {
+            String ownerTenantDomain = getOrganizationManager().resolveTenantDomain(ownerOrgId);
             // Use tenant of the organization to whom the application getting shared. When the consumer application is
             // loaded, tenant domain will be derived from the user who created the application.
             String sharedTenantDomain = getOrganizationManager().resolveTenantDomain(sharedOrgId);
@@ -538,7 +539,7 @@ public class OrgApplicationManagerImpl implements OrgApplicationManager {
             // Create Oauth consumer app to redirect login to shared (fragment) application.
             OAuthConsumerAppDTO createdOAuthApp;
             try {
-                createdOAuthApp = createOAuthApplication(mainApplication.getApplicationName());
+                createdOAuthApp = createOAuthApplication(mainApplication.getApplicationName(), ownerTenantDomain);
             } catch (URLBuilderException | IdentityOAuthAdminException e) {
                 throw handleServerException(ERROR_CODE_ERROR_CREATING_OAUTH_APP, e,
                         mainApplication.getApplicationResourceId(), sharedOrgId);
@@ -566,10 +567,11 @@ public class OrgApplicationManagerImpl implements OrgApplicationManager {
         return getOrgApplicationMgtDAO().getSharedApplicationResourceId(mainAppId, ownerOrgId, sharedOrgId);
     }
 
-    private OAuthConsumerAppDTO createOAuthApplication(String mainAppName)
+    private OAuthConsumerAppDTO createOAuthApplication(String mainAppName, String tenantDomain)
             throws URLBuilderException, IdentityOAuthAdminException {
 
-        ServiceURL commonAuthServiceUrl = ServiceURLBuilder.create().addPath(FrameworkConstants.COMMONAUTH).build();
+        ServiceURL commonAuthServiceUrl =
+                ServiceURLBuilder.create().setTenant(tenantDomain).addPath(FrameworkConstants.COMMONAUTH).build();
         String callbackUrl = commonAuthServiceUrl.getAbsolutePublicURL();
 
         OAuthConsumerAppDTO consumerApp = new OAuthConsumerAppDTO();


### PR DESCRIPTION
## Purpose

> The callback url of the shared application was set to the shared organization's commonauth endpoint instead of the main app owned organization's commonauth endpoint.

The output of SAML tracer before the fix.

<img width="1431" alt="Screenshot 2022-12-05 at 20 26 41" src="https://user-images.githubusercontent.com/35717390/205787521-11eaf8c2-d7d8-499d-bc53-db67a796cdb2.png">

The output of SAML tracer after the fix. (please note that app shared orgId is different)

<img width="1403" alt="Screenshot 2022-12-06 at 06 34 10" src="https://user-images.githubusercontent.com/35717390/205787639-c7327663-61ac-4eca-a7a4-f932e0eb1638.png">
