### PR TITLE
Introduce pre add user validations for email domain discovery feature

### DIFF
--- a/components/org.wso2.carbon.identity.organization.discovery.service/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.discovery.service/pom.xml
@@ -72,6 +72,7 @@
                             org.apache.commons.logging;version="${org.apache.commons.logging.imp.pkg.version.range}",
                             org.osgi.framework;version="${osgi.framework.imp.pkg.version.range}",
                             org.osgi.service.component;version="${osgi.service.component.imp.pkg.version.range}",
+                            org.wso2.carbon.context;version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.database.utils.jdbc;version="${org.wso2.carbon.database.utils.version.range}",
                             org.wso2.carbon.database.utils.jdbc.exceptions;version="${org.wso2.carbon.database.utils.version.range}",
                             org.wso2.carbon.identity.organization.config.service;version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
@@ -83,7 +84,11 @@
                             org.wso2.carbon.identity.organization.management.service;version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
                             org.wso2.carbon.identity.organization.management.service.constant;version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
                             org.wso2.carbon.identity.organization.management.service.exception;version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
-                            org.wso2.carbon.identity.organization.management.service.util;version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}"
+                            org.wso2.carbon.identity.organization.management.service.util;version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.core;version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.core.util;version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.user.core;version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.user.core.listener;version="${carbon.kernel.package.import.version.range}"
                         </Import-Package>
                     </instructions>
                 </configuration>

--- a/components/org.wso2.carbon.identity.organization.discovery.service/src/main/java/org/wso2/carbon/identity/organization/discovery/service/AttributeBasedOrganizationDiscoveryHandler.java
+++ b/components/org.wso2.carbon.identity.organization.discovery.service/src/main/java/org/wso2/carbon/identity/organization/discovery/service/AttributeBasedOrganizationDiscoveryHandler.java
@@ -20,6 +20,8 @@ package org.wso2.carbon.identity.organization.discovery.service;
 
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 
+import java.util.List;
+
 /**
  * Interface for handling organization discovery types.
  */
@@ -50,4 +52,12 @@ public interface AttributeBasedOrganizationDiscoveryHandler {
      * @return The extracted attribute value.
      */
     String extractAttributeValue(String discoveryInput);
+
+    /**
+     * Get the list of validations that are required for events triggered during organization discovery related
+     * operations.
+     *
+     * @return the list of events.
+     */
+    List<String> requiredEventValidations();
 }

--- a/components/org.wso2.carbon.identity.organization.discovery.service/src/main/java/org/wso2/carbon/identity/organization/discovery/service/EmailDomainBasedDiscoveryHandler.java
+++ b/components/org.wso2.carbon.identity.organization.discovery.service/src/main/java/org/wso2/carbon/identity/organization/discovery/service/EmailDomainBasedDiscoveryHandler.java
@@ -31,6 +31,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import static org.wso2.carbon.identity.organization.discovery.service.constant.DiscoveryConstants.PRE_ADD_USER_EMAIL_DOMAIN_VALIDATE;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_DISCOVERY_CONFIG_DISABLED;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_RETRIEVING_DISCOVERY_CONFIGURATION;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.getOrganizationId;
@@ -80,5 +81,11 @@ public class EmailDomainBasedDiscoveryHandler implements AttributeBasedOrganizat
             return emailSplit[1];
         }
         return null;
+    }
+
+    @Override
+    public List<String> requiredEventValidations() {
+
+        return Collections.singletonList(PRE_ADD_USER_EMAIL_DOMAIN_VALIDATE);
     }
 }

