### PR TITLE
Revoke active access token when unsharing a shared app

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManagerImpl.java
@@ -304,7 +304,7 @@ public class OrgApplicationManagerImpl implements OrgApplicationManager {
     }
 
     /**
-     * Revoke access token generated for a shared application.
+     * Revoke access tokens issued for a shared application.
      *
      * @param rootOrganizationId   Root organization id.
      * @param rootApplicationId    Root application id.

--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManagerImpl.java
@@ -309,6 +309,7 @@ public class OrgApplicationManagerImpl implements OrgApplicationManager {
      * @param rootOrganizationId   Root organization id.
      * @param rootApplicationId    Root application id.
      * @param sharedOrganizationId Shared organization id.
+     * @throws OrganizationManagementException Organization management exception.
      */
     private void revokeAccessTokensOfSharedApp(String rootOrganizationId, String rootApplicationId,
                                                String sharedOrganizationId) throws OrganizationManagementException {


### PR DESCRIPTION
## Purpose
When unsharing a shared app, the access token associated with the shared app will be revoked with this effort.

### Note:
This PR should be merged after [this PR](https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2171) got merged and released.
