### PR TITLE
Improve organization user invitation and user sharing

### DIFF
--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/InvitationCoreService.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/InvitationCoreService.java
@@ -93,4 +93,16 @@ public interface InvitationCoreService {
      */
     boolean deleteInvitedUserAssociation(String userId, UserStoreManager userStoreManager)
             throws UserInvitationMgtException;
+
+    /**
+     * Checks whether the user claim values can be updated for the user.
+     *
+     * @param userID The ID of the user.
+     * @param profileName The profile name of the user.
+     * @param userStoreManager The user store manager of the user.
+     * @return True if the user claim values can be updated.
+     * @throws UserInvitationMgtException If an error occurs while checking the user claim values can be updated.
+     */
+    boolean isUpdateUserClaimValuesAllowed(String userID, String profileName, UserStoreManager userStoreManager)
+            throws UserInvitationMgtException;
 }

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/constant/SQLConstants.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/constant/SQLConstants.java
@@ -65,9 +65,11 @@ public class SQLConstants {
         public static final String CREATE_USER_ASSOCIATION_TO_ORG = "INSERT INTO IDN_ORG_USER_ASSOCIATION(" +
                 "SHARED_USER_ID, SUB_ORG_ID, REAL_USER_ID, USER_RESIDENT_ORG_ID) VALUES(?, ?, ?, ?)";
         public static final String DELETE_ORG_ASSOCIATION_FOR_SHARED_USER = "DELETE FROM " +
-                "IDN_ORG_USER_ASSOCIATION WHERE SHARED_USER_ID = ? AND SUB_ORG_ID = ?";
+                "IDN_ORG_USER_ASSOCIATION WHERE SHARED_USER_ID = ? AND USER_RESIDENT_ORG_ID = ?";
         public static final String DELETE_ALL_ORG_ASSOCIATIONS_FOR_SHARED_USER = "DELETE FROM " +
                 "IDN_ORG_USER_ASSOCIATION WHERE REAL_USER_ID = ? AND USER_RESIDENT_ORG_ID = ?";
+        public static final String GET_ALL_ORG_ASSOCIATIONS_FOR_SHARED_USER = "SELECT SHARED_USER_ID, SUB_ORG_ID " +
+                "FROM IDN_ORG_USER_ASSOCIATION WHERE REAL_USER_ID = ? AND USER_RESIDENT_ORG_ID = ?";
     }
 
     /**
@@ -88,5 +90,7 @@ public class SQLConstants {
         public static final String COLUMN_NAME_REDIRECT_URL = "USER_REDIRECT_URL";
         public static final String COLUMN_NAME_APP_ID = "APPLICATION_ID";
         public static final String COLUMN_NAME_ROLE_ID = "ROLE_ID";
+        public static final String COLUMN_NAME_SHARED_USER_ID = "SHARED_USER_ID";
+        public static final String COLUMN_NAME_SUB_ORG_ID = "SUB_ORG_ID";
     }
 }

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/constant/UserInvitationMgtConstants.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/constant/UserInvitationMgtConstants.java
@@ -55,6 +55,11 @@ public class UserInvitationMgtConstants {
     public static final int SQL_FK_CONSTRAINT_VIOLATION_ERROR_CODE = 547;
     public static final String INVITATION_EVENT_HANDLER_ENABLED = "UserInvitationEventHandler.enable";
 
+    // Configurations
+    public static final String ORG_USER_INVITATION_USER_DOMAIN = "OrganizationUserInvitation.PrimaryUserDomain";
+    public static final String ORG_USER_INVITATION_DEFAULT_REDIRECT_URL =
+            "OrganizationUserInvitation.DefaultRedirectURL";
+
     /**
      * Error messages for organization user invitation management related errors.
      */
