### PR TITLE
Check if existing role name is for the same role Id in patching role

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/RoleManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/RoleManagerImpl.java
@@ -406,16 +406,11 @@ public class RoleManagerImpl implements RoleManager {
         if (values.size() > 1) {
             throw handleClientException(ERROR_CODE_ROLE_DISPLAY_NAME_MULTIPLE_VALUES);
         }
-        try {
-            validateRoleNameNotExist(organizationId, values.get(0));
-        } catch (OrganizationManagementException e) {
-            if (StringUtils.equals(e.getErrorCode(), ERROR_CODE_ROLE_DISPLAY_NAME_ALREADY_EXISTS.getCode())) {
-                Role role = roleManagementDAO.getRoleById(organizationId, roleId);
-                if (!StringUtils.equalsIgnoreCase(role.getDisplayName(), values.get(0))) {
-                    throw e;
-                }
-            }
+        Role role = roleManagementDAO.getRoleById(organizationId, roleId);
+        if (StringUtils.equalsIgnoreCase(role.getDisplayName(), values.get(0))) {
+            return;
         }
+        validateRoleNameNotExist(organizationId, values.get(0));
     }
 
     /**

--- a/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/RoleManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/RoleManagerImpl.java
@@ -216,7 +216,7 @@ public class RoleManagerImpl implements RoleManager {
                 } else if (StringUtils.equalsIgnoreCase(patchPath, GROUPS)) {
                     validateGroups(patchOperation.getValues(), getTenantId());
                 } else if (StringUtils.equalsIgnoreCase(patchPath, DISPLAY_NAME)) {
-                    validatePatchOpDisplayName(patchOperation.getValues(), organizationId);
+                    validatePatchOpDisplayName(patchOperation.getValues(), organizationId, roleId);
                 }
             }
         }
@@ -400,13 +400,23 @@ public class RoleManagerImpl implements RoleManager {
         }
     }
 
-    private void validatePatchOpDisplayName(List<String> values, String organizationId)
+    private void validatePatchOpDisplayName(List<String> values, String organizationId, String roleId)
             throws OrganizationManagementException {
 
         if (values.size() > 1) {
             throw handleClientException(ERROR_CODE_ROLE_DISPLAY_NAME_MULTIPLE_VALUES);
         }
         validateRoleNameNotExist(organizationId, values.get(0));
+        try {
+            validateRoleNameNotExist(organizationId, values.get(0));
+        } catch (OrganizationManagementException e) {
+            if (StringUtils.equals(e.getErrorCode(), ERROR_CODE_ROLE_DISPLAY_NAME_ALREADY_EXISTS.getCode())) {
+                Role role = roleManagementDAO.getRoleById(organizationId, roleId);
+                if (!StringUtils.equalsIgnoreCase(role.getDisplayName(), values.get(0))) {
+                    throw e;
+                }
+            }
+        }
     }
 
     /**

--- a/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/RoleManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/RoleManagerImpl.java
@@ -406,7 +406,6 @@ public class RoleManagerImpl implements RoleManager {
         if (values.size() > 1) {
             throw handleClientException(ERROR_CODE_ROLE_DISPLAY_NAME_MULTIPLE_VALUES);
         }
-        validateRoleNameNotExist(organizationId, values.get(0));
         try {
             validateRoleNameNotExist(organizationId, values.get(0));
         } catch (OrganizationManagementException e) {


### PR DESCRIPTION
## Purpose
The current role display name check to patch role doesn't allow following scenarios
- new role name -> same as old role name (returns 409)
- There are only case differences between new role name and old role name (returns 409)

This PR fixes this issue

