### PR TITLE
Block authentication script configuration for fragment Application

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.application/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.application/pom.xml
@@ -137,6 +137,7 @@
                             org.wso2.carbon.identity.application.authentication.framework.model; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.application.common; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.application.common.model; version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.application.common.model.script; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.application.mgt; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.application.mgt.listener; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.claim.metadata.mgt; version="${carbon.identity.package.import.version.range}",

--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/constant/OrgApplicationMgtConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/constant/OrgApplicationMgtConstants.java
@@ -34,10 +34,8 @@ public class OrgApplicationMgtConstants {
     public static final String UPDATE_SP_METADATA_SHARE_WITH_ALL_CHILDREN = "updateShareWithAllChildren";
     public static final String DELETE_SHARE_FOR_MAIN_APPLICATION = "deleteShareForMainApp";
 
-    public static final String USER_ORGANIZATION_CLAIM_URI = "http://wso2.org/claims/runtime/user_organization";
+    public static final String USER_ORGANIZATION_CLAIM_URI =  "http://wso2.org/claims/runtime/user_organization";
     public static final String USER_ORGANIZATION_CLAIM = "user_organization";
     public static final String OIDC_CLAIM_DIALECT_URI = "http://wso2.org/oidc/claim";
-    public static final String DEFAULT_AUTH_SCRIPT =
-            "var onLoginRequest = function(context) {\n    executeStep(1);\n};\n";
 
 }

--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/constant/OrgApplicationMgtConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/constant/OrgApplicationMgtConstants.java
@@ -34,8 +34,10 @@ public class OrgApplicationMgtConstants {
     public static final String UPDATE_SP_METADATA_SHARE_WITH_ALL_CHILDREN = "updateShareWithAllChildren";
     public static final String DELETE_SHARE_FOR_MAIN_APPLICATION = "deleteShareForMainApp";
 
-    public static final String USER_ORGANIZATION_CLAIM_URI =  "http://wso2.org/claims/runtime/user_organization";
+    public static final String USER_ORGANIZATION_CLAIM_URI = "http://wso2.org/claims/runtime/user_organization";
     public static final String USER_ORGANIZATION_CLAIM = "user_organization";
     public static final String OIDC_CLAIM_DIALECT_URI = "http://wso2.org/oidc/claim";
+    public static final String DEFAULT_AUTH_SCRIPT =
+            "var onLoginRequest = function(context) {\n    executeStep(1);\n};\n";
 
 }

--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.organization.management.application.listener;
 
 import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.application.common.IdentityApplicationManagementClientException;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.model.ClaimConfig;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
@@ -96,13 +97,13 @@ public class FragmentApplicationMgtListener extends AbstractApplicationMgtListen
             serviceProvider.setInboundAuthenticationConfig(existingApplication.getInboundAuthenticationConfig());
             LocalAndOutboundAuthenticationConfig localAndOutBoundAuthenticationConfig =
                     serviceProvider.getLocalAndOutBoundAuthenticationConfig();
