### PR TITLE
User invitation improvements and block shared user update

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/SharedUserOperationEventListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/SharedUserOperationEventListener.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.organization.management.organization.user.sharing.listener;
 
+import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.identity.core.AbstractIdentityUserOperationEventListener;
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.OrganizationUserSharingService;
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.OrganizationUserSharingServiceImpl;
@@ -33,6 +34,7 @@ import java.util.Map;
 
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.CLAIM_MANAGED_ORGANIZATION;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_MANAGED_ORGANIZATION_CLAIM_UPDATE_NOT_ALLOWED;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_SHARED_USER_CLAIM_UPDATE_NOT_ALLOWED;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.getOrganizationId;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.getTenantDomain;
 
@@ -84,6 +86,7 @@ public class SharedUserOperationEventListener extends AbstractIdentityUserOperat
         if (!isEnable() || userStoreManager == null) {
             return true;
         }
+        blockClaimUpdatesForSharedUser((AbstractUserStoreManager) userStoreManager, userID);
         if (!claims.isEmpty() && claims.containsKey(CLAIM_MANAGED_ORGANIZATION)) {
             throw new UserStoreClientException(
                     String.format(ERROR_CODE_MANAGED_ORGANIZATION_CLAIM_UPDATE_NOT_ALLOWED.getDescription(),
@@ -100,6 +103,7 @@ public class SharedUserOperationEventListener extends AbstractIdentityUserOperat
         if (!isEnable() || userStoreManager == null) {
             return true;
         }
+        blockClaimUpdatesForSharedUser((AbstractUserStoreManager) userStoreManager, userID);
         if (CLAIM_MANAGED_ORGANIZATION.equals(claimURI)) {
             throw new UserStoreClientException(
                     String.format(ERROR_CODE_MANAGED_ORGANIZATION_CLAIM_UPDATE_NOT_ALLOWED.getDescription(),
@@ -107,5 +111,15 @@ public class SharedUserOperationEventListener extends AbstractIdentityUserOperat
                     ERROR_CODE_MANAGED_ORGANIZATION_CLAIM_UPDATE_NOT_ALLOWED.getCode());
         }
         return true;
+    }
+
+    private void blockClaimUpdatesForSharedUser(AbstractUserStoreManager userStoreManager, String userID)
+            throws UserStoreException {
+
+        if (StringUtils.isEmpty(OrganizationSharedUserUtil.getUserManagedOrganizationClaim(userStoreManager, userID))) {
+            return;
+        }
+        throw new UserStoreClientException(ERROR_CODE_SHARED_USER_CLAIM_UPDATE_NOT_ALLOWED.getMessage(),
+                ERROR_CODE_SHARED_USER_CLAIM_UPDATE_NOT_ALLOWED.getCode());
     }
 }

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/InvitationCoreServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/InvitationCoreServiceImpl.java
@@ -170,7 +170,7 @@ public class InvitationCoreServiceImpl implements InvitationCoreService {
                         .resolveTenantDomain(invitedUserResidentOrg);
                 userStoreManager = getAbstractUserStoreManager(
                         IdentityTenantUtil.getTenantId(invitedUserResidentTenantDomain));
-                emailClaim = userStoreManager.getUserClaimValue(userDomainQualifiedUserName,CLAIM_EMAIL_ADDRESS, null);
+                emailClaim = userStoreManager.getUserClaimValue(userDomainQualifiedUserName, CLAIM_EMAIL_ADDRESS, null);
             }
 
             invitation.setEmail(emailClaim);

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/InvitationCoreServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/InvitationCoreServiceImpl.java
@@ -173,7 +173,8 @@ public class InvitationCoreServiceImpl implements InvitationCoreService {
                     String userResidentTenantDomain = organizationManager.resolveTenantDomain(managedOrganization);
                     userStoreManager = getAbstractUserStoreManager(IdentityTenantUtil.
                             getTenantId(userResidentTenantDomain));
-                    emailClaim = userStoreManager.getUserClaimValue(userDomainQualifiedUserName, CLAIM_EMAIL_ADDRESS, null);
+                    emailClaim = userStoreManager.getUserClaimValue(userDomainQualifiedUserName,
+                            CLAIM_EMAIL_ADDRESS, null);
                 }
                 if (StringUtils.isEmpty(emailClaim)) {
                     throw new UserInvitationMgtClientException(ERROR_CODE_INVITED_USER_EMAIL_NOT_FOUND.getCode(),

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/constant/UserInvitationMgtConstants.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/constant/UserInvitationMgtConstants.java
@@ -123,6 +123,9 @@ public class UserInvitationMgtConstants {
         ERROR_CODE_INVALID_ROLE("10029",
                 "Invalid role identification provided.",
                 "Could not find a role with given roleId %s."),
+        ERROR_CODE_INVITED_USER_EMAIL_NOT_FOUND("10030",
+                "Failed to resolve the email of the invited user.",
+                "Could not find the email of the invited user %s."),
 
         // DAO layer errors
         ERROR_CODE_STORE_INVITATION("10501",

--- a/pom.xml
+++ b/pom.xml
@@ -507,7 +507,7 @@
         <org.wso2.identity.organization.mgt.imp.pkg.version.range>[1.0.0,2.0.0)
         </org.wso2.identity.organization.mgt.imp.pkg.version.range>
 
-        <identity.organization.management.core.version>1.0.79</identity.organization.management.core.version>
+        <identity.organization.management.core.version>1.0.88-SNAPSHOT</identity.organization.management.core.version>
         <org.wso2.identity.organization.mgt.core.imp.pkg.version.range>[1.0.0,2.0.0)
         </org.wso2.identity.organization.mgt.core.imp.pkg.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -507,7 +507,7 @@
         <org.wso2.identity.organization.mgt.imp.pkg.version.range>[1.0.0,2.0.0)
         </org.wso2.identity.organization.mgt.imp.pkg.version.range>
 
-        <identity.organization.management.core.version>1.0.88-SNAPSHOT</identity.organization.management.core.version>
+        <identity.organization.management.core.version>1.0.88</identity.organization.management.core.version>
         <org.wso2.identity.organization.mgt.core.imp.pkg.version.range>[1.0.0,2.0.0)
         </org.wso2.identity.organization.mgt.core.imp.pkg.version.range>
 


### PR DESCRIPTION
## Purpose
>  $subject

1 - Block claim updates for shared users.

2 - Fail user invite if an invitation is send for user with the same name who already exist.

3 - Allow inviting shared users to another organization by fetching the email claim of the original user.