### PR TITLE
Improve claim provider according to the organization bound token improvements

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.claim.provider/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.claim.provider/pom.xml
@@ -37,6 +37,10 @@
             <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
             <artifactId>org.wso2.carbon.identity.oauth</artifactId>
         </dependency>

--- a/components/org.wso2.carbon.identity.organization.management.claim.provider/src/main/java/org/wso2/carbon/identity/organization/management/claim/provider/OrganizationClaimProvider.java
+++ b/components/org.wso2.carbon.identity.organization.management.claim.provider/src/main/java/org/wso2/carbon/identity/organization/management/claim/provider/OrganizationClaimProvider.java
@@ -83,6 +83,7 @@ public class OrganizationClaimProvider implements ClaimProvider, JWTAccessTokenC
 
         String userResidentOrgId = oAuthTokenReqMessageContext.getAuthorizedUser().getUserResidentOrganization();
         String authorizedOrgId = oAuthTokenReqMessageContext.getAuthorizedUser().getAccessingOrganization();
+        // The below condition is not required once console is modeled as B2B app.
         if (StringUtils.isEmpty(authorizedOrgId)) {
             authorizedOrgId = resolveOrganizationId(oAuthTokenReqMessageContext.getAuthorizedUser().getTenantDomain());
         }

--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,11 @@
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
                 <artifactId>org.wso2.carbon.identity.oauth</artifactId>
                 <version>${identity.inbound.auth.oauth.version}</version>
@@ -494,7 +499,7 @@
         <carbon.multitenancy.package.import.version.range>[4.7.0,5.0.0)
         </carbon.multitenancy.package.import.version.range>
 
-        <carbon.identity.framework.version>5.25.369</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.390-SNAPSHOT</carbon.identity.framework.version>
         <carbon.identity.package.import.version.range>[5.20.0, 7.0.0)
         </carbon.identity.package.import.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -499,7 +499,7 @@
         <carbon.multitenancy.package.import.version.range>[4.7.0,5.0.0)
         </carbon.multitenancy.package.import.version.range>
 
-        <carbon.identity.framework.version>5.25.390-SNAPSHOT</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.396</carbon.identity.framework.version>
         <carbon.identity.package.import.version.range>[5.20.0, 7.0.0)
         </carbon.identity.package.import.version.range>
 


### PR DESCRIPTION
## Purpose

According to the organization bound token improvement, the user accessing organization should be fetch from the newly introduced attributes of the authenticated user object. 
Also the user's resident organization information also need to fetched and added to the ID token as an additional claim.

### Related Issues.
- https://github.com/wso2/product-is/issues/16365

### When should this PR be merged

Depends on
- https://github.com/wso2/carbon-identity-framework/pull/4915