--- a/components/org.wso2.carbon.identity.organization.discovery.service/src/main/java/org/wso2/carbon/identity/organization/discovery/service/OrganizationDiscoveryManager.java
+++ b/components/org.wso2.carbon.identity.organization.discovery.service/src/main/java/org/wso2/carbon/identity/organization/discovery/service/OrganizationDiscoveryManager.java
@@ -89,6 +89,20 @@ public interface OrganizationDiscoveryManager {
     boolean isDiscoveryAttributeValueAvailable(String type, String value) throws OrganizationManagementException;
 
     /**
+     * Check if the given discovery attribute is already mapped to an organization within the hierarchy under the given
+     * organization.
+     *
+     * @param organizationId The organization ID.
+     * @param type           The organization discovery attribute type.
+     * @param value          The organization discovery attribute value.
+     * @return If the discovery attribute already exists within the hierarchy.
+     * @throws OrganizationManagementException The exception thrown when checking if the discovery attribute already
+     *                                         exists within the hierarchy.
+     */
+    boolean isDiscoveryAttributeValueAvailable(String organizationId, String type, String value) throws
+            OrganizationManagementException;
+
+    /**
      * List the discovery attributes of all the organizations under the root organization.
      *
      * @return The discovery attributes of the organizations.

--- a/components/org.wso2.carbon.identity.organization.discovery.service/src/main/java/org/wso2/carbon/identity/organization/discovery/service/OrganizationDiscoveryManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.discovery.service/src/main/java/org/wso2/carbon/identity/organization/discovery/service/OrganizationDiscoveryManagerImpl.java
@@ -124,6 +124,14 @@ public class OrganizationDiscoveryManagerImpl implements OrganizationDiscoveryMa
     }
 
     @Override
+    public boolean isDiscoveryAttributeValueAvailable(String organizationId, String type, String value)
+            throws OrganizationManagementException {
+
+        return !organizationDiscoveryDAO.isDiscoveryAttributeExistInHierarchy(false, organizationId,
+                null, type, Collections.singletonList(value));
+    }
+
+    @Override
     public Map<String, List<OrgDiscoveryAttribute>> getOrganizationsDiscoveryAttributes()
             throws OrganizationManagementException {
 

--- a/components/org.wso2.carbon.identity.organization.discovery.service/src/main/java/org/wso2/carbon/identity/organization/discovery/service/constant/DiscoveryConstants.java
+++ b/components/org.wso2.carbon.identity.organization.discovery.service/src/main/java/org/wso2/carbon/identity/organization/discovery/service/constant/DiscoveryConstants.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.discovery.service.constant;
+
+/**
+ * This class holds the constants related to organization discovery service.
+ */
+public class DiscoveryConstants {
+
+    public static final String ENABLE_CONFIG = ".enable";
+    public static final String PRE_ADD_USER_EMAIL_DOMAIN_VALIDATE = "PRE_ADD_USER_EMAIL_DOMAIN_VALIDATE";
+}

--- a/components/org.wso2.carbon.identity.organization.discovery.service/src/main/java/org/wso2/carbon/identity/organization/discovery/service/internal/OrganizationDiscoveryServiceComponent.java
+++ b/components/org.wso2.carbon.identity.organization.discovery.service/src/main/java/org/wso2/carbon/identity/organization/discovery/service/internal/OrganizationDiscoveryServiceComponent.java
@@ -32,7 +32,9 @@ import org.wso2.carbon.identity.organization.discovery.service.AttributeBasedOrg
 import org.wso2.carbon.identity.organization.discovery.service.EmailDomainBasedDiscoveryHandler;
 import org.wso2.carbon.identity.organization.discovery.service.OrganizationDiscoveryManager;
 import org.wso2.carbon.identity.organization.discovery.service.OrganizationDiscoveryManagerImpl;
+import org.wso2.carbon.identity.organization.discovery.service.listener.OrganizationDiscoveryUserOperationListener;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.user.core.listener.UserOperationEventListener;
 
 /**
  * Service component class for the organization discovery service.
@@ -53,6 +55,8 @@ public class OrganizationDiscoveryServiceComponent {
         AttributeBasedOrganizationDiscoveryHandler emailDomainDiscovery = new EmailDomainBasedDiscoveryHandler();
         bundleContext.registerService(AttributeBasedOrganizationDiscoveryHandler.class.getName(), emailDomainDiscovery,
                 null);
+        bundleContext.registerService(UserOperationEventListener.class.getName(),
+                new OrganizationDiscoveryUserOperationListener(), null);
         LOG.info("Organization discovery service component activated successfully.");
     }
 


### PR DESCRIPTION
Depends on https://github.com/wso2/identity-organization-management-core/pull/95
Related PR: https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/488

**Scenario 1**: Organization has mapped domains. A user is added with an email domain that is not associated with this organization.

https://github.com/wso2-extensions/identity-organization-management/assets/24982871/c9028422-002a-4419-9793-db3db54c46cb



**Scenario 2**: Organization doesn't have any mapped domains. A user is added with an email domain that is associated with a different organization.

https://github.com/wso2-extensions/identity-organization-management/assets/24982871/c8855e26-c908-42e1-9898-318a19c50638