@@ -112,6 +117,21 @@ public class UserInvitationMgtConstants {
         ERROR_CODE_INVALID_USER("10027",
                 "Invalid user identification provided.",
                 "Authenticated user %s is not entitled for the invitation."),
+        ERROR_CODE_GET_MANAGED_CLAIM("10028",
+                "Unable to get the claim.",
+                "Unable to get the managed org claim for user %s."),
+        ERROR_CODE_CONSTRUCT_REDIRECT_URL("10029",
+                "Unable to construct the redirect URL.",
+                "Unable to construct the redirect URL for invitation acceptance."),
+        ERROR_CODE_GET_ORG_ID_FROM_TENANT("10030",
+                "Unable to get the organization id.",
+                "Unable to get the organization id for the tenant %s."),
+        ERROR_CODE_GET_USER_STORE_MANAGER("10031",
+                "Unable to get the user store manager.",
+                "Unable to get the user store manager for the tenant."),
+        ERROR_CODE_GET_TENANT_FROM_ORG("10032",
+                "Unable to get the tenant domain.",
+                "Unable to get the tenant domain for the organization %s."),
 
         // DAO layer errors
         ERROR_CODE_STORE_INVITATION("10501",
@@ -168,11 +188,17 @@ public class UserInvitationMgtConstants {
         ERROR_CODE_STORE_ROLES_APP_ID_INVALID("10518",
                 "Unable to store the role assignments.",
                 "Provided application/s is/are not valid."),
+        ERROR_CODE_GET_ORG_ASSOCIATIONS_FOR_USER("10519",
+                "Unable to get the organization associations.",
+                "Unable to get the organization associations for the user %s."),
 
         // Event listener errors
         ERROR_CODE_DELETE_INVITED_USER_ASSOCIATION("10400",
                 "Unable to delete invited user association.",
-                "Could not delete invited user association for user %s.");
+                "Could not delete invited user association for user %s."),
+        ERROR_CODE_CHECK_USER_CLAIM_UPDATE_ALLOWED("10401",
+                   "Unable to check whether the update is allowed.",
+                   "Could not check whether the user claim update is allowed for user %s.");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/dao/UserInvitationDAO.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/dao/UserInvitationDAO.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.organization.user.invitation.management.dao;
 import org.wso2.carbon.identity.organization.user.invitation.management.exception.UserInvitationMgtException;
 import org.wso2.carbon.identity.organization.user.invitation.management.exception.UserInvitationMgtServerException;
 import org.wso2.carbon.identity.organization.user.invitation.management.models.Invitation;
+import org.wso2.carbon.identity.organization.user.invitation.management.models.SharedUserAssociation;
 
 import java.util.List;
 
@@ -131,5 +132,16 @@ public interface UserInvitationDAO {
      * @throws UserInvitationMgtException If an error occurs while deleting the associations.
      */
     boolean deleteAllAssociationsOfOrgUserToSharedOrgs(String userId, String organizationId)
+            throws UserInvitationMgtException;
+
+    /**
+     * Get all the associations for the child organizations when the user is deleting from the parent organization.
+     *
+     * @param userId Actual user id of the user in the parent organization.
+     * @param organizationId The organization id of the parent organization.
+     * @return True if the associations are deleted successfully.
+     * @throws UserInvitationMgtException If an error occurs while deleting the associations.
+     */
+    List<SharedUserAssociation> getAllAssociationsOfOrgUserToSharedOrgs(String userId, String organizationId)
             throws UserInvitationMgtException;
 }

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/listener/OrgSharedUserOperationEventListener.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/listener/OrgSharedUserOperationEventListener.java
@@ -25,6 +25,9 @@ import org.wso2.carbon.identity.organization.user.invitation.management.exceptio
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
 
+import java.util.Map;
+
+import static org.wso2.carbon.identity.organization.user.invitation.management.constant.UserInvitationMgtConstants.ErrorMessage.ERROR_CODE_CHECK_USER_CLAIM_UPDATE_ALLOWED;
 import static org.wso2.carbon.identity.organization.user.invitation.management.constant.UserInvitationMgtConstants.ErrorMessage.ERROR_CODE_DELETE_INVITED_USER_ASSOCIATION;
 
 /**
@@ -35,7 +38,7 @@ public class OrgSharedUserOperationEventListener extends AbstractIdentityUserOpe
     @Override
     public int getExecutionOrderId() {
 
-        return 160;
+        return 8;
     }
 
     @Override
@@ -51,6 +54,22 @@ public class OrgSharedUserOperationEventListener extends AbstractIdentityUserOpe
         } catch (UserInvitationMgtException e) {
             throw new UserStoreException(String.format(ERROR_CODE_DELETE_INVITED_USER_ASSOCIATION.getDescription(),
                     userID), ERROR_CODE_DELETE_INVITED_USER_ASSOCIATION.getCode(), e);
+        }
+    }
+
+    @Override
+    public boolean doPreSetUserClaimValuesWithID(String userID, Map<String, String> claims, String profileName,
+                                                 UserStoreManager userStoreManager) throws UserStoreException {
+
+        if (!isEnable() || userStoreManager == null) {
+            return true;
+        }
+        InvitationCoreService invitationCoreService = new InvitationCoreServiceImpl();
+        try {
+            return invitationCoreService.isUpdateUserClaimValuesAllowed(userID, profileName, userStoreManager);
+        } catch (UserInvitationMgtException e) {
+            throw new UserStoreException(String.format(ERROR_CODE_CHECK_USER_CLAIM_UPDATE_ALLOWED.getDescription(),
+                    userID), ERROR_CODE_CHECK_USER_CLAIM_UPDATE_ALLOWED.getCode(), e);
         }
     }
 

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/models/SharedUserAssociation.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/models/SharedUserAssociation.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.user.invitation.management.models;
+
+/**
+ * Model class to represent the shared user association.
+ */
+public class SharedUserAssociation {
+
+    private String sharedUserId;
+    private String sharedOrganizationId;
+
+    public String getSharedUserId() {
+
+        return sharedUserId;
+    }
+
+    public void setSharedUserId(String sharedUserId) {
+
+        this.sharedUserId = sharedUserId;
+    }
+
+    public String getSharedOrganizationId() {
+
+        return sharedOrganizationId;
+    }
+
+    public void setSharedOrganizationId(String sharedOrganizationId) {
+
+        this.sharedOrganizationId = sharedOrganizationId;
+    }
+}

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/test/java/org/wso2/carbon/identity/organization/user/invitation/management/InvitationCoreServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/test/java/org/wso2/carbon/identity/organization/user/invitation/management/InvitationCoreServiceImplTest.java
@@ -28,6 +28,7 @@ import org.wso2.carbon.base.CarbonBaseConstants;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.organization.user.invitation.management.dao.UserInvitationDAO;
 import org.wso2.carbon.identity.organization.user.invitation.management.dao.UserInvitationDAOImpl;
@@ -81,7 +82,8 @@ import static org.wso2.carbon.identity.organization.user.invitation.management.u
         IdentityDatabaseUtil.class,
         UserInvitationMgtDataHolder.class,
         IdentityTenantUtil.class,
-        UserInvitationMgtDataHolder.class})
+        UserInvitationMgtDataHolder.class,
+        IdentityUtil.class})
 public class InvitationCoreServiceImplTest extends PowerMockTestCase {
 
     private final UserInvitationDAO userInvitationDAO = new UserInvitationDAOImpl();
@@ -96,6 +98,7 @@ public class InvitationCoreServiceImplTest extends PowerMockTestCase {
         mockCarbonContextForTenant();
         mockStatic(IdentityTenantUtil.class);
         mockStatic(IdentityDatabaseUtil.class);
+        mockStatic(IdentityUtil.class);
 
         Connection connection1 = getConnection();
         Connection connection2 = getConnection();
@@ -274,6 +277,7 @@ public class InvitationCoreServiceImplTest extends PowerMockTestCase {
     private void populateH2Base(Connection connection, Invitation invitation) throws Exception {
 
         when(IdentityDatabaseUtil.getDBConnection(anyBoolean())).thenReturn(connection);
+        when(IdentityUtil.getProperty(anyString())).thenReturn("1440");
         userInvitationDAO.createInvitation(invitation);
     }
 


### PR DESCRIPTION
## Purpose
* $subject
* Added the `doPreSetUserClaimValuesWithID` to restrict the user claim update for shared users.
* Made the followings configurable.
  - Expiry time of the invitations.
  - Default user store domain for users in the parent organization.
  - Default user redirection URL for invitation acceptance.
* Improve `doPreDeleteUserWithID` listener.