### PR TITLE
Add util method to get the user ID of an associated user

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.authz.service/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.authz.service/pom.xml
@@ -1,18 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2022, WSO2 Inc. (http://www.wso2.com).
+  ~ Copyright (c) 2022-2023, WSO2 LLC. (http://www.wso2.com).
   ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
   ~ http://www.apache.org/licenses/LICENSE-2.0
   ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -59,6 +61,10 @@
             <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
             <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.organization.user.sharing</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -101,6 +107,8 @@
                             org.wso2.carbon.identity.organization.management.authz.service.handler;version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
                             org.wso2.carbon.identity.organization.management.service.authz;version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
                             org.wso2.carbon.identity.organization.management.service.exception;version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.management.organization.user.sharing.util;version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.management.organization.user.sharing.models;version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
                             org.wso2.carbon.user.api; version="${carbon.user.api.imp.pkg.version.range}",
                             org.wso2.carbon.user.core;version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.user.core.common;version="${carbon.kernel.package.import.version.range}",

--- a/components/org.wso2.carbon.identity.organization.management.authz.service/src/main/java/org/wso2/carbon/identity/organization/management/authz/service/handler/OrganizationManagementAuthzHandler.java
+++ b/components/org.wso2.carbon.identity.organization.management.authz.service/src/main/java/org/wso2/carbon/identity/organization/management/authz/service/handler/OrganizationManagementAuthzHandler.java
@@ -161,8 +161,8 @@ public class OrganizationManagementAuthzHandler extends AuthorizationHandler {
         try {
             AbstractUserStoreManager userStoreManager = (AbstractUserStoreManager) getUserStoreManager(user);
             String userId = userStoreManager.getUser(null, user.getUserName()).getUserID();
-            Optional<String> optionalUserId = OrganizationSharedUserUtil
-                    .fetchUserIdOfAssociatedUser(userId, orgId);
+            Optional<String> optionalUserId =
+                    OrganizationSharedUserUtil.getUserIdOfAssociatedUserByOrgId(userId, orgId);
             return optionalUserId.orElse(userId);
         } catch (UserStoreException | OrganizationManagementException e) {
             throw new OrganizationManagementAuthzServiceServerException(e);

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/internal/OrganizationUserSharingDataHolder.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/internal/OrganizationUserSharingDataHolder.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.organization.management.organization.user.sharing.internal;
 
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.OrganizationUserSharingService;
 import org.wso2.carbon.identity.organization.management.role.management.service.RoleManager;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.user.core.service.RealmService;
@@ -31,6 +32,7 @@ public class OrganizationUserSharingDataHolder {
     private RealmService realmService;
     private OrganizationManager organizationManager;
     private RoleManager roleManager;
+    private OrganizationUserSharingService organizationUserSharingService;
 
     public static OrganizationUserSharingDataHolder getInstance() {
 
@@ -95,5 +97,25 @@ public class OrganizationUserSharingDataHolder {
     public void setRoleManager(RoleManager roleManager) {
 
         this.roleManager = roleManager;
+    }
+
+    /**
+     * Get the organization user sharing service.
+     *
+     * @return OrganizationUserSharingService organization user sharing service.
+     */
+    public OrganizationUserSharingService getOrganizationUserSharingService() {
+
+        return organizationUserSharingService;
+    }
+
+    /**
+     * Set the organization user sharing service.
+     *
+     * @param organizationUserSharingService Organization user sharing service.
+     */
+    public void setOrganizationUserSharingService(OrganizationUserSharingService organizationUserSharingService) {
+
+        this.organizationUserSharingService = organizationUserSharingService;
     }
 }

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/internal/OrganizationUserSharingServiceComponent.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/internal/OrganizationUserSharingServiceComponent.java
@@ -52,8 +52,11 @@ public class OrganizationUserSharingServiceComponent {
     protected void activate(ComponentContext componentContext) {
 
         BundleContext bundleContext = componentContext.getBundleContext();
-        bundleContext.registerService(OrganizationUserSharingService.class.getName(),
-                new OrganizationUserSharingServiceImpl(), null);
+        OrganizationUserSharingService organizationUserSharingService = new OrganizationUserSharingServiceImpl();
+        OrganizationUserSharingDataHolder.getInstance()
+                .setOrganizationUserSharingService(organizationUserSharingService);
+        bundleContext.registerService(OrganizationUserSharingService.class.getName(), organizationUserSharingService,
+                null);
         bundleContext.registerService(UserOperationEventListener.class.getName(),
                 new SharedUserOperationEventListener(), null);
         bundleContext.registerService(AbstractEventHandler.class.getName(),

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/util/OrganizationSharedUserUtil.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/util/OrganizationSharedUserUtil.java
@@ -43,10 +43,13 @@ public class OrganizationSharedUserUtil {
     }
 
 
-    public static Optional<String> fetchUserIdOfAssociatedUser(String userId, String accessingOrgId)
+    /**
+     * Get the user ID of the associated user by the organization ID.
+     */
+    public static Optional<String> getUserIdOfAssociatedUserByOrgId(String associatedUserId, String orgId)
             throws OrganizationManagementException {
 
         return Optional.ofNullable(OrganizationUserSharingDataHolder.getInstance().getOrganizationUserSharingService()
-                .getUserAssociationOfAssociatedUserByOrgId(userId, accessingOrgId).getUserId());
+                .getUserAssociationOfAssociatedUserByOrgId(associatedUserId, orgId).getUserId());
     }
 }

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/util/OrganizationSharedUserUtil.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/util/OrganizationSharedUserUtil.java
@@ -18,10 +18,13 @@
 
 package org.wso2.carbon.identity.organization.management.organization.user.sharing.util;
 
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.internal.OrganizationUserSharingDataHolder;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
 
 import java.util.Map;
+import java.util.Optional;
 
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.CLAIM_MANAGED_ORGANIZATION;
 
@@ -39,4 +42,11 @@ public class OrganizationSharedUserUtil {
         return claimsMap.get(CLAIM_MANAGED_ORGANIZATION);
     }
 
+
+    public static Optional<String> fetchUserIdOfAssociatedUser(String userId, String accessingOrgId)
+            throws OrganizationManagementException {
+
+        return Optional.ofNullable(OrganizationUserSharingDataHolder.getInstance().getOrganizationUserSharingService()
+                .getUserAssociationOfAssociatedUserByOrgId(userId, accessingOrgId).getUserId());
+    }
 }


### PR DESCRIPTION
## Purpose
- Added a  util method to resolve the user ID if the given user ID is an associated user ID of the given organization.
- Used that util in the organization management authorization handler which is based on the user permissions.