### PR TITLE
Add organization shared user listener

### DIFF
--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/pom.xml
@@ -115,6 +115,7 @@
                             org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
                             org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",
                             org.wso2.carbon.context;version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.identity.core;version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.core.util;version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.core.bean.context; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.event.handler; version="${carbon.identity.package.import.version.range}",
@@ -125,7 +126,9 @@
                             org.wso2.carbon.identity.organization.management.service.util;version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
                             org.wso2.carbon.identity.organization.management.service.exception;version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
                             org.wso2.carbon.user.api;version="${carbon.user.api.imp.pkg.version.range}",
+                            org.wso2.carbon.user.core;version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.user.core.common;version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.user.core.listener;version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.user.core.service;version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.user.core.util;version="${carbon.kernel.package.import.version.range}",
                         </Import-Package>

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/InvitationCoreService.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/InvitationCoreService.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.organization.user.invitation.management;
 
 import org.wso2.carbon.identity.organization.user.invitation.management.exception.UserInvitationMgtException;
 import org.wso2.carbon.identity.organization.user.invitation.management.models.Invitation;
+import org.wso2.carbon.user.api.UserStoreManager;
 
 import java.util.List;
 
@@ -81,4 +82,15 @@ public interface InvitationCoreService {
      * @throws UserInvitationMgtException If an error occurs while resending the invitation.
      */
     Invitation resendInvitation(String username, String domain) throws UserInvitationMgtException;
+
+    /**
+     * Delete the associations of the invited user.
+     *
+     * @param userId The ID of the invited user.
+     * @param userStoreManager The user store manager of the invited user.
+     * @return True if the associations are deleted successfully.
+     * @throws UserInvitationMgtException If an error occurs while deleting the associations.
+     */
+    boolean deleteInvitedUserAssociation(String userId, UserStoreManager userStoreManager)
+            throws UserInvitationMgtException;
 }

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/constant/SQLConstants.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/constant/SQLConstants.java
@@ -64,6 +64,10 @@ public class SQLConstants {
                 "USER_ORG_ID = ? AND INVITED_ORG_ID = ? AND EXPIRED_AT > CURRENT_TIMESTAMP";
         public static final String CREATE_USER_ASSOCIATION_TO_ORG = "INSERT INTO IDN_ORG_USER_ASSOCIATION(" +
                 "SHARED_USER_ID, SUB_ORG_ID, REAL_USER_ID, USER_RESIDENT_ORG_ID) VALUES(?, ?, ?, ?)";
+        public static final String DELETE_ORG_ASSOCIATION_FOR_SHARED_USER = "DELETE FROM " +
+                "IDN_ORG_USER_ASSOCIATION WHERE SHARED_USER_ID = ? AND SUB_ORG_ID = ?";
+        public static final String DELETE_ALL_ORG_ASSOCIATIONS_FOR_SHARED_USER = "DELETE FROM " +
+                "IDN_ORG_USER_ASSOCIATION WHERE REAL_USER_ID = ? AND USER_RESIDENT_ORG_ID = ?";
     }
 
     /**

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/constant/UserInvitationMgtConstants.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/constant/UserInvitationMgtConstants.java
@@ -101,6 +101,12 @@ public class UserInvitationMgtConstants {
         ERROR_CODE_ACCEPT_INVITATION("10024",
                 "Unable to accept the invitation.",
                 "Could not accept the invitation for the user %s."),
+        ERROR_CODE_GET_USER_CLAIMS("10025",
+                "Unable to remove the user.",
+                "Could not get the user claim: %s for the user: %s."),
+        ERROR_CODE_GET_PARENT_ORG("10026",
+                "Unable to get the parent organization.",
+                "Could not get the parent organization for the organization: %s."),
 
         // DAO layer errors
         ERROR_CODE_STORE_INVITATION("10001",
@@ -153,7 +159,12 @@ public class UserInvitationMgtConstants {
                 "Could not create organization association for user %s."),
         ERROR_CODE_GET_INVITATION_BY_CONF_CODE("10017",
                 "Unable to get the invitation.",
-                "Could not get the invitation with role assignments for confirmation code %s."),;
+                "Could not get the invitation with role assignments for confirmation code %s."),
+
+        // Event listener errors
+        ERROR_CODE_DELETE_INVITED_USER_ASSOCIATION("10400",
+                "Unable to delete invited user association.",
+                "Could not delete invited user association for user %s.");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/dao/UserInvitationDAO.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/dao/UserInvitationDAO.java
@@ -110,4 +110,26 @@ public interface UserInvitationDAO {
      */
     void createOrganizationAssociation(String realUserId, String residentOrgId, String sharedUserId,
                                        String sharedOrgId) throws UserInvitationMgtException;
