### PR TITLE
Restrict fragment application deletion through sub organizations.

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
@@ -204,9 +204,7 @@ public class FragmentApplicationMgtListener extends AbstractApplicationMgtListen
                                 IdentityUtil.threadLocalProperties.get().containsKey(DELETE_FRAGMENT_APPLICATION))) {
                         return true;
                     }
-                    if (sharedApplicationDO.get().shareWithAllChildren())  {
-                        return false;
-                    }
+                    return false;
                 }
             } catch (OrganizationManagementException e) {
                 throw new IdentityApplicationManagementException(


### PR DESCRIPTION
## Purpose
> Fragment application deletion should only be available through the un-share option of the parent organization. Therefore the fragment application deletion is being restricted if not done through un-share option or the deletion of the main application.