### PR TITLE
Set skip logout consent prop to shared apps

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
@@ -139,7 +139,8 @@ public class FragmentApplicationMgtListener extends AbstractApplicationMgtListen
                 String sharedOrgId = getOrganizationManager().resolveOrganizationId(tenantDomain);
                 mainApplicationDO = getOrgApplicationMgtDAO()
                         .getMainApplication(serviceProvider.getApplicationResourceId(), sharedOrgId);
-
+                // Add the skip logout consent property to true for the shared application
+                serviceProvider.getLocalAndOutBoundAuthenticationConfig().setSkipLogoutConsent(true);
                 if (mainApplicationDO.isPresent()) {
                     /* Add User Attribute Section related configurations from the
                     main application to the shared application


### PR DESCRIPTION
## Purpose
- Setting the skipLogoutConsent property value to `true` for the shared application to skip the logout consent prompting when the logout is performed from the sub organizations.

## Goals
- Properly logout the user from the sub organization.

## Approach
- Set `skipLogoutConsent` property to `true` from the listener.