### PR TITLE
Improve sub org role PUT operation validations

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/RoleManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/RoleManagerImpl.java
@@ -410,12 +410,7 @@ public class RoleManagerImpl implements RoleManager {
 
         // Update is not allowed, if the modified role display name is equal to a display name of an existing role.
         if (!role.getDisplayName().equalsIgnoreCase(modifiedRole.getDisplayName())) {
-            boolean checkRoleNameExists = roleManagementDAO.checkRoleExists(organizationId, null,
-                    modifiedRole.getDisplayName());
-            if (checkRoleNameExists) {
-                throw handleClientException(ERROR_CODE_ROLE_DISPLAY_NAME_ALREADY_EXISTS,
-                        modifiedRole.getDisplayName(), organizationId);
-            }
+            validateRoleNameNotExist(organizationId, modifiedRole.getDisplayName());
         }
 
         // The org-creator role assigned during org creation, is not allowed to be updated.

--- a/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/RoleManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/RoleManagerImpl.java
@@ -401,11 +401,23 @@ public class RoleManagerImpl implements RoleManager {
         if (role == null) {
             throw handleClientException(ERROR_CODE_INVALID_ROLE, roleId);
         }
+
         // The Administrator role permissions and display name are not allowed to be updated.
         if (ORG_ADMINISTRATOR_ROLE.equalsIgnoreCase(role.getDisplayName())) {
             return new HashSet<>(role.getPermissions()).equals(new HashSet<>(modifiedRole.getPermissions()))
                     && ORG_ADMINISTRATOR_ROLE.equalsIgnoreCase(modifiedRole.getDisplayName());
         }
+
+        // Update is not allowed, if the modified role display name is equal to a display name of an existing role.
+        if (!role.getDisplayName().equalsIgnoreCase(modifiedRole.getDisplayName())) {
+            boolean checkRoleNameExists = roleManagementDAO.checkRoleExists(organizationId, null,
+                    modifiedRole.getDisplayName());
+            if (checkRoleNameExists) {
+                throw handleClientException(ERROR_CODE_ROLE_DISPLAY_NAME_ALREADY_EXISTS,
+                        modifiedRole.getDisplayName(), organizationId);
+            }
+        }
+
         // The org-creator role assigned during org creation, is not allowed to be updated.
         return !ORG_CREATOR_ROLE.equalsIgnoreCase(role.getDisplayName());
     }


### PR DESCRIPTION
## Purpose
> Prevent update role via PUT op, if the modified role display name is equal to a display name of an existing role.

## Goals
> To not having two roles with the same display name.

## Related Issues
- https://github.com/wso2-enterprise/asgardeo-product/issues/16750