### PR TITLE
Create root organization for tenant created without organizations.

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.tenant.association/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.tenant.association/pom.xml
@@ -43,6 +43,10 @@
             <groupId>org.wso2.carbon.identity.organization.management</groupId>
             <artifactId>org.wso2.carbon.identity.organization.management.role.management.service</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -79,6 +83,9 @@
                             org.wso2.carbon.identity.organization.management.role.management.service.models;version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
                             org.wso2.carbon.identity.organization.management.service.exception;version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
                             org.wso2.carbon.identity.organization.management.service.util;version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.management.service; version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.management.service.constant; version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.management.service.model; version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
                         </Import-Package>
                     </instructions>
                 </configuration>

--- a/components/org.wso2.carbon.identity.organization.management.tenant.association/src/main/java/org/wso2/carbon/identity/organization/management/tenant/association/internal/TenantAssociationDataHolder.java
+++ b/components/org.wso2.carbon.identity.organization.management.tenant.association/src/main/java/org/wso2/carbon/identity/organization/management/tenant/association/internal/TenantAssociationDataHolder.java
@@ -31,7 +31,6 @@ public class TenantAssociationDataHolder {
     private static RoleManager roleManager;
     private static OrganizationManager organizationManager;
 
-
     private TenantAssociationDataHolder() {
 
     }

--- a/components/org.wso2.carbon.identity.organization.management.tenant.association/src/main/java/org/wso2/carbon/identity/organization/management/tenant/association/internal/TenantAssociationDataHolder.java
+++ b/components/org.wso2.carbon.identity.organization.management.tenant.association/src/main/java/org/wso2/carbon/identity/organization/management/tenant/association/internal/TenantAssociationDataHolder.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.organization.management.tenant.association.internal;
 
 import org.wso2.carbon.identity.organization.management.role.management.service.RoleManager;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.user.core.service.RealmService;
 
 /**
@@ -28,6 +29,8 @@ public class TenantAssociationDataHolder {
 
     private static RealmService realmService;
     private static RoleManager roleManager;
+    private static OrganizationManager organizationManager;
+
 
     private TenantAssociationDataHolder() {
 
@@ -74,5 +77,15 @@ public class TenantAssociationDataHolder {
     public static void setRoleManager(RoleManager roleManager) {
 
         TenantAssociationDataHolder.roleManager = roleManager;
+    }
+
+    public static OrganizationManager getOrganizationManager() {
+
+        return organizationManager;
+    }
+
+    public static void setOrganizationManager(OrganizationManager organizationManager) {
+
+        TenantAssociationDataHolder.organizationManager = organizationManager;
     }
 }

--- a/components/org.wso2.carbon.identity.organization.management.tenant.association/src/main/java/org/wso2/carbon/identity/organization/management/tenant/association/internal/TenantAssociationServiceComponent.java
+++ b/components/org.wso2.carbon.identity.organization.management.tenant.association/src/main/java/org/wso2/carbon/identity/organization/management/tenant/association/internal/TenantAssociationServiceComponent.java
@@ -28,6 +28,7 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.identity.organization.management.role.management.service.RoleManager;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.organization.management.tenant.association.listeners.TenantAssociationManagementListener;
 import org.wso2.carbon.stratos.common.listeners.TenantMgtListener;
 import org.wso2.carbon.user.core.service.RealmService;
@@ -89,5 +90,20 @@ public class TenantAssociationServiceComponent {
     protected void unsetRoleManagerService(RoleManager roleManagerService) {
 
         TenantAssociationDataHolder.setRoleManager(null);
+    }
+
+    @Reference(name = "identity.organization.management.component",
+            service = OrganizationManager.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetOrganizationManager")
+    protected void setOrganizationManager(OrganizationManager organizationManager) {
+
+        TenantAssociationDataHolder.setOrganizationManager(organizationManager);
+    }
+
+    protected void unsetOrganizationManager(OrganizationManager organizationManager) {
+
+        TenantAssociationDataHolder.setOrganizationManager(null);
     }
 }

--- a/components/org.wso2.carbon.identity.organization.management.tenant.association/src/main/java/org/wso2/carbon/identity/organization/management/tenant/association/listeners/TenantAssociationManagementListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.tenant.association/src/main/java/org/wso2/carbon/identity/organization/management/tenant/association/listeners/TenantAssociationManagementListener.java
@@ -72,7 +72,8 @@ public class TenantAssociationManagementListener extends AbstractIdentityTenantM
             Tenant tenant = realmService.getTenantManager().getTenant(tenantId);
             // Association will be created only if the tenant created with an organization id.
             String organizationID = tenant.getAssociatedOrganizationUUID();
-            if (organizationID == null || getOrganizationManager().getOrganizationDepthInHierarchy(organizationID) == -1) {
+            if (organizationID == null ||
+                    getOrganizationManager().getOrganizationDepthInHierarchy(organizationID) == -1) {
                 Organization organization = new Organization();
                 if (StringUtils.isBlank(organizationID)) {
                     organizationID = UUID.randomUUID().toString();

--- a/components/org.wso2.carbon.identity.organization.management.tenant.association/src/main/java/org/wso2/carbon/identity/organization/management/tenant/association/listeners/TenantAssociationManagementListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.tenant.association/src/main/java/org/wso2/carbon/identity/organization/management/tenant/association/listeners/TenantAssociationManagementListener.java
@@ -24,7 +24,10 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.core.AbstractIdentityTenantMgtListener;
 import org.wso2.carbon.identity.organization.management.role.management.service.models.Role;
 import org.wso2.carbon.identity.organization.management.role.management.service.models.User;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.identity.organization.management.service.model.Organization;
 import org.wso2.carbon.identity.organization.management.service.util.Utils;
 import org.wso2.carbon.identity.organization.management.tenant.association.Constants;
 import org.wso2.carbon.identity.organization.management.tenant.association.internal.TenantAssociationDataHolder;
@@ -35,6 +38,7 @@ import org.wso2.carbon.user.core.service.RealmService;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.UUID;
 
 import static org.wso2.carbon.identity.organization.management.role.management.service.constant.RoleManagementConstants.ORG_ADMINISTRATOR_ROLE;
 import static org.wso2.carbon.identity.organization.management.role.management.service.constant.RoleManagementConstants.ORG_CREATOR_ROLE;
@@ -68,7 +72,16 @@ public class TenantAssociationManagementListener extends AbstractIdentityTenantM
             Tenant tenant = realmService.getTenantManager().getTenant(tenantId);
             // Association will be created only if the tenant created with an organization id.
             String organizationID = tenant.getAssociatedOrganizationUUID();
-            if (StringUtils.isBlank(organizationID)) {
+            if (organizationID == null || getOrganizationManager().getOrganizationDepthInHierarchy(organizationID) == -1) {
+                Organization organization = new Organization();
+                if (StringUtils.isBlank(organizationID)) {
+                    organizationID = UUID.randomUUID().toString();
+                }
+                organization.setId(organizationID);
+                organization.setName(tenantInfo.getTenantDomain());
+                organization.setStatus(OrganizationManagementConstants.OrganizationStatus.ACTIVE.name());
+                organization.setType(OrganizationManagementConstants.OrganizationTypes.TENANT.name());
+                getOrganizationManager().addRootOrganization(tenant.getId(), organization);
                 return;
             }
             // If the organization uses carbon roles, this organization association is not required.
@@ -136,5 +149,10 @@ public class TenantAssociationManagementListener extends AbstractIdentityTenantM
         orgAdministratorRolePermissions.add(Constants.ADMINISTRATOR_ROLE_PERMISSION);
         organizationAdministratorRole.setPermissions(orgAdministratorRolePermissions);
         return organizationAdministratorRole;
+    }
+
+    private OrganizationManager getOrganizationManager() {
+
+        return TenantAssociationDataHolder.getOrganizationManager();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -491,7 +491,7 @@
         <org.wso2.identity.organization.mgt.imp.pkg.version.range>[1.0.0,2.0.0)
         </org.wso2.identity.organization.mgt.imp.pkg.version.range>
 
-        <identity.organization.management.core.version>1.0.71-SNAPSHOT</identity.organization.management.core.version>
+        <identity.organization.management.core.version>1.0.71</identity.organization.management.core.version>
         <org.wso2.identity.organization.mgt.core.imp.pkg.version.range>[1.0.0,2.0.0)
         </org.wso2.identity.organization.mgt.core.imp.pkg.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -491,7 +491,7 @@
         <org.wso2.identity.organization.mgt.imp.pkg.version.range>[1.0.0,2.0.0)
         </org.wso2.identity.organization.mgt.imp.pkg.version.range>
 
-        <identity.organization.management.core.version>1.0.71</identity.organization.management.core.version>
+        <identity.organization.management.core.version>1.0.72</identity.organization.management.core.version>
         <org.wso2.identity.organization.mgt.core.imp.pkg.version.range>[1.0.0,2.0.0)
         </org.wso2.identity.organization.mgt.core.imp.pkg.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -491,7 +491,7 @@
         <org.wso2.identity.organization.mgt.imp.pkg.version.range>[1.0.0,2.0.0)
         </org.wso2.identity.organization.mgt.imp.pkg.version.range>
 
-        <identity.organization.management.core.version>1.0.69</identity.organization.management.core.version>
+        <identity.organization.management.core.version>1.0.71-SNAPSHOT</identity.organization.management.core.version>
         <org.wso2.identity.organization.mgt.core.imp.pkg.version.range>[1.0.0,2.0.0)
         </org.wso2.identity.organization.mgt.core.imp.pkg.version.range>
 


### PR DESCRIPTION
## Purpose

When tenants are created by tenant management API, those tenants are not associated to an organization. In order to provide the B2B capabilities for those tenants, those tenants should be associated for a root organization where an organization hierarchy can be made.

The tenant's associated organization ID can be either defined at tenant creation level or if not a generated UUID is set as its root organization ID.

### Depends on
- https://github.com/wso2/identity-organization-management-core/pull/89

### Related Issues
- https://github.com/wso2/product-is/issues/16712