### PR TITLE
Resolve group resident org when assigning a group to a role.

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/constant/SQLConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/constant/SQLConstants.java
@@ -37,6 +37,12 @@ public class SQLConstants {
     public static final String ADD_ROLE_GROUP_MAPPING_ORACLE = "INSERT INTO UM_ORG_ROLE_GROUP (UM_GROUP_ID, " +
             "UM_ROLE_ID) WITH orgRoleGroups AS (";
 
+    public static final String ADD_ROLE_GROUP_WITH_ORG_MAPPING = "INSERT INTO UM_ORG_ROLE_GROUP " +
+            "(UM_GROUP_ID, UM_ROLE_ID, UM_GROUP_RESIDENT_ORG_ID) VALUES ";
+
+    public static final String ADD_ROLE_GROUP_WITH_ORG_MAPPING_ORACLE = "INSERT INTO UM_ORG_ROLE_GROUP (UM_GROUP_ID, " +
+            "UM_ROLE_ID, UM_GROUP_RESIDENT_ORG_ID) WITH orgRoleGroups AS (";
+
     public static final String ADD_ROLE_GROUP_MAPPING_INSERT_VALUES = "(:" +
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_GROUP_ID + "%1$d;,:" +
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_ROLE_ID + "%1$d;)";
@@ -44,6 +50,16 @@ public class SQLConstants {
     public static final String ADD_ROLE_GROUP_MAPPING_INSERT_VALUES_ORACLE = "SELECT :" +
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_GROUP_ID + "%1$d;, :" +
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_ROLE_ID + "%1$d; FROM dual";
+
+    public static final String ADD_ROLE_GROUP_WITH_ORG_MAPPING_INSERT_VALUES = "(:" +
+            SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_GROUP_ID + "%1$d;,:" +
+            SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_ROLE_ID + "%1$d;,:" +
+            SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_GROUP_RES_ORG_ID + "%1$d;)";
+
+    public static final String ADD_ROLE_GROUP_WITH_ORG_MAPPING_INSERT_VALUES_ORACLE = "SELECT :" +
+            SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_GROUP_ID + "%1$d;, :" +
+            SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_UM_ROLE_ID + "%1$d;, :" +
+            SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_GROUP_RES_ORG_ID + "%1$d; FROM dual";
 
     public static final String ADD_ROLE_GROUP_MAPPING_TAIL_ORACLE = ") SELECT * FROM orgRoleGroups";
 
@@ -323,6 +339,12 @@ public class SQLConstants {
             "FROM UM_ORG_ROLE_USER";
     public static final String IS_USER_RES_ORG_ID_COLUMN_EXISTS_ORACLE = "SELECT UM_USER_RESIDENT_ORG_ID " +
             "FROM UM_ORG_ROLE_USER WHERE ROWNUM < 2";
+    public static final String IS_GROUP_RES_ORG_ID_COLUMN_EXISTS = "SELECT UM_GROUP_RESIDENT_ORG_ID " +
+            "FROM UM_ORG_ROLE_GROUP LIMIT 1";
+    public static final String IS_GROUP_RES_ORG_ID_COLUMN_EXISTS_MSSQL = "SELECT TOP 1 UM_GROUP_RESIDENT_ORG_ID " +
+            "FROM UM_ORG_ROLE_GROUP";
+    public static final String IS_GROUP_RES_ORG_ID_COLUMN_EXISTS_ORACLE = "SELECT UM_GROUP_RESIDENT_ORG_ID " +
+            "FROM UM_ORG_ROLE_GROUP WHERE ROWNUM < 2";
 
     public static final String UPDATE_USER_RES_ORG_ID = "UPDATE UM_ORG_ROLE_USER SET UM_USER_RESIDENT_ORG_ID=:" +
             SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_USER_RES_ORG_ID + "; WHERE UM_ROLE_ID=:" +
@@ -347,6 +369,7 @@ public class SQLConstants {
         public static final String DB_SCHEMA_COLUMN_NAME_UM_USER_ID = "UM_USER_ID";
         public static final String DB_SCHEMA_COLUMN_NAME_UM_ACTION = "UM_ACTION";
         public static final String DB_SCHEMA_COLUMN_NAME_USER_RES_ORG_ID = "UM_USER_RESIDENT_ORG_ID";
+        public static final String DB_SCHEMA_COLUMN_NAME_GROUP_RES_ORG_ID = "UM_GROUP_RESIDENT_ORG_ID";
 
         public static final String DB_SCHEMA_LIMIT = "LIMIT";
     }

--- a/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/internal/RoleManagementDataHolder.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/internal/RoleManagementDataHolder.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.organization.management.role.management.service.internal;
 
+import org.wso2.carbon.identity.organization.management.service.OrganizationGroupResidentResolverService;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.organization.management.service.OrganizationUserResidentResolverService;
 import org.wso2.carbon.user.core.service.RealmService;
@@ -30,6 +31,7 @@ public class RoleManagementDataHolder {
     private static final RoleManagementDataHolder ROLE_MANAGEMENT_DATA_HOLDER = new RoleManagementDataHolder();
     private OrganizationManager organizationManager;
     private OrganizationUserResidentResolverService organizationUserResidentResolverService;
+    private OrganizationGroupResidentResolverService organizationGroupResidentResolverService;
     private RealmService realmService;
 
     public static RoleManagementDataHolder getInstance() {
@@ -56,6 +58,17 @@ public class RoleManagementDataHolder {
             OrganizationUserResidentResolverService organizationUserResidentResolverService) {
 
         this.organizationUserResidentResolverService = organizationUserResidentResolverService;
+    }
+
+    public OrganizationGroupResidentResolverService getOrganizationGroupResidentResolverService() {
+
+        return organizationGroupResidentResolverService;
+    }
+
+    public void setOrganizationGroupResidentResolverService(
+            OrganizationGroupResidentResolverService organizationGroupResidentResolverService) {
+
+        this.organizationGroupResidentResolverService = organizationGroupResidentResolverService;
     }
 
     public RealmService getRealmService() {

--- a/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/internal/RoleManagementServiceComponent.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/internal/RoleManagementServiceComponent.java
@@ -30,6 +30,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.identity.organization.management.role.management.service.RoleManager;
 import org.wso2.carbon.identity.organization.management.role.management.service.RoleManagerImpl;
 import org.wso2.carbon.identity.organization.management.role.management.service.listener.OrganizationUserOperationEventListener;
+import org.wso2.carbon.identity.organization.management.service.OrganizationGroupResidentResolverService;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.organization.management.service.OrganizationUserResidentResolverService;
 import org.wso2.carbon.user.core.listener.UserOperationEventListener;
@@ -132,5 +133,31 @@ public class RoleManagementServiceComponent {
             LOG.debug("Unset organization user resident resolver service.");
         }
         RoleManagementDataHolder.getInstance().setOrganizationUserResidentResolverService(null);
+    }
+
+    @Reference(
+            name = "organization.group.resident.resolver.service",
+            service = OrganizationGroupResidentResolverService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetOrganizationGroupResidentResolverService"
+    )
+    protected void setOrganizationGroupResidentResolverService(
+            OrganizationGroupResidentResolverService organizationGroupResidentResolverService) {
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Setting the organization user resident resolver service.");
+        }
+        RoleManagementDataHolder.getInstance()
+                .setOrganizationGroupResidentResolverService(organizationGroupResidentResolverService);
+    }
+
+    protected void unsetOrganizationGroupResidentResolverService(
+            OrganizationGroupResidentResolverService organizationGroupResidentResolverService) {
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Unset organization group resident resolver service.");
+        }
+        RoleManagementDataHolder.getInstance().setOrganizationGroupResidentResolverService(null);
     }
 }

--- a/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/models/Group.java
+++ b/components/org.wso2.carbon.identity.organization.management.role.management.service/src/main/java/org/wso2/carbon/identity/organization/management/role/management/service/models/Group.java
@@ -29,6 +29,8 @@ public class Group {
     private String groupName;
     private List<Role> roleList;
     private List<User> userList;
+    private String groupResidentOrgId;
+    private String groupResidentOrgName;
 
     public Group(String groupId, String groupName, List<Role> roleList, List<User> userList) {
 
@@ -87,5 +89,25 @@ public class Group {
     public void setUserList(List<User> userList) {
 
         this.userList = userList;
+    }
+
+    public String getGroupResidentOrgId() {
+
+        return groupResidentOrgId;
+    }
+
+    public void setGroupResidentOrgId(String groupResidentOrgId) {
+
+        this.groupResidentOrgId = groupResidentOrgId;
+    }
+
+    public String getGroupResidentOrgName() {
+
+        return groupResidentOrgName;
+    }
+
+    public void setGroupResidentOrgName(String groupResidentOrgName) {
+
+        this.groupResidentOrgName = groupResidentOrgName;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -398,7 +398,7 @@
         <org.wso2.identity.organization.mgt.imp.pkg.version.range>[1.0.0,2.0.0)
         </org.wso2.identity.organization.mgt.imp.pkg.version.range>
 
-        <identity.organization.management.core.version>1.0.45</identity.organization.management.core.version>
+        <identity.organization.management.core.version>1.0.48</identity.organization.management.core.version>
         <org.wso2.identity.organization.mgt.core.imp.pkg.version.range>[1.0.0,2.0.0)
         </org.wso2.identity.organization.mgt.core.imp.pkg.version.range>
 


### PR DESCRIPTION
## Purpose
> Resolve group resident org id when assigning a group to a sub-org role if DB column is available.

## Goals
> Assign parent org groups to a sub org role.

## Related PRs
- https://github.com/wso2-extensions/identity-organization-management-core/pull/64