-            if (serviceProvider.getLocalAndOutBoundAuthenticationConfig() != null &&
-                    serviceProvider.getLocalAndOutBoundAuthenticationConfig().getAuthenticationScriptConfig() != null) {
+            if (localAndOutBoundAuthenticationConfig != null &&
+                    localAndOutBoundAuthenticationConfig.getAuthenticationScriptConfig() != null) {
                 AuthenticationScriptConfig authenticationScriptConfig =
                         localAndOutBoundAuthenticationConfig.getAuthenticationScriptConfig();
                 if (authenticationScriptConfig.isEnabled() &&
                         !StringUtils.isBlank(authenticationScriptConfig.getContent())) {
-                    throw new IdentityApplicationManagementException(
+                    throw new IdentityApplicationManagementClientException(
                             "Authentication script configuration not allowed for shared applications.");
                 }
             }

--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
@@ -25,6 +25,7 @@ import org.wso2.carbon.identity.application.common.model.ClaimConfig;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.common.model.ServiceProviderProperty;
+import org.wso2.carbon.identity.application.common.model.script.AuthenticationScriptConfig;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.application.mgt.listener.AbstractApplicationMgtListener;
 import org.wso2.carbon.identity.application.mgt.listener.ApplicationMgtListener;
@@ -92,8 +93,14 @@ public class FragmentApplicationMgtListener extends AbstractApplicationMgtListen
                 .anyMatch(p -> IS_FRAGMENT_APP.equalsIgnoreCase(p.getName()) && Boolean.parseBoolean(p.getValue()))) {
             serviceProvider.setSpProperties(existingApplication.getSpProperties());
             serviceProvider.setInboundAuthenticationConfig(existingApplication.getInboundAuthenticationConfig());
+            AuthenticationScriptConfig authenticationScriptConfig =
+                    serviceProvider.getLocalAndOutBoundAuthenticationConfig().getAuthenticationScriptConfig();
+            if (authenticationScriptConfig.isEnabled() &&
+                    !StringUtils.isBlank(authenticationScriptConfig.getContent())) {
+                throw new IdentityApplicationManagementException(
+                        "Authentication script configuration not allowed for fragment applications");
+            }
         }
-
         // Updating the shareWithAllChildren flag of application is blocked.
         if (existingApplication != null
                 && !IdentityUtil.threadLocalProperties.get().containsKey(UPDATE_SP_METADATA_SHARE_WITH_ALL_CHILDREN)) {

--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
@@ -20,7 +20,6 @@ package org.wso2.carbon.identity.organization.management.application.listener;
 
 import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
-import org.wso2.carbon.identity.application.common.IdentityApplicationManagementClientException;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.model.ClaimConfig;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
@@ -33,7 +32,6 @@ import org.wso2.carbon.identity.application.mgt.listener.AbstractApplicationMgtL
 import org.wso2.carbon.identity.application.mgt.listener.ApplicationMgtListener;
 import org.wso2.carbon.identity.core.model.IdentityEventListenerConfig;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
-import org.wso2.carbon.identity.organization.management.application.constant.OrgApplicationMgtConstants;
 import org.wso2.carbon.identity.organization.management.application.dao.OrgApplicationMgtDAO;
 import org.wso2.carbon.identity.organization.management.application.internal.OrgApplicationMgtDataHolder;
 import org.wso2.carbon.identity.organization.management.application.model.MainApplicationDO;
@@ -46,7 +44,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static java.lang.String.format;
-
 import static org.wso2.carbon.identity.organization.management.application.constant.OrgApplicationMgtConstants.DELETE_FRAGMENT_APPLICATION;
 import static org.wso2.carbon.identity.organization.management.application.constant.OrgApplicationMgtConstants.DELETE_MAIN_APPLICATION;
 import static org.wso2.carbon.identity.organization.management.application.constant.OrgApplicationMgtConstants.DELETE_SHARE_FOR_MAIN_APPLICATION;
@@ -104,9 +101,8 @@ public class FragmentApplicationMgtListener extends AbstractApplicationMgtListen
                 AuthenticationScriptConfig authenticationScriptConfig =
                         localAndOutBoundAuthenticationConfig.getAuthenticationScriptConfig();
                 if (authenticationScriptConfig.isEnabled() &&
-                        !StringUtils.equals(authenticationScriptConfig.getContent(),
-                                OrgApplicationMgtConstants.DEFAULT_AUTH_SCRIPT)) {
-                    throw new IdentityApplicationManagementClientException(
+                        !StringUtils.isBlank(authenticationScriptConfig.getContent())) {
+                    throw new IdentityApplicationManagementException(
                             "Authentication script configuration not allowed for shared applications.");
                 }
             }
@@ -203,11 +199,10 @@ public class FragmentApplicationMgtListener extends AbstractApplicationMgtListen
                     if (IdentityUtil.threadLocalProperties.get().containsKey(DELETE_MAIN_APPLICATION) ||
                             IdentityUtil.threadLocalProperties.get().containsKey(DELETE_SHARE_FOR_MAIN_APPLICATION) ||
                             (!sharedApplicationDO.get().shareWithAllChildren() &&
-                                    IdentityUtil.threadLocalProperties.get()
-                                            .containsKey(DELETE_FRAGMENT_APPLICATION))) {
+                                    IdentityUtil.threadLocalProperties.get().containsKey(DELETE_FRAGMENT_APPLICATION))) {
                         return true;
                     }
-                    if (sharedApplicationDO.get().shareWithAllChildren()) {
+                    if (sharedApplicationDO.get().shareWithAllChildren())  {
                         return false;
                     }
                 }
@@ -229,7 +224,7 @@ public class FragmentApplicationMgtListener extends AbstractApplicationMgtListen
                         organizationId, application.getApplicationResourceId());
                 IdentityUtil.threadLocalProperties.get().put(DELETE_MAIN_APPLICATION, true);
                 String username = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
-                for (SharedApplicationDO sharedApplicationDO : sharedApplications) {
+                for (SharedApplicationDO sharedApplicationDO: sharedApplications) {
                     getApplicationMgtService().deleteApplication(application.getApplicationName(),
                             sharedApplicationDO.getOrganizationId(), username);
                 }

--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
@@ -98,7 +98,7 @@ public class FragmentApplicationMgtListener extends AbstractApplicationMgtListen
             if (authenticationScriptConfig.isEnabled() &&
                     !StringUtils.isBlank(authenticationScriptConfig.getContent())) {
                 throw new IdentityApplicationManagementException(
-                        "Authentication script configuration not allowed for fragment applications");
+                        "Authentication script configuration not allowed for shared applications.");
             }
         }
         // Updating the shareWithAllChildren flag of application is blocked.

