### PR TITLE
Propagate claim dialect changes to suborganizations

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/handler/OrgClaimMgtHandler.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/handler/OrgClaimMgtHandler.java
@@ -92,6 +92,12 @@ public class OrgClaimMgtHandler extends AbstractEventHandler {
             case IdentityEventConstants.Event.POST_ADD_CLAIM_DIALECT:
                 handleAddClaimDialect(event);
                 break;
+            case IdentityEventConstants.Event.POST_UPDATE_CLAIM_DIALECT:
+                handleUpdateClaimDialect(event);
+                break;
+            case IdentityEventConstants.Event.POST_DELETE_CLAIM_DIALECT:
+                handleDeleteClaimDialect(event);
+                break;
             default:
                 break;
         }
@@ -389,6 +395,74 @@ public class OrgClaimMgtHandler extends AbstractEventHandler {
             throw new IdentityEventException("An error occurred while adding the claim dialect " + claimDialectURI, e);
         } catch (ClaimMetadataException e) {
             throw new IdentityEventException("An error occurred while adding the claim dialect " + claimDialectURI, e);
+        }
+    }
+
+    private void handleUpdateClaimDialect(Event event) throws IdentityEventException {
+
+        Map<String, Object> eventProperties = event.getEventProperties();
+        int tenantId = (int) eventProperties.get(IdentityEventConstants.EventProperty.TENANT_ID);
+        String tenantDomain = IdentityTenantUtil.getTenantDomain(tenantId);
+        String oldClaimDialectURI =
+                (String) eventProperties.get(IdentityEventConstants.EventProperty.OLD_CLAIM_DIALECT_URI);
+        String newClaimDialectURI =
+                (String) eventProperties.get(IdentityEventConstants.EventProperty.NEW_CLAIM_DIALECT_URI);
+        try {
+            String organizationId = getOrganizationManager().resolveOrganizationId(tenantDomain);
+            List<BasicOrganization> childOrganizations = getOrganizationManager().
+                    getChildOrganizations(organizationId, true);
+            for (BasicOrganization organization : childOrganizations) {
+                String sharedOrganizationTenantDomain = getOrganizationManager().
+                        resolveTenantDomain(organization.getId());
+                getClaimMetadataManagementService().renameClaimDialect(new ClaimDialect(oldClaimDialectURI),
+                        new ClaimDialect(newClaimDialectURI), sharedOrganizationTenantDomain);
+            }
+        } catch (OrganizationManagementException e) {
+            // This is to handle the scenario where the tenant is not modeled as an organization.
+            if (ERROR_CODE_ORGANIZATION_NOT_FOUND_FOR_TENANT.getCode().equals(e.getErrorCode())) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Organization not found for the tenant: " + tenantDomain);
+                }
+                return;
+            }
+            throw new IdentityEventException(
+                    "An error occurred while updating the claim dialect " + oldClaimDialectURI, e);
+        } catch (ClaimMetadataException e) {
+            throw new IdentityEventException(
+                    "An error occurred while updating the claim dialect " + oldClaimDialectURI, e);
+        }
+    }
+
+    private void handleDeleteClaimDialect(Event event) throws IdentityEventException {
+
+        Map<String, Object> eventProperties = event.getEventProperties();
+        int tenantId = (int) eventProperties.get(IdentityEventConstants.EventProperty.TENANT_ID);
+        String tenantDomain = IdentityTenantUtil.getTenantDomain(tenantId);
+        String claimDialectURI =
+                (String) eventProperties.get(IdentityEventConstants.EventProperty.CLAIM_DIALECT_URI);
+        try {
+            String organizationId = getOrganizationManager().resolveOrganizationId(tenantDomain);
+            List<BasicOrganization> childOrganizations = getOrganizationManager().
+                    getChildOrganizations(organizationId, true);
+            for (BasicOrganization organization : childOrganizations) {
+                String sharedOrganizationTenantDomain = getOrganizationManager().
+                        resolveTenantDomain(organization.getId());
+                getClaimMetadataManagementService().removeClaimDialect(
+                        new ClaimDialect(claimDialectURI), sharedOrganizationTenantDomain);
+            }
+        } catch (OrganizationManagementException e) {
+            // This is to handle the scenario where the tenant is not modeled as an organization.
+            if (ERROR_CODE_ORGANIZATION_NOT_FOUND_FOR_TENANT.getCode().equals(e.getErrorCode())) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Organization not found for the tenant: " + tenantDomain);
+                }
+                return;
+            }
+            throw new IdentityEventException(
+                    "An error occurred while deleting the claim dialect " + claimDialectURI, e);
+        } catch (ClaimMetadataException e) {
+            throw new IdentityEventException(
+                    "An error occurred while deleting the claim dialect " + claimDialectURI, e);
         }
     }
 


### PR DESCRIPTION
## Purpose

When a new attribute mapping is created, it is not added to the suborganizations but when a new external claim is added to that attribute mapping, the claim is copied to the suborganization. Because the attribute mapping of the suborganization does not exist, this throws an error.

This PR contains the following changes.
- Captures the `POST_ADD_CLAIM_DIALECT` event and copies the claim dialect to the suborganizations.
- Captures the `POST_RENAME_CLAIM_DIALECT` event and renames the claim dialect in the suborganizations.
- Captures the `POST_DELETE_CLAIM_DIALECT` event and deletes the claim dialect in the suborganizations.

This fixes the following issue.
- https://github.com/wso2/product-is/issues/17947
