### PR TITLE
Class def not found error fix

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.application/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.application/pom.xml
@@ -188,6 +188,7 @@
                             org.wso2.carbon.identity.event.services; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.role.v2.mgt.core.*;
                             version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon; version="${carbon.kernel.package.import.version.range}",
                         </Import-Package>
                     </instructions>
                 </configuration>


### PR DESCRIPTION
## Purpose
```
ERROR {org.wso2.carbon.identity.api.dispatcher.core.DefaultExceptionMapper} - Server encountered an error while serving the request. java.lang.NoClassDefFoundError: org/wso2/carbon/CarbonConstants
    at org.wso2.carbon.identity.organization.management.application.listener.FragmentApplicationMgtListener.doPostGetServiceProvider(FragmentApplicationMgtListener.java:247)
    at org.wso2.carbon.identity.application.mgt.listener.DefaultApplicationResourceMgtListener.doPostGetApplicationByResourceId(DefaultApplicationResourceMgtListener.java:189)
```
Fix the class def not found error introduced with https://github.com/wso2-extensions/identity-organization-management/pull/275

Part of https://github.com/wso2/product-is/issues/16363