### PR TITLE
Add Administrator role for creator

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/RoleManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/RoleManagerImpl.java
@@ -54,6 +54,7 @@ import static org.wso2.carbon.identity.organization.management.role.management.s
 import static org.wso2.carbon.identity.organization.management.role.management.service.constant.RoleManagementConstants.CursorDirection.FORWARD;
 import static org.wso2.carbon.identity.organization.management.role.management.service.constant.RoleManagementConstants.DISPLAY_NAME;
 import static org.wso2.carbon.identity.organization.management.role.management.service.constant.RoleManagementConstants.GROUPS;
+import static org.wso2.carbon.identity.organization.management.role.management.service.constant.RoleManagementConstants.ORG_ADMINISTRATOR_ROLE;
 import static org.wso2.carbon.identity.organization.management.role.management.service.constant.RoleManagementConstants.ORG_CREATOR_ROLE;
 import static org.wso2.carbon.identity.organization.management.role.management.service.constant.RoleManagementConstants.PERMISSIONS;
 import static org.wso2.carbon.identity.organization.management.role.management.service.constant.RoleManagementConstants.USERS;
@@ -90,7 +91,8 @@ public class RoleManagerImpl implements RoleManager {
     @Override
     public Role createRole(String organizationId, Role role) throws OrganizationManagementException {
 
-        if (!StringUtils.equals(ORG_CREATOR_ROLE, role.getDisplayName())) {
+        if (!StringUtils.equals(ORG_CREATOR_ROLE, role.getDisplayName()) &&
+                !StringUtils.equals(ORG_ADMINISTRATOR_ROLE, role.getDisplayName())) {
             validateOrganizationRoleAllowedToAccess(organizationId);
         }
         role.setId(generateUniqueID());

--- a/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/constant/RoleManagementConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/constant/RoleManagementConstants.java
@@ -42,6 +42,7 @@ public class RoleManagementConstants {
     public static final String UNION_SEPARATOR = " UNION ALL ";
 
     public static final String ORG_CREATOR_ROLE = "org-creator";
+    public static final String ORG_ADMINISTRATOR_ROLE = "Administrator";
 
     /**
      * Enum for cursor based pagination direction.

--- a/components/org.wso2.carbon.identity.organization.management.tenant.association/src/main/java/org/wso2/carbon/identity/organization/management/tenant/association/Constants.java
+++ b/components/org.wso2.carbon.identity.organization.management.tenant.association/src/main/java/org/wso2/carbon/identity/organization/management/tenant/association/Constants.java
@@ -44,6 +44,7 @@ public class Constants {
     public static final String CLAIM_META_DATA_MGT_VIEW_PERMISSION =
             "/permission/admin/manage/identity/claimmgt/metadata/view";
     public static final String USER_MGT_CREATE_PERMISSION = "/permission/admin/manage/identity/usermgt/create";
+    public static final String ADMINISTRATOR_ROLE_PERMISSION = "/permission/admin";
 
     /*
     Minimum permissions required for org creator to logged in to the console and view user, groups, roles, SP,

--- a/components/org.wso2.carbon.identity.organization.management.tenant.association/src/main/java/org/wso2/carbon/identity/organization/management/tenant/association/Constants.java
+++ b/components/org.wso2.carbon.identity.organization.management.tenant.association/src/main/java/org/wso2/carbon/identity/organization/management/tenant/association/Constants.java
@@ -44,7 +44,7 @@ public class Constants {
     public static final String CLAIM_META_DATA_MGT_VIEW_PERMISSION =
             "/permission/admin/manage/identity/claimmgt/metadata/view";
     public static final String USER_MGT_CREATE_PERMISSION = "/permission/admin/manage/identity/usermgt/create";
-    public static final String ADMINISTRATOR_ROLE_PERMISSION = "/permission/admin";
+    public static final String ADMINISTRATOR_ROLE_PERMISSION = "/permission";
 
     /*
     Minimum permissions required for org creator to logged in to the console and view user, groups, roles, SP,

--- a/components/org.wso2.carbon.identity.organization.management.tenant.association/src/main/java/org/wso2/carbon/identity/organization/management/tenant/association/listeners/TenantAssociationManagementListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.tenant.association/src/main/java/org/wso2/carbon/identity/organization/management/tenant/association/listeners/TenantAssociationManagementListener.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.user.core.service.RealmService;
 import java.util.ArrayList;
 import java.util.Collections;
 
+import static org.wso2.carbon.identity.organization.management.role.management.service.constant.RoleManagementConstants.ORG_ADMINISTRATOR_ROLE;
 import static org.wso2.carbon.identity.organization.management.role.management.service.constant.RoleManagementConstants.ORG_CREATOR_ROLE;
 import static org.wso2.carbon.identity.organization.management.tenant.association.Constants.MINIMUM_PERMISSIONS_REQUIRED_FOR_ORG_CREATOR_VIEW;
 
@@ -91,7 +92,9 @@ public class TenantAssociationManagementListener extends AbstractIdentityTenantM
                 return;
             }
             Role organizationCreatorRole = buildOrgCreatorRole(adminUUID);
+            Role administratorRole = buildAdministratorRole(adminUUID);
             TenantAssociationDataHolder.getRoleManager().createRole(organizationID, organizationCreatorRole);
+            TenantAssociationDataHolder.getRoleManager().createRole(organizationID, administratorRole);
         } catch (UserStoreException | OrganizationManagementException e) {
             String error = "Error occurred while adding user-tenant association for the tenant id: " + tenantId;
             LOG.error(error, e);
@@ -119,5 +122,19 @@ public class TenantAssociationManagementListener extends AbstractIdentityTenantM
         orgCreatorRolePermissions.add(Constants.USER_MGT_CREATE_PERMISSION);
         organizationCreatorRole.setPermissions(orgCreatorRolePermissions);
         return organizationCreatorRole;
+    }
+
+    private Role buildAdministratorRole(String adminUUID) {
+
+        Role organizationAdministratorRole = new Role();
+        organizationAdministratorRole.setDisplayName(ORG_ADMINISTRATOR_ROLE);
+        User orgAdministrator = new User(adminUUID);
+        organizationAdministratorRole.setUsers(Collections.singletonList(orgAdministrator));
+        // Set permissions for org-administrator role.
+        ArrayList<String> orgAdministratorRolePermissions = new ArrayList<>();
+        // Setting all administrative permissions for the Administrator role
+        orgAdministratorRolePermissions.add(Constants.ADMINISTRATOR_ROLE_PERMISSION);
+        organizationAdministratorRole.setPermissions(orgAdministratorRolePermissions);
+        return organizationAdministratorRole;
     }
 }


### PR DESCRIPTION
## Purpose
> Assign the organization creator to an administrator role which contains all permissions in addition to the org-creator role. 

## Goals
> Create Administrator role for the organization at the time of creation along with org-creator role. The administrator role is then assigned to the creator in addition to the org-creator role. 

