### PR TITLE
Get user resident organization from carbon context

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/SharingOrganizationCreatorUserEventHandler.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/SharingOrganizationCreatorUserEventHandler.java
@@ -20,7 +20,6 @@ package org.wso2.carbon.identity.organization.management.organization.user.shari
 
 import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
-import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.event.Event;
 import org.wso2.carbon.identity.event.handler.AbstractEventHandler;

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/SharingOrganizationCreatorUserEventHandler.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/SharingOrganizationCreatorUserEventHandler.java
@@ -63,7 +63,8 @@ public class SharingOrganizationCreatorUserEventHandler extends AbstractEventHan
                 }
 
                 String associatedUserId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUserId();
-                String associatedOrgId = (String) IdentityUtil.threadLocalProperties.get().get("USER_RESIDENT_ORG");
+                String associatedOrgId = PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                        .getUserResidentOrganizationId();
                 if (StringUtils.isEmpty(associatedOrgId)) {
                     associatedOrgId = getOrganizationManager().resolveOrganizationId(Utils.getTenantDomain());
                 }

--- a/pom.xml
+++ b/pom.xml
@@ -472,7 +472,7 @@
     <properties>
 
         <!-- Carbon kernel version -->
-        <carbon.kernel.version>4.9.16</carbon.kernel.version>
+        <carbon.kernel.version>4.9.17-SNAPSHOT</carbon.kernel.version>
         <carbon.kernel.package.import.version.range>[4.7.0, 5.0.0)</carbon.kernel.package.import.version.range>
         <carbon.kernel.feature.version>4.6.0</carbon.kernel.feature.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -472,7 +472,7 @@
     <properties>
 
         <!-- Carbon kernel version -->
-        <carbon.kernel.version>4.9.17-SNAPSHOT</carbon.kernel.version>
+        <carbon.kernel.version>4.9.17</carbon.kernel.version>
         <carbon.kernel.package.import.version.range>[4.7.0, 5.0.0)</carbon.kernel.package.import.version.range>
         <carbon.kernel.feature.version>4.6.0</carbon.kernel.feature.version>
 


### PR DESCRIPTION
## Purpose
> Remove the usage of thread local and use the carbon context to fetch the authenticated user's resident organization.

#### Depends on
- https://github.com/wso2/carbon-kernel/pull/3716