--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
@@ -107,6 +107,7 @@ public class FragmentApplicationMgtListener extends AbstractApplicationMgtListen
                 }
             }
         }
+
         // Updating the shareWithAllChildren flag of application is blocked.
         if (existingApplication != null
                 && !IdentityUtil.threadLocalProperties.get().containsKey(UPDATE_SP_METADATA_SHARE_WITH_ALL_CHILDREN)) {
@@ -197,9 +198,9 @@ public class FragmentApplicationMgtListener extends AbstractApplicationMgtListen
                         tenantDomain);
                 if (sharedApplicationDO.isPresent()) {
                     if (IdentityUtil.threadLocalProperties.get().containsKey(DELETE_MAIN_APPLICATION) ||
-                            IdentityUtil.threadLocalProperties.get().containsKey(DELETE_SHARE_FOR_MAIN_APPLICATION) ||
-                            (!sharedApplicationDO.get().shareWithAllChildren() &&
-                                    IdentityUtil.threadLocalProperties.get().containsKey(DELETE_FRAGMENT_APPLICATION))) {
+                        IdentityUtil.threadLocalProperties.get().containsKey(DELETE_SHARE_FOR_MAIN_APPLICATION) ||
+                        (!sharedApplicationDO.get().shareWithAllChildren() &&
+                                IdentityUtil.threadLocalProperties.get().containsKey(DELETE_FRAGMENT_APPLICATION))) {
                         return true;
                     }
                     if (sharedApplicationDO.get().shareWithAllChildren())  {

--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
@@ -24,6 +24,7 @@ import org.wso2.carbon.identity.application.common.IdentityApplicationManagement
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.model.ClaimConfig;
 import org.wso2.carbon.identity.application.common.model.ClaimMapping;
+import org.wso2.carbon.identity.application.common.model.LocalAndOutboundAuthenticationConfig;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.common.model.ServiceProviderProperty;
 import org.wso2.carbon.identity.application.common.model.script.AuthenticationScriptConfig;
@@ -45,6 +46,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static java.lang.String.format;
+
 import static org.wso2.carbon.identity.organization.management.application.constant.OrgApplicationMgtConstants.DELETE_FRAGMENT_APPLICATION;
 import static org.wso2.carbon.identity.organization.management.application.constant.OrgApplicationMgtConstants.DELETE_MAIN_APPLICATION;
 import static org.wso2.carbon.identity.organization.management.application.constant.OrgApplicationMgtConstants.DELETE_SHARE_FOR_MAIN_APPLICATION;
@@ -95,13 +97,18 @@ public class FragmentApplicationMgtListener extends AbstractApplicationMgtListen
                 .anyMatch(p -> IS_FRAGMENT_APP.equalsIgnoreCase(p.getName()) && Boolean.parseBoolean(p.getValue()))) {
             serviceProvider.setSpProperties(existingApplication.getSpProperties());
             serviceProvider.setInboundAuthenticationConfig(existingApplication.getInboundAuthenticationConfig());
-            AuthenticationScriptConfig authenticationScriptConfig =
-                    serviceProvider.getLocalAndOutBoundAuthenticationConfig().getAuthenticationScriptConfig();
-            if (authenticationScriptConfig.isEnabled() &&
-                    !StringUtils.equals(authenticationScriptConfig.getContent(),
-                            OrgApplicationMgtConstants.DEFAULT_AUTH_SCRIPT)) {
-                throw new IdentityApplicationManagementClientException(
-                        "Authentication script configuration not allowed for shared applications.");
+            LocalAndOutboundAuthenticationConfig localAndOutBoundAuthenticationConfig =
+                    serviceProvider.getLocalAndOutBoundAuthenticationConfig();
+            if (serviceProvider.getLocalAndOutBoundAuthenticationConfig() != null &&
+                    serviceProvider.getLocalAndOutBoundAuthenticationConfig().getAuthenticationScriptConfig() != null) {
+                AuthenticationScriptConfig authenticationScriptConfig =
+                        localAndOutBoundAuthenticationConfig.getAuthenticationScriptConfig();
+                if (authenticationScriptConfig.isEnabled() &&
+                        !StringUtils.equals(authenticationScriptConfig.getContent(),
+                                OrgApplicationMgtConstants.DEFAULT_AUTH_SCRIPT)) {
+                    throw new IdentityApplicationManagementClientException(
+                            "Authentication script configuration not allowed for shared applications.");
+                }
             }
         }
         // Updating the shareWithAllChildren flag of application is blocked.


### PR DESCRIPTION
## Purpose
> The current implementation allows authentication script configuration to be changed for fragment applications. This is not to be allowed in the future. This PR contains the implementation to block updating the authentication script configuration. 

## Goals
> Block updating the authentication script configuration for fragment applications. 

## Approach
> In the pre update process for the applications, check if application is fragment application. If yes, check if it's updating the authentication script. If so throw an error stating that the operation is not allowed. 