+
+    /**
+     * Delete the invited organization user association to the child organization from the child organization.
+     *
+     * @param userId The user id of the invited organization user.
+     * @param organizationId The organization id of the invited/child organization.
+     * @return True if the association is deleted successfully.
+     * @throws UserInvitationMgtException If an error occurs while deleting the association.
+     */
+    boolean deleteOrgUserAssociationToSharedOrg(String userId, String organizationId)
+            throws UserInvitationMgtException;
+
+    /**
+     * Delete all the associations for the child organizations when the user is deleting from the parent organization.
+     *
+     * @param userId Actual user id of the user in the parent organization.
+     * @param organizationId The organization id of the parent organization.
+     * @return True if the associations are deleted successfully.
+     * @throws UserInvitationMgtException If an error occurs while deleting the associations.
+     */
+    boolean deleteAllAssociationsOfOrgUserToSharedOrgs(String userId, String organizationId)
+            throws UserInvitationMgtException;
 }

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/dao/UserInvitationDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/dao/UserInvitationDAOImpl.java
@@ -54,7 +54,9 @@ import static org.wso2.carbon.identity.organization.user.invitation.management.c
 import static org.wso2.carbon.identity.organization.user.invitation.management.constant.SQLConstants.SQLPlaceholders.COLUMN_NAME_USER_NAME;
 import static org.wso2.carbon.identity.organization.user.invitation.management.constant.SQLConstants.SQLPlaceholders.COLUMN_NAME_USER_ORG_ID;
 import static org.wso2.carbon.identity.organization.user.invitation.management.constant.SQLConstants.SQLQueries.CREATE_USER_ASSOCIATION_TO_ORG;
+import static org.wso2.carbon.identity.organization.user.invitation.management.constant.SQLConstants.SQLQueries.DELETE_ALL_ORG_ASSOCIATIONS_FOR_SHARED_USER;
 import static org.wso2.carbon.identity.organization.user.invitation.management.constant.SQLConstants.SQLQueries.DELETE_INVITATION_BY_INVITATION_ID;
+import static org.wso2.carbon.identity.organization.user.invitation.management.constant.SQLConstants.SQLQueries.DELETE_ORG_ASSOCIATION_FOR_SHARED_USER;
 import static org.wso2.carbon.identity.organization.user.invitation.management.constant.SQLConstants.SQLQueries.DELETE_ROLE_ASSIGNMENTS_BY_INVITATION_ID;
 import static org.wso2.carbon.identity.organization.user.invitation.management.constant.SQLConstants.SQLQueries.GET_ACTIVE_INVITATION_BY_USER;
 import static org.wso2.carbon.identity.organization.user.invitation.management.constant.SQLConstants.SQLQueries.GET_INVITATIONS_BY_INVITED_ORG_ID;
