### PR TITLE
Restrict application creation in sub-organizations in PCC and IS+B2B connector setup 

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.application/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.application/pom.xml
@@ -104,6 +104,11 @@
             <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/org.wso2.carbon.identity.organization.management.application/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.application/pom.xml
@@ -109,6 +109,12 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/constant/OrgApplicationMgtConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/constant/OrgApplicationMgtConstants.java
@@ -59,4 +59,7 @@ public class OrgApplicationMgtConstants {
             "POST_GET_APPLICATION_SHARED_ORGANIZATIONS";
     public static final String EVENT_PRE_GET_SHARED_APPLICATIONS = "PRE_GET_SHARED_APPLICATIONS";
     public static final String EVENT_POST_GET_SHARED_APPLICATIONS = "POST_GET_SHARED_APPLICATIONS";
+    public static final String CODE_SUB_ORG_CANNOT_CREATE_APP = "RLS-10004";
+    public static final String ERROR_SUB_ORG_CANNOT_CREATE_APP =
+            "Applications cannot be created for sub organizations.";
 }

--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/constant/OrgApplicationMgtConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/constant/OrgApplicationMgtConstants.java
@@ -59,7 +59,4 @@ public class OrgApplicationMgtConstants {
             "POST_GET_APPLICATION_SHARED_ORGANIZATIONS";
     public static final String EVENT_PRE_GET_SHARED_APPLICATIONS = "PRE_GET_SHARED_APPLICATIONS";
     public static final String EVENT_POST_GET_SHARED_APPLICATIONS = "POST_GET_SHARED_APPLICATIONS";
-    public static final String CODE_SUB_ORG_CANNOT_CREATE_APP = "RLS-10004";
-    public static final String ERROR_SUB_ORG_CANNOT_CREATE_APP =
-            "Applications cannot be created for sub organizations.";
 }

--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
@@ -48,15 +48,14 @@ import java.util.List;
 import java.util.Optional;
 
 import static java.lang.String.format;
-import static org.wso2.carbon.identity.organization.management.application.constant.OrgApplicationMgtConstants.CODE_SUB_ORG_CANNOT_CREATE_APP;
 import static org.wso2.carbon.identity.organization.management.application.constant.OrgApplicationMgtConstants.DELETE_FRAGMENT_APPLICATION;
 import static org.wso2.carbon.identity.organization.management.application.constant.OrgApplicationMgtConstants.DELETE_MAIN_APPLICATION;
 import static org.wso2.carbon.identity.organization.management.application.constant.OrgApplicationMgtConstants.DELETE_SHARE_FOR_MAIN_APPLICATION;
-import static org.wso2.carbon.identity.organization.management.application.constant.OrgApplicationMgtConstants.ERROR_SUB_ORG_CANNOT_CREATE_APP;
 import static org.wso2.carbon.identity.organization.management.application.constant.OrgApplicationMgtConstants.IS_FRAGMENT_APP;
 import static org.wso2.carbon.identity.organization.management.application.constant.OrgApplicationMgtConstants.SHARE_WITH_ALL_CHILDREN;
 import static org.wso2.carbon.identity.organization.management.application.constant.OrgApplicationMgtConstants.UPDATE_SP_METADATA_SHARE_WITH_ALL_CHILDREN;
 import static org.wso2.carbon.identity.organization.management.application.util.OrgApplicationManagerUtil.setShareWithAllChildrenProperty;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_SUB_ORG_CANNOT_CREATE_APP;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.SUPER_ORG_ID;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.isB2BApplicationRoleSupportEnabled;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.isSubOrganization;
@@ -99,8 +98,9 @@ public class FragmentApplicationMgtListener extends AbstractApplicationMgtListen
                     getOrganizationManager().getOrganizationDepthInHierarchy(organizationId);
             if (isSubOrganization(organizationDepthInHierarchy)) {
                 if (!isSharedAppFromInternalProcess(serviceProvider, tenantDomain)) {
-                    throw new IdentityApplicationManagementClientException(CODE_SUB_ORG_CANNOT_CREATE_APP,
-                            ERROR_SUB_ORG_CANNOT_CREATE_APP);
+                    throw new IdentityApplicationManagementClientException(
+                            ERROR_CODE_SUB_ORG_CANNOT_CREATE_APP.getCode(),
+                            ERROR_CODE_SUB_ORG_CANNOT_CREATE_APP.getMessage());
                 }
                 return true;
             }
