### PR TITLE
New services to derive whether app is shared to a given org /  get main app id

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManager.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManager.java
@@ -104,6 +104,36 @@ public interface OrgApplicationManager {
     }
 
     /**
+     * Check whether the application is shared with the given organization.
+     *
+     * @param mainAppId   UUID of the main application.
+     * @param ownerOrgId  Identifier of the organization owning the application.
+     * @param sharedOrgId Identifier of the organization which checking whether app is shared or not.
+     * @return True if the application is shared with the given organization.
+     * @throws OrganizationManagementException If errors occurred when checking whether the application is shared
+     *                                         with the given organization.
+     */
+    default boolean isApplicationSharedWithGivenOrganization(String mainAppId, String ownerOrgId, String sharedOrgId)
+            throws OrganizationManagementException {
+
+        return false;
+    }
+
+    /**
+     * Get the main application id for given shared application.
+     *
+     * @param sharedAppId Shared application id.
+     * @param sharedOrgId Organization id of the shared application.
+     * @return Main application id.
+     * @throws OrganizationManagementException If errors occurred when getting the main application id.
+     */
+    default String getMainApplicationIdForGivenSharedApp(String sharedAppId, String sharedOrgId)
+            throws OrganizationManagementException {
+
+        return null;
+    }
+
+    /**
      * Share the application to an organization.
      *
      * @param ownerOrgId           Identifier of the organization owning the application.

--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManagerImpl.java
@@ -56,6 +56,7 @@ import org.wso2.carbon.identity.oauth.dto.ScopeDTO;
 import org.wso2.carbon.identity.organization.management.application.dao.OrgApplicationMgtDAO;
 import org.wso2.carbon.identity.organization.management.application.internal.OrgApplicationMgtDataHolder;
 import org.wso2.carbon.identity.organization.management.application.listener.ApplicationSharingManagerListener;
+import org.wso2.carbon.identity.organization.management.application.model.MainApplicationDO;
 import org.wso2.carbon.identity.organization.management.application.model.SharedApplication;
 import org.wso2.carbon.identity.organization.management.application.model.SharedApplicationDO;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
@@ -395,6 +396,23 @@ public class OrgApplicationManagerImpl implements OrgApplicationManager {
         } catch (IdentityApplicationManagementException e) {
             throw handleServerException(ERROR_CODE_ERROR_RESOLVING_SHARED_APPLICATION, e, mainAppUUID, ownerOrgId);
         }
+    }
+
+    @Override
+    public boolean isApplicationSharedWithGivenOrganization(String mainAppId, String ownerOrgId, String sharedOrgId)
+            throws OrganizationManagementException {
+
+        return resolveSharedApp(mainAppId, ownerOrgId, sharedOrgId).isPresent();
+    }
+
+    @Override
+    public String getMainApplicationIdForGivenSharedApp(String sharedAppId, String sharedOrgId)
+            throws OrganizationManagementException {
+
+        return getOrgApplicationMgtDAO()
+                .getMainApplication(sharedAppId, sharedOrgId)
+                .map(MainApplicationDO::getMainApplicationId)
+                .orElse(null);
     }
 
     /**


### PR DESCRIPTION
## Purpose
Added two new services:
1. check whether a given main app is shared with a given org
2. retrieve the main application id for a given shared app

Part of: https://github.com/wso2/product-is/issues/16363