@@ -391,6 +393,40 @@ public class UserInvitationDAOImpl implements UserInvitationDAO {
             createOrgAssocPrepStat.executeUpdate();
         } catch (SQLException e) {
             throw handleServerException(ERROR_CODE_CREATE_ORG_ASSOC, sharedUserId, e);
+        }
+    }
+
+    @Override
+    public boolean deleteOrgUserAssociationToSharedOrg(String userId, String organizationId)
+            throws UserInvitationMgtException {
+
+        try (Connection connection = IdentityDatabaseUtil.getDBConnection(true);
+             PreparedStatement userOrgDeletePrepStat =
+                     connection.prepareStatement(DELETE_ORG_ASSOCIATION_FOR_SHARED_USER)) {
+            userOrgDeletePrepStat.setString(1, userId);
+            userOrgDeletePrepStat.setString(2, organizationId);
+            userOrgDeletePrepStat.executeUpdate();
+            connection.commit();
+            return true;
+        } catch (SQLException e) {
+            throw handleServerException(ERROR_CODE_GET_INVITATION_BY_USER, userId, e);
+        }
+    }
+
+    @Override
+    public boolean deleteAllAssociationsOfOrgUserToSharedOrgs(String userId, String organizationId)
+            throws UserInvitationMgtException {
+
+        try (Connection connection = IdentityDatabaseUtil.getDBConnection(true);
+             PreparedStatement userOrgDeletePrepStat =
+                     connection.prepareStatement(DELETE_ALL_ORG_ASSOCIATIONS_FOR_SHARED_USER)) {
+            userOrgDeletePrepStat.setString(1, userId);
+            userOrgDeletePrepStat.setString(2, organizationId);
+            userOrgDeletePrepStat.executeUpdate();
+            connection.commit();
+            return true;
+        } catch (SQLException e) {
+            throw handleServerException(ERROR_CODE_GET_INVITATION_BY_USER, userId, e);
         }
     }
 

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/internal/UserInvitationMgtServiceComponent.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/internal/UserInvitationMgtServiceComponent.java
@@ -33,6 +33,8 @@ import org.wso2.carbon.identity.organization.management.service.OrganizationMana
 import org.wso2.carbon.identity.organization.user.invitation.management.InvitationCoreService;
 import org.wso2.carbon.identity.organization.user.invitation.management.InvitationCoreServiceImpl;
 import org.wso2.carbon.identity.organization.user.invitation.management.handler.UserInvitationEventHandler;
+import org.wso2.carbon.identity.organization.user.invitation.management.listener.OrgSharedUserOperationEventListener;
+import org.wso2.carbon.user.core.listener.UserOperationEventListener;
 import org.wso2.carbon.user.core.service.RealmService;
 
 /**
@@ -57,6 +59,9 @@ public class UserInvitationMgtServiceComponent {
             bundleContext.registerService(AbstractEventHandler.class.getName(),
                     new UserInvitationEventHandler(), null);
             LOG.info("Organization User Invitation Handler activated successfully.");
+            bundleContext.registerService(UserOperationEventListener.class.getName(),
+                    new OrgSharedUserOperationEventListener(), null);
+            LOG.info("Shared Organization User Listener activated successfully.");
         } catch (Throwable e) {
             LOG.error("Error while activating Organization User Invitation Mgt Component", e);
         }

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/listener/OrgSharedUserOperationEventListener.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/listener/OrgSharedUserOperationEventListener.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.user.invitation.management.listener;
+
+import org.wso2.carbon.identity.core.AbstractIdentityUserOperationEventListener;
+import org.wso2.carbon.identity.organization.user.invitation.management.InvitationCoreService;
+import org.wso2.carbon.identity.organization.user.invitation.management.InvitationCoreServiceImpl;
+import org.wso2.carbon.identity.organization.user.invitation.management.exception.UserInvitationMgtException;
+import org.wso2.carbon.user.core.UserStoreException;
+import org.wso2.carbon.user.core.UserStoreManager;
+
+import static org.wso2.carbon.identity.organization.user.invitation.management.constant.UserInvitationMgtConstants.ErrorMessage.ERROR_CODE_DELETE_INVITED_USER_ASSOCIATION;
+
+/**
+ * Organization shared user operation event listener.
+ */
+public class OrgSharedUserOperationEventListener extends AbstractIdentityUserOperationEventListener {
+
+    @Override
+    public int getExecutionOrderId() {
+
+        return 160;
+    }
+
+    @Override
+    public boolean doPreDeleteUserWithID(String userID, UserStoreManager userStoreManager) throws UserStoreException {
+
+        if (!isEnable() || userStoreManager == null) {
+            return true;
+        }
+
+        InvitationCoreService invitationCoreService = new InvitationCoreServiceImpl();
+        try {
+            return invitationCoreService.deleteInvitedUserAssociation(userID, userStoreManager);
+        } catch (UserInvitationMgtException e) {
+            throw new UserStoreException(String.format(ERROR_CODE_DELETE_INVITED_USER_ASSOCIATION.getDescription(),
+                    userID), ERROR_CODE_DELETE_INVITED_USER_ASSOCIATION.getCode(), e);
+        }
+    }
+}


### PR DESCRIPTION
## Purpose
* $subject
* In this initial implementation, when a user is deleted then if there are any associations to the child organizations, they will be removed before deleting the user.