@@ -330,9 +330,9 @@ public class FragmentApplicationMgtListener extends AbstractApplicationMgtListen
     }
 
     /**
-     * Check whether the service provider app is shared application for a sub organization by an internal process of
-     * Asgardeo. In that process, the isFragmentApp attribute is set to true and request initiated tenant domain and the
-     * * service provider belonging tenant domain would be different.
+     * Check whether the service provider app is a shared application for a sub-organization by an internal process.
+     * In that process, the isFragmentApp attribute is set to true, and request initiated tenant domain and the
+     * service provider belonging tenant domain would be different.
      *
      * @param serviceProvider The service provider app which is going to be provisioned.
      * @param tenantDomain    The tenant domain which the service provider app is belongs to.

--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
@@ -96,13 +96,11 @@ public class FragmentApplicationMgtListener extends AbstractApplicationMgtListen
             String organizationId = getOrganizationManager().resolveOrganizationId(tenantDomain);
             int organizationDepthInHierarchy =
                     getOrganizationManager().getOrganizationDepthInHierarchy(organizationId);
-            if (isSubOrganization(organizationDepthInHierarchy)) {
-                if (!isSharedAppFromInternalProcess(serviceProvider, tenantDomain)) {
-                    throw new IdentityApplicationManagementClientException(
-                            ERROR_CODE_SUB_ORG_CANNOT_CREATE_APP.getCode(),
-                            ERROR_CODE_SUB_ORG_CANNOT_CREATE_APP.getMessage());
-                }
-                return true;
+            if (isSubOrganization(organizationDepthInHierarchy) &&
+                    !isSharedAppFromInternalProcess(serviceProvider, tenantDomain)) {
+                throw new IdentityApplicationManagementClientException(
+                        ERROR_CODE_SUB_ORG_CANNOT_CREATE_APP.getCode(),
+                        ERROR_CODE_SUB_ORG_CANNOT_CREATE_APP.getMessage());
             }
         } catch (OrganizationManagementException e) {
             throw new IdentityApplicationManagementException(

--- a/components/org.wso2.carbon.identity.organization.management.application/src/test/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListenerTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/test/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListenerTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.management.application.listener;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.common.IdentityApplicationManagementClientException;
+import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
+import org.wso2.carbon.identity.application.common.model.ServiceProvider;
+import org.wso2.carbon.identity.organization.management.application.internal.OrgApplicationMgtDataHolder;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Test class for FragmentApplicationMgtListener.
+ */
+public class FragmentApplicationMgtListenerTest {
+
+    @Mock
+    private OrganizationManager organizationManager;
+
+    @InjectMocks
+    private FragmentApplicationMgtListener fragmentApplicationMgtListener;
+
+    private ServiceProvider serviceProvider;
+    private String tenantDomain;
+    private String userName;
+
+    @BeforeMethod
+    public void setUp() {
+
+        MockitoAnnotations.openMocks(this);
+        serviceProvider = mock(ServiceProvider.class);
+        OrgApplicationMgtDataHolder.getInstance().setOrganizationManager(organizationManager);
+        tenantDomain = "sampleTenantDomain";
+        userName = "sampleUser";
+    }
+
+    @Test
+    public void testDoPreCreateApplicationWithOrganization()
+            throws IdentityApplicationManagementException, OrganizationManagementException {
+
+        when(organizationManager.resolveOrganizationId(tenantDomain)).thenReturn("orgId1");
+        when(organizationManager.getOrganizationDepthInHierarchy("orgId1")).thenReturn(0);
+
+        boolean result = fragmentApplicationMgtListener.doPreCreateApplication(serviceProvider, tenantDomain, userName);
+
+        assertTrue(result);
+        verify(organizationManager, times(1)).resolveOrganizationId(tenantDomain);
+        verify(organizationManager, times(1)).getOrganizationDepthInHierarchy("orgId1");
+    }
+
+    @Test(expectedExceptions = IdentityApplicationManagementClientException.class)
+    public void testDoPreCreateApplicationWithSubOrganization() throws IdentityApplicationManagementException,
+            OrganizationManagementException {
+
+        when(organizationManager.resolveOrganizationId(tenantDomain)).thenReturn("orgId2");
+        when(organizationManager.getOrganizationDepthInHierarchy("orgId2")).thenReturn(2);
+
+        try {
+            fragmentApplicationMgtListener.doPreCreateApplication(serviceProvider, tenantDomain, userName);
+        } finally {
+            verify(organizationManager, times(1)).resolveOrganizationId(tenantDomain);
+            verify(organizationManager, times(1)).getOrganizationDepthInHierarchy("orgId2");
+        }
+    }
+}
+

--- a/components/org.wso2.carbon.identity.organization.management.application/src/test/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListenerTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/test/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListenerTest.java
@@ -71,11 +71,13 @@ public class FragmentApplicationMgtListenerTest {
     @DataProvider(name = "subOrganizationMetaData")
     public Object[][] getSubOrganizationMetaData() {
 
-        return new Object[][]{{"orgId2", 2, tenantDomain, false, true}, // Create application in sub-organization.
-                {"orgId3", 2, tenantDomain, true, true},
+        return new Object[][]{
+                // Create application in sub-organization.
+                {"orgId2", 2, tenantDomain, false, true},
                 // Create an application in a sub-organization, and it's marked as a fragment app.
-                {"orgId4", 2, primaryTenantDomain, true, false}
+                {"orgId3", 2, tenantDomain, true, true},
                 // Create an application marked as a fragmented app by an internal process of primaryTenantDomain.
+                {"orgId4", 2, primaryTenantDomain, true, false}
         };
     }
 

--- a/components/org.wso2.carbon.identity.organization.management.application/src/test/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListenerTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/test/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListenerTest.java
@@ -20,7 +20,10 @@ package org.wso2.carbon.identity.organization.management.application.listener;
 
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -28,6 +31,7 @@ import org.wso2.carbon.identity.application.common.IdentityApplicationManagement
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.common.model.ServiceProviderProperty;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.organization.management.application.internal.OrgApplicationMgtDataHolder;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
@@ -49,9 +53,12 @@ public class FragmentApplicationMgtListenerTest {
     @InjectMocks
     private FragmentApplicationMgtListener fragmentApplicationMgtListener;
 
+    private MockedStatic<IdentityTenantUtil> mockedUtilities;
+
     private ServiceProvider serviceProvider;
-    private String tenantDomain;
-    private String userName;
+    private static String primaryTenantDomain = "primaryTenantDomain";
+    private static String tenantDomain = "sampleTenantDomain";
+    private static String userName = "sampleUser";
 
     @BeforeMethod
     public void setUp() {
@@ -59,35 +66,32 @@ public class FragmentApplicationMgtListenerTest {
         MockitoAnnotations.openMocks(this);
         serviceProvider = mock(ServiceProvider.class);
         OrgApplicationMgtDataHolder.getInstance().setOrganizationManager(organizationManager);
-        tenantDomain = "sampleTenantDomain";
-        userName = "sampleUser";
     }
 
     @DataProvider(name = "organizationHierarchyData")
     public Object[][] getOrganizationHierarchyData() {
 
         return new Object[][]{
-                {"orgId1", 0, false, false},
-                {"orgId2", 2, false, true},
-                {"orgId3", 2, true, false}
+                {"orgId1", 0, primaryTenantDomain, false}, // Test case with primary organization.
+                {"orgId2", 2, tenantDomain, true}, // Test case with sub-organization which cannot create applications.
+                {"orgId3", 2, primaryTenantDomain, false}
+                // Test case with sub-organization which can create applications.
         };
     }
 
     @Test(dataProvider = "organizationHierarchyData")
-    public void testDoPreCreateApplication(String organizationId, int hierarchyDepth, boolean subOrgCanCreateApp,
+    public void testDoPreCreateApplication(String organizationId, int hierarchyDepth, String requestInitiatedDomain,
                                            boolean expectException)
             throws IdentityApplicationManagementException, OrganizationManagementException {
 
         when(organizationManager.resolveOrganizationId(tenantDomain)).thenReturn(organizationId);
         when(organizationManager.getOrganizationDepthInHierarchy(organizationId)).thenReturn(hierarchyDepth);
-        // Set the property to true if the sub organization can create applications.
-        if (subOrgCanCreateApp) {
-            ServiceProviderProperty[] spProperties = new ServiceProviderProperty[2];
-            spProperties[0] = new ServiceProviderProperty();
-            spProperties[0].setName(IS_FRAGMENT_APP);
-            spProperties[0].setValue(String.valueOf(true));
-            when(serviceProvider.getSpProperties()).thenReturn(spProperties);
-        }
+        ServiceProviderProperty[] spProperties = new ServiceProviderProperty[1];
+        spProperties[0] = new ServiceProviderProperty();
+        spProperties[0].setName(IS_FRAGMENT_APP);
+        spProperties[0].setValue(String.valueOf(true));
+        when(serviceProvider.getSpProperties()).thenReturn(spProperties);
+        mockUtils(requestInitiatedDomain);
         try {
             boolean result = fragmentApplicationMgtListener.doPreCreateApplication(serviceProvider, tenantDomain,
                     userName);
@@ -95,6 +99,19 @@ public class FragmentApplicationMgtListenerTest {
         } catch (IdentityApplicationManagementClientException e) {
             assertTrue(expectException);
         }
+    }
+
+    private void mockUtils(String requestInitiatedDomain) {
+
+        mockedUtilities = Mockito.mockStatic(IdentityTenantUtil.class, Mockito.withSettings()
+                .defaultAnswer(Mockito.CALLS_REAL_METHODS));
+        mockedUtilities.when(() -> IdentityTenantUtil.getTenantDomainFromContext()).thenReturn(requestInitiatedDomain);
+    }
+
+    @AfterMethod
+    public void tearDown() {
+
+        mockedUtilities.close();
     }
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -227,6 +227,12 @@
                 <version>${mockito-core.version}</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-inline</artifactId>
+                <version>${mockito-core.version}</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -421,7 +421,7 @@
         <org.wso2.identity.organization.mgt.imp.pkg.version.range>[1.0.0,2.0.0)
         </org.wso2.identity.organization.mgt.imp.pkg.version.range>
 
-        <identity.organization.management.core.version>1.0.52</identity.organization.management.core.version>
+        <identity.organization.management.core.version>1.0.53</identity.organization.management.core.version>
         <org.wso2.identity.organization.mgt.core.imp.pkg.version.range>[1.0.0,2.0.0)
         </org.wso2.identity.organization.mgt.core.imp.pkg.version.range>
 


### PR DESCRIPTION
## Purpose
> Purpose of this is to restrict application creation in sub-organizations. 

## Goals
>  Restrict application creation in sub-organizations in PCC and IS+B2B connector setup.