### PR TITLE
Insert orgID in the DB when creating users of a role

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/constant/SQLConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/constant/SQLConstants.java
@@ -156,8 +156,8 @@ public class SQLConstants {
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_ROLE_ID + "; AND UM_ORG_ID=:" +
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_ORG_ID + ";";
 
-    public static final String GET_USERS_FROM_ROLE_ID = "SELECT * FROM UM_ORG_ROLE_USER WHERE UM_ROLE_ID=:" +
-            SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_ROLE_ID + ";";
+    public static final String GET_USERS_FROM_ROLE_ID = "SELECT UM_USER_ID, UM_ROLE_ID, UM_USER_RESIDENT_ORG_ID " +
+            "FROM UM_ORG_ROLE_USER WHERE UM_ROLE_ID=:" + SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_ROLE_ID + ";";
 
     public static final String GET_MEMBER_GROUP_IDS_FROM_ROLE_ID = "SELECT UM_GROUP_ID FROM UM_ORG_ROLE_GROUP WHERE " +
             "UM_ROLE_ID=:" + SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_ROLE_ID + ";";

--- a/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/constant/SQLConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/constant/SQLConstants.java
@@ -156,8 +156,13 @@ public class SQLConstants {
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_ROLE_ID + "; AND UM_ORG_ID=:" +
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_ORG_ID + ";";
 
-    public static final String GET_USERS_FROM_ROLE_ID = "SELECT UM_USER_ID, UM_ROLE_ID, UM_USER_RESIDENT_ORG_ID " +
-            "FROM UM_ORG_ROLE_USER WHERE UM_ROLE_ID=:" + SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_ROLE_ID + ";";
+    public static final String GET_USERS_FROM_ROLE_ID = "SELECT * FROM UM_ORG_ROLE_USER WHERE UM_ROLE_ID=:" +
+            SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_ROLE_ID + ";";
+
+    public static final String GET_USERS_FROM_ROLE_ID_WITH_ORG = "SELECT UM_USER_ID, UM_ROLE_ID, " +
+            "UM_USER_RESIDENT_ORG_ID, UM_ORG_NAME FROM UM_ORG_ROLE_USER " +
+            "JOIN UM_ORG ON UM_USER_RESIDENT_ORG_ID = UM_ID " +
+            "WHERE UM_ROLE_ID=:" + SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_ROLE_ID + ";";
 
     public static final String GET_MEMBER_GROUP_IDS_FROM_ROLE_ID = "SELECT UM_GROUP_ID FROM UM_ORG_ROLE_GROUP WHERE " +
             "UM_ROLE_ID=:" + SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_ROLE_ID + ";";
@@ -333,6 +338,7 @@ public class SQLConstants {
         public static final String DB_SCHEMA_COLUMN_NAME_UM_ROLE_ID = "UM_ROLE_ID";
         public static final String DB_SCHEMA_COLUMN_NAME_UM_ROLE_NAME = "UM_ROLE_NAME";
         public static final String DB_SCHEMA_COLUMN_NAME_UM_ORG_ID = "UM_ORG_ID";
+        public static final String DB_SCHEMA_COLUMN_NAME_UM_ORG_NAME = "UM_ORG_NAME";
         public static final String DB_SCHEMA_COLUMN_NAME_UM_TENANT_ID = "UM_TENANT_ID";
         public static final String DB_SCHEMA_COLUMN_NAME_UM_GROUP_ID = "UM_GROUP_ID";
         public static final String DB_SCHEMA_COLUMN_NAME_UM_GROUP_NAME = "UM_GROUP_NAME";

--- a/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/constant/SQLConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/constant/SQLConstants.java
@@ -52,6 +52,12 @@ public class SQLConstants {
     public static final String ADD_ROLE_USER_MAPPING_ORACLE = "INSERT INTO UM_ORG_ROLE_USER (UM_USER_ID, UM_ROLE_ID) " +
             "WITH orgRoleUsers AS (";
 
+    public static final String ADD_ROLE_USER_WITH_ORG_MAPPING = "INSERT INTO UM_ORG_ROLE_USER " +
+            "(UM_USER_ID, UM_ROLE_ID, UM_USER_RESIDENT_ORG_ID) VALUES ";
+
+    public static final String ADD_ROLE_USER_WITH_ORG_MAPPING_ORACLE = "INSERT INTO UM_ORG_ROLE_USER " +
+            "(UM_USER_ID, UM_ROLE_ID, UM_USER_RESIDENT_ORG_ID) WITH orgRoleUsers AS (";
+
     public static final String ADD_ROLE_USER_MAPPING_INSERT_VALUES = "(:" +
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_USER_ID + "%1$d;,:" +
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_ROLE_ID + "%1$d;)";
@@ -59,6 +65,16 @@ public class SQLConstants {
     public static final String ADD_ROLE_USER_MAPPING_INSERT_VALUES_ORACLE = "SELECT :" +
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_USER_ID + "%1$d;, :" +
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_ROLE_ID + "%1$d; FROM dual";
+
+    public static final String ADD_ROLE_USER_WITH_ORG_MAPPING_INSERT_VALUES = "(:" +
+            SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_USER_ID + "%1$d;,:" +
+            SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_ROLE_ID + "%1$d;,:" +
+            SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_USER_RES_ORG_ID + "%1$d;)";
+
+    public static final String ADD_ROLE_USER_WITH_ORG_MAPPING_INSERT_VALUES_ORACLE = "SELECT :" +
+            SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_USER_ID + "%1$d;, :" +
+            SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_ROLE_ID + "%1$d;, :" +
+            SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_USER_RES_ORG_ID + "%1$d; FROM dual";
 
     public static final String ADD_ROLE_USER_MAPPING_TAIL_ORACLE = ") SELECT * FROM orgRoleUsers";
 
@@ -295,6 +311,14 @@ public class SQLConstants {
 
     public static final String DELETE_USER_ROLE_BY_USER_ID = "DELETE FROM UM_ORG_ROLE_USER WHERE UM_USER_ID=:" +
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_USER_ID + ";";
+
+    public static final String IS_USER_RES_ORG_ID_COLUMN_EXISTS = "SELECT UM_USER_RESIDENT_ORG_ID " +
+            "FROM UM_ORG_ROLE_USER LIMIT 1";
+    public static final String IS_USER_RES_ORG_ID_COLUMN_EXISTS_MSSQL = "SELECT TOP 1 UM_USER_RESIDENT_ORG_ID " +
+            "FROM UM_ORG_ROLE_USER";
+    public static final String IS_USER_RES_ORG_ID_COLUMN_EXISTS_ORACLE = "SELECT UM_USER_RESIDENT_ORG_ID " +
+            "FROM UM_ORG_ROLE_USER WHERE ROWNUM < 2";
+
     /**
      * Placeholders to be used in NamedJdbcTemplate.
      */
@@ -311,6 +335,7 @@ public class SQLConstants {
         public static final String DB_SCHEMA_COLUMN_NAME_UM_RESOURCE_ID = "UM_RESOURCE_ID";
         public static final String DB_SCHEMA_COLUMN_NAME_UM_USER_ID = "UM_USER_ID";
         public static final String DB_SCHEMA_COLUMN_NAME_UM_ACTION = "UM_ACTION";
+        public static final String DB_SCHEMA_COLUMN_NAME_USER_RES_ORG_ID = "UM_USER_RESIDENT_ORG_ID";
 
         public static final String DB_SCHEMA_LIMIT = "LIMIT";
     }

--- a/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/constant/SQLConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/constant/SQLConstants.java
@@ -319,6 +319,11 @@ public class SQLConstants {
     public static final String IS_USER_RES_ORG_ID_COLUMN_EXISTS_ORACLE = "SELECT UM_USER_RESIDENT_ORG_ID " +
             "FROM UM_ORG_ROLE_USER WHERE ROWNUM < 2";
 
+    public static final String UPDATE_USER_RES_ORG_ID = "UPDATE UM_ORG_ROLE_USER SET UM_USER_RESIDENT_ORG_ID=:" +
+            SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_USER_RES_ORG_ID + "; WHERE UM_ROLE_ID=:" +
+            SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_ROLE_ID + "; AND UM_USER_ID=:" +
+            SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_USER_ID + ";";
+
     /**
      * Placeholders to be used in NamedJdbcTemplate.
      */

--- a/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/dao/RoleManagementDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/dao/RoleManagementDAOImpl.java
@@ -1058,6 +1058,7 @@ public class RoleManagementDAOImpl implements RoleManagementDAO {
                             Optional<String> resolvedUserName = getOrganizationUserResidentResolverService()
                                     .getUserNameFromResidentOrgId(user.getId(), resolvedUserResidentOrgId.get());
                             resolvedUserName.ifPresent(user::setUserName);
+
                             namedJdbcTemplate.withTransaction(template -> {
                                 template.executeUpdate(UPDATE_USER_RES_ORG_ID,
                                         namedPreparedStatement -> {

--- a/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/dao/RoleManagementDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/dao/RoleManagementDAOImpl.java
@@ -1040,8 +1040,8 @@ public class RoleManagementDAOImpl implements RoleManagementDAO {
                             throw new RuntimeException(e);
                         }
                         try {
-                            if (checkUserResOrgIDColumnExists()) {
-                                user.setUserResOrgId(resultSet.getString(DB_SCHEMA_COLUMN_NAME_USER_RES_ORG_ID));
+                            if (checkUserResidentOrgIDColumnExists()) {
+                                user.setUserResidentOrgId(resultSet.getString(DB_SCHEMA_COLUMN_NAME_USER_RES_ORG_ID));
                             }
                         } catch (OrganizationManagementServerException e) {
                             throw new RuntimeException(e);
@@ -1168,16 +1168,16 @@ public class RoleManagementDAOImpl implements RoleManagementDAO {
                         }
                     } else {
                         try {
-                            if (USERS.equals(attribute) && checkUserResOrgIDColumnExists()) {
+                            if (USERS.equals(attribute) && checkUserResidentOrgIDColumnExists()) {
                                 for (int i = 0; i < valueList.size(); i++) {
                                     namedPreparedStatement.setString(finalColumnName + i, valueList.get(i));
                                     namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_UM_ROLE_ID + i, roleId);
-                                    Optional<String> userResOrgID = RoleManagementDataHolder.getInstance()
+                                    Optional<String> userResidentOrgID = RoleManagementDataHolder.getInstance()
                                             .getOrganizationUserResidentResolverService()
                                             .resolveResidentOrganization(valueList.get(i), requestInvokingOrgId);
-                                    if (userResOrgID.isPresent()) {
+                                    if (userResidentOrgID.isPresent()) {
                                         namedPreparedStatement.setString(
-                                                DB_SCHEMA_COLUMN_NAME_USER_RES_ORG_ID + i, userResOrgID.get());
+                                                DB_SCHEMA_COLUMN_NAME_USER_RES_ORG_ID + i, userResidentOrgID.get());
                                     }
                                 }
                             } else {
@@ -1400,7 +1400,7 @@ public class RoleManagementDAOImpl implements RoleManagementDAO {
      *                                               checking database type.
      */
     private String getAddRoleUserMappingQuery(int numberOfElements) throws OrganizationManagementException {
-        if (checkUserResOrgIDColumnExists()) {
+        if (checkUserResidentOrgIDColumnExists()) {
             if (isOracleDB()) {
                 return buildQueryForInsertAndRemoveValues(numberOfElements, ADD_ROLE_USER_WITH_ORG_MAPPING_ORACLE,
                         ADD_ROLE_USER_WITH_ORG_MAPPING_INSERT_VALUES_ORACLE, UNION_SEPARATOR,
@@ -1548,7 +1548,7 @@ public class RoleManagementDAOImpl implements RoleManagementDAO {
 
     }
 
-    private boolean checkUserResOrgIDColumnExists() throws OrganizationManagementServerException {
+    private boolean checkUserResidentOrgIDColumnExists() throws OrganizationManagementServerException {
 
         String sqlStm = IS_USER_RES_ORG_ID_COLUMN_EXISTS;
         if (isOracleDB()) {

--- a/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/dao/RoleManagementDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/dao/RoleManagementDAOImpl.java
@@ -605,9 +605,9 @@ public class RoleManagementDAOImpl implements RoleManagementDAO {
     public void deleteUserFromOrganizationRoles(String userId) throws OrganizationManagementServerException {
 
         try {
-            getNewTemplate().executeUpdate(DELETE_USER_ROLE_BY_USER_ID, namedPreparedStatement -> {
-                namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_UM_USER_ID, userId);
-            });
+            getNewTemplate().executeUpdate(DELETE_USER_ROLE_BY_USER_ID,
+                    namedPreparedStatement -> namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_UM_USER_ID, userId)
+            );
         } catch (DataAccessException e) {
             throw handleServerException(ERROR_CODE_ERROR_DELETING_USER_ROLE_ASSIGNMENTS, e, userId);
         }

--- a/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/dao/RoleManagementDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/dao/RoleManagementDAOImpl.java
@@ -186,6 +186,7 @@ import static org.wso2.carbon.identity.organization.management.service.constant.
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.PATCH_OP_REMOVE;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.PATCH_OP_REPLACE;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.getNewTemplate;
+import static org.wso2.carbon.identity.organization.management.service.util.Utils.getOrganizationId;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.getTenantId;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.handleClientException;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.handleServerException;
@@ -212,12 +213,12 @@ public class RoleManagementDAOImpl implements RoleManagementDAO {
                 if (CollectionUtils.isNotEmpty(role.getGroups())) {
                     String query = getAddRoleGroupMappingQuery(role.getGroups().size());
                     assignRoleAttributes(role.getGroups().stream().map(Group::getGroupId).collect(Collectors.toList()),
-                            role.getId(), query, GROUPS, organizationId);
+                            role.getId(), query, GROUPS);
                 }
                 if (CollectionUtils.isNotEmpty(role.getUsers())) {
                     String query = getAddRoleUserMappingQuery(role.getUsers().size());
                     assignRoleAttributes(role.getUsers().stream().map(User::getId).collect(Collectors.toList()),
-                            role.getId(), query, USERS, organizationId);
+                            role.getId(), query, USERS);
                 }
                 if (CollectionUtils.isNotEmpty(role.getPermissions())) {
                     int tenantID = getTenantId();
@@ -227,7 +228,7 @@ public class RoleManagementDAOImpl implements RoleManagementDAO {
                     List<String> permissionList = getPermissionIds(role.getPermissions(),
                             tenantID).stream().map(Object::toString).collect(Collectors.toList());
                     String query = getAddRolePermissionMappingQuery(permissionList.size());
-                    assignRoleAttributes(permissionList, role.getId(), query, PERMISSIONS, organizationId);
+                    assignRoleAttributes(permissionList, role.getId(), query, PERMISSIONS);
                 }
                 return null;
             });
@@ -455,13 +456,13 @@ public class RoleManagementDAOImpl implements RoleManagementDAO {
             return namedJdbcTemplate.withTransaction(template -> {
                 for (PatchOperation patchOp : patchOperations) {
                     if (StringUtils.equalsIgnoreCase(patchOp.getOp(), PATCH_OP_ADD)) {
-                        patchOperationAdd(roleId, patchOp.getPath(), patchOp.getValues(), organizationId);
+                        patchOperationAdd(roleId, patchOp.getPath(), patchOp.getValues());
                     } else if (StringUtils.equalsIgnoreCase(patchOp.getOp(), PATCH_OP_REMOVE)) {
                         /* If values are passed they should be on the path param. Therefore, if values are passed
                         with this, they would not be considered. */
                         patchOperationRemove(roleId, patchOp.getPath());
                     } else if (StringUtils.equalsIgnoreCase(patchOp.getOp(), PATCH_OP_REPLACE)) {
-                        patchOperationReplace(roleId, patchOp.getPath(), patchOp.getValues(), organizationId);
+                        patchOperationReplace(roleId, patchOp.getPath(), patchOp.getValues());
                     }
                 }
                 return getRoleById(organizationId, roleId);
@@ -526,12 +527,12 @@ public class RoleManagementDAOImpl implements RoleManagementDAO {
                 if (CollectionUtils.isNotEmpty(role.getUsers())) {
                     String query = getAddRoleUserMappingQuery(role.getUsers().size());
                     assignRoleAttributes(role.getUsers().stream().map(User::getId).collect(Collectors.toList()),
-                            roleId, query, USERS, organizationId);
+                            roleId, query, USERS);
                 }
                 if (CollectionUtils.isNotEmpty(role.getGroups())) {
                     String query = getAddRoleGroupMappingQuery(role.getGroups().size());
                     assignRoleAttributes(role.getGroups().stream().map(Group::getGroupId).collect(Collectors.toList()),
-                            roleId, query, GROUPS, organizationId);
+                            roleId, query, GROUPS);
                 }
                 if (CollectionUtils.isNotEmpty(role.getPermissions())) {
                     int tenantID = getTenantId();
@@ -542,7 +543,7 @@ public class RoleManagementDAOImpl implements RoleManagementDAO {
                             getPermissionIds(role.getPermissions(), tenantID).stream().map(Object::toString)
                                     .collect(Collectors.toList());
                     String query = getAddRolePermissionMappingQuery(permissionList.size());
-                    assignRoleAttributes(permissionList, roleId, query, PERMISSIONS, organizationId);
+                    assignRoleAttributes(permissionList, roleId, query, PERMISSIONS);
                 }
                 return null;
             });
@@ -700,7 +701,7 @@ public class RoleManagementDAOImpl implements RoleManagementDAO {
      * @throws OrganizationManagementException The exception is thrown when an error occurs during patch
      *                                         operation.
      */
-    private void patchOperationReplace(String roleId, String path, List<String> values, String organizationId)
+    private void patchOperationReplace(String roleId, String path, List<String> values)
             throws OrganizationManagementException {
 
         if (StringUtils.equals(path, DISPLAY_NAME)) {
@@ -709,13 +710,13 @@ public class RoleManagementDAOImpl implements RoleManagementDAO {
             removeAttributesFromRoleUsingRoleId(roleId, USERS);
             if (CollectionUtils.isNotEmpty(values)) {
                 String query = getAddRoleUserMappingQuery(values.size());
-                assignRoleAttributes(values, roleId, query, USERS, organizationId);
+                assignRoleAttributes(values, roleId, query, USERS);
             }
         } else if (StringUtils.equalsIgnoreCase(path, GROUPS)) {
             removeAttributesFromRoleUsingRoleId(roleId, GROUPS);
             if (CollectionUtils.isNotEmpty(values)) {
                 String query = getAddRoleGroupMappingQuery(values.size());
-                assignRoleAttributes(values, roleId, query, GROUPS, organizationId);
+                assignRoleAttributes(values, roleId, query, GROUPS);
             }
         } else if (StringUtils.equalsIgnoreCase(path, PERMISSIONS)) {
             removeAttributesFromRoleUsingRoleId(roleId, PERMISSIONS);
@@ -725,7 +726,7 @@ public class RoleManagementDAOImpl implements RoleManagementDAO {
                 List<String> permissionList = getPermissionIds(values,
                         getTenantId()).stream().map(Object::toString).collect(Collectors.toList());
                 String query = getAddRolePermissionMappingQuery(values.size());
-                assignRoleAttributes(permissionList, roleId, query, PERMISSIONS, organizationId);
+                assignRoleAttributes(permissionList, roleId, query, PERMISSIONS);
             }
         }
     }
@@ -779,7 +780,7 @@ public class RoleManagementDAOImpl implements RoleManagementDAO {
      * @param values The value for the patch operation.
      * @throws OrganizationManagementException The exception is thrown when an error occurs during patch operation.
      */
-    private void patchOperationAdd(String roleId, String path, List<String> values, String organizationId)
+    private void patchOperationAdd(String roleId, String path, List<String> values)
             throws OrganizationManagementException {
 
         if (StringUtils.equalsIgnoreCase(path, USERS)) {
@@ -787,14 +788,14 @@ public class RoleManagementDAOImpl implements RoleManagementDAO {
                     DB_SCHEMA_COLUMN_NAME_UM_USER_ID, false, values);
             if (CollectionUtils.isNotEmpty(newUserList)) {
                 String query = getAddRoleUserMappingQuery(newUserList.size());
-                assignRoleAttributes(newUserList, roleId, query, USERS, organizationId);
+                assignRoleAttributes(newUserList, roleId, query, USERS);
             }
         } else if (StringUtils.equalsIgnoreCase(path, GROUPS)) {
             List<String> newGroupList = findNonAssignedAttributeValues(roleId, CHECK_GROUP_ROLE_MAPPING_EXISTS,
                     DB_SCHEMA_COLUMN_NAME_UM_GROUP_ID, false, values);
             if (CollectionUtils.isNotEmpty(newGroupList)) {
                 String query = getAddRoleGroupMappingQuery(newGroupList.size());
-                assignRoleAttributes(newGroupList, roleId, query, GROUPS, organizationId);
+                assignRoleAttributes(newGroupList, roleId, query, GROUPS);
             }
         } else if (StringUtils.equalsIgnoreCase(path, PERMISSIONS)) {
             int tenantID = getTenantId();
@@ -808,7 +809,7 @@ public class RoleManagementDAOImpl implements RoleManagementDAO {
                 List<String> permissionList = getPermissionIds(newPermissionList, tenantID).stream()
                         .map(Object::toString).collect(Collectors.toList());
                 String query = getAddRolePermissionMappingQuery(permissionList.size());
-                assignRoleAttributes(permissionList, roleId, query, PERMISSIONS, organizationId);
+                assignRoleAttributes(permissionList, roleId, query, PERMISSIONS);
             }
         } else if (StringUtils.equals(path, DISPLAY_NAME)) {
             replaceDisplayName(values.get(0), roleId);
@@ -1131,10 +1132,11 @@ public class RoleManagementDAOImpl implements RoleManagementDAO {
      * @param attribute The role attribute.
      * @throws OrganizationManagementServerException The exception is thrown if an error occurs while inserting values.
      */
-    private void assignRoleAttributes(List<String> valueList, String roleId, String query, String attribute,
-                                      String organizationId) throws OrganizationManagementServerException {
+    private void assignRoleAttributes(List<String> valueList, String roleId, String query, String attribute)
+            throws OrganizationManagementServerException {
 
         NamedJdbcTemplate namedJdbcTemplate = getNewTemplate();
+        String requestInvokingOrgId = getOrganizationId();
         ErrorMessages errorMessage;
         String columnName = StringUtils.EMPTY;
         switch (attribute) {
@@ -1158,30 +1160,34 @@ public class RoleManagementDAOImpl implements RoleManagementDAO {
             String finalColumnName = columnName;
             namedJdbcTemplate.withTransaction(template -> {
                 template.executeInsert(query, namedPreparedStatement -> {
-                    if (DB_SCHEMA_COLUMN_NAME_UM_PERMISSION_ID.equals(finalColumnName)) {
+                    if (PERMISSIONS.equals(attribute)) {
                         for (int i = 0; i < valueList.size(); i++) {
                             namedPreparedStatement.setInt(finalColumnName + i,
                                     Integer.parseInt(valueList.get(i)));
                             namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_UM_ROLE_ID + i, roleId);
                         }
                     } else {
-                        for (int i = 0; i < valueList.size(); i++) {
-                            namedPreparedStatement.setString(finalColumnName + i, valueList.get(i));
-                            namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_UM_ROLE_ID + i, roleId);
-                            try {
-                                if (DB_SCHEMA_COLUMN_NAME_UM_USER_ID.equals(finalColumnName) &&
-                                        checkUserResOrgIDColumnExists()) {
+                        try {
+                            if (USERS.equals(attribute) && checkUserResOrgIDColumnExists()) {
+                                for (int i = 0; i < valueList.size(); i++) {
+                                    namedPreparedStatement.setString(finalColumnName + i, valueList.get(i));
+                                    namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_UM_ROLE_ID + i, roleId);
                                     Optional<String> userResOrgID = RoleManagementDataHolder.getInstance()
                                             .getOrganizationUserResidentResolverService()
-                                            .resolveResidentOrganization(valueList.get(i), organizationId);
+                                            .resolveResidentOrganization(valueList.get(i), requestInvokingOrgId);
                                     if (userResOrgID.isPresent()) {
                                         namedPreparedStatement.setString(
                                                 DB_SCHEMA_COLUMN_NAME_USER_RES_ORG_ID + i, userResOrgID.get());
                                     }
                                 }
-                            } catch (OrganizationManagementException e) {
-                                throw new RuntimeException(e);
+                            } else {
+                                for (int i = 0; i < valueList.size(); i++) {
+                                    namedPreparedStatement.setString(finalColumnName + i, valueList.get(i));
+                                    namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_UM_ROLE_ID + i, roleId);
+                                }
                             }
+                        } catch (OrganizationManagementException e) {
+                            throw new RuntimeException(e);
                         }
                     }
                 }, valueList, false);

--- a/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/dao/RoleManagementDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/dao/RoleManagementDAOImpl.java
@@ -1550,6 +1550,13 @@ public class RoleManagementDAOImpl implements RoleManagementDAO {
 
     }
 
+    /**
+     * Check if USER_RESIDENT_ORG_ID column exists in UM_ORG_ROLE_USER table.
+     *
+     * @return Boolean that indicates if USER_RESIDENT_ORG_ID column exists in UM_ORG_ROLE_USER table.
+     * @throws OrganizationManagementServerException The server exception is thrown when an error occurs while
+     *                                               checking database type.
+     */
     private boolean checkUserResidentOrgIDColumnExists() throws OrganizationManagementServerException {
 
         String sqlStm = IS_USER_RES_ORG_ID_COLUMN_EXISTS;

--- a/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/dao/RoleManagementDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/dao/RoleManagementDAOImpl.java
@@ -1437,18 +1437,16 @@ public class RoleManagementDAOImpl implements RoleManagementDAO {
                 return buildQueryForInsertAndRemoveValues(numberOfElements, ADD_ROLE_USER_WITH_ORG_MAPPING_ORACLE,
                         ADD_ROLE_USER_WITH_ORG_MAPPING_INSERT_VALUES_ORACLE, UNION_SEPARATOR,
                         ADD_ROLE_USER_MAPPING_TAIL_ORACLE);
-            } else {
-                return buildQueryForInsertAndRemoveValues(numberOfElements, ADD_ROLE_USER_WITH_ORG_MAPPING,
-                        ADD_ROLE_USER_WITH_ORG_MAPPING_INSERT_VALUES, COMMA_SEPARATOR, StringUtils.EMPTY);
             }
+            return buildQueryForInsertAndRemoveValues(numberOfElements, ADD_ROLE_USER_WITH_ORG_MAPPING,
+                    ADD_ROLE_USER_WITH_ORG_MAPPING_INSERT_VALUES, COMMA_SEPARATOR, StringUtils.EMPTY);
         } else {
             if (isOracleDB()) {
                 return buildQueryForInsertAndRemoveValues(numberOfElements, ADD_ROLE_USER_MAPPING_ORACLE,
                         ADD_ROLE_USER_MAPPING_INSERT_VALUES_ORACLE, UNION_SEPARATOR, ADD_ROLE_USER_MAPPING_TAIL_ORACLE);
-            } else {
-                return buildQueryForInsertAndRemoveValues(numberOfElements, ADD_ROLE_USER_MAPPING,
-                        ADD_ROLE_USER_MAPPING_INSERT_VALUES, COMMA_SEPARATOR, StringUtils.EMPTY);
             }
+            return buildQueryForInsertAndRemoveValues(numberOfElements, ADD_ROLE_USER_MAPPING,
+                    ADD_ROLE_USER_MAPPING_INSERT_VALUES, COMMA_SEPARATOR, StringUtils.EMPTY);
         }
     }
 

--- a/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/dao/RoleManagementDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/dao/RoleManagementDAOImpl.java
@@ -1042,9 +1042,7 @@ public class RoleManagementDAOImpl implements RoleManagementDAO {
                                 user.setUserResidentOrgName(RoleManagementDataHolder.getInstance()
                                         .getOrganizationManager().getOrganizationNameById(user.getUserResidentOrgId()));
                             }
-                        } catch (UserStoreException e) {
-                            throw new RuntimeException(e);
-                        } catch (OrganizationManagementException e) {
+                        } catch (UserStoreException | OrganizationManagementException e) {
                             throw new RuntimeException(e);
                         }
 

--- a/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/models/User.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/models/User.java
@@ -25,6 +25,8 @@ public class User {
 
     private String id;
     private String userName;
+    private String userResOrgId;
+    private String userResOrgName;
 
     public User(String id, String userName) {
 
@@ -55,5 +57,25 @@ public class User {
     public void setUserName(String userName) {
 
         this.userName = userName;
+    }
+
+    public String getUserResOrgId() {
+
+        return userResOrgId;
+    }
+
+    public void setUserResOrgId(String userResOrgId) {
+
+        this.userResOrgId = userResOrgId;
+    }
+
+    public String getUserResOrgName() {
+
+        return userResOrgName;
+    }
+
+    public void setUserResOrgName(String userResOrgName) {
+
+        this.userResOrgName = userResOrgName;
     }
 }

--- a/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/models/User.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/models/User.java
@@ -25,8 +25,8 @@ public class User {
 
     private String id;
     private String userName;
-    private String userResOrgId;
-    private String userResOrgName;
+    private String userResidentOrgId;
+    private String userResidentOrgName;
 
     public User(String id, String userName) {
 
@@ -59,23 +59,23 @@ public class User {
         this.userName = userName;
     }
 
-    public String getUserResOrgId() {
+    public String getUserResidentOrgId() {
 
-        return userResOrgId;
+        return userResidentOrgId;
     }
 
-    public void setUserResOrgId(String userResOrgId) {
+    public void setUserResidentOrgId(String userResidentOrgId) {
 
-        this.userResOrgId = userResOrgId;
+        this.userResidentOrgId = userResidentOrgId;
     }
 
-    public String getUserResOrgName() {
+    public String getUserResidentOrgName() {
 
-        return userResOrgName;
+        return userResidentOrgName;
     }
 
-    public void setUserResOrgName(String userResOrgName) {
+    public void setUserResidentOrgName(String userResidentOrgName) {
 
-        this.userResOrgName = userResOrgName;
+        this.userResidentOrgName = userResidentOrgName;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -398,7 +398,7 @@
         <org.wso2.identity.organization.mgt.imp.pkg.version.range>[1.0.0,2.0.0)
         </org.wso2.identity.organization.mgt.imp.pkg.version.range>
 
-        <identity.organization.management.core.version>1.0.41</identity.organization.management.core.version>
+        <identity.organization.management.core.version>1.0.42</identity.organization.management.core.version>
         <org.wso2.identity.organization.mgt.core.imp.pkg.version.range>[1.0.0,2.0.0)
         </org.wso2.identity.organization.mgt.core.imp.pkg.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -398,7 +398,7 @@
         <org.wso2.identity.organization.mgt.imp.pkg.version.range>[1.0.0,2.0.0)
         </org.wso2.identity.organization.mgt.imp.pkg.version.range>
 
-        <identity.organization.management.core.version>1.0.42</identity.organization.management.core.version>
+        <identity.organization.management.core.version>1.0.45</identity.organization.management.core.version>
         <org.wso2.identity.organization.mgt.core.imp.pkg.version.range>[1.0.0,2.0.0)
         </org.wso2.identity.organization.mgt.core.imp.pkg.version.range>
 


### PR DESCRIPTION
## Purpose

- > Check whether the UM_USER_RESIDENT_ORG_ID column is available in the UM_ORG_ROLE_USER_TABLE and add the related value for it if the column is available when creating users of a role in POST, PUT, PATCH requests.

- > Send details required to change get role by roleID API response (https://github.com/wso2-enterprise/identity-api-organization-management/pull/30)

## Related PRs
Merge this PR after merging the following PRs
- https://github.com/wso2-extensions/identity-organization-management-core/pull/61

## Related Issues
- https://github.com/wso2-enterprise/asgardeo-product/issues/15292