### PR TITLE
Use organization owner information when sharing the organization creator and block sharing the owner when not reside in parent for self-service org onboard

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/pom.xml
@@ -61,6 +61,10 @@
             <artifactId>org.wso2.carbon.identity.application.mgt</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.utils</groupId>
             <artifactId>org.wso2.carbon.database.utils</artifactId>
         </dependency>
@@ -140,6 +144,7 @@
                             org.wso2.carbon.identity.application.common;version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.application.common.model;version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.application.mgt;version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.application.authentication.framework.util; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.core;version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.core.util;version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.role.v2.mgt.core;version="${carbon.identity.package.import.version.range}",

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/pom.xml
@@ -151,6 +151,7 @@
                             org.wso2.carbon.identity.organization.management.service.constant;version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
                             org.wso2.carbon.identity.organization.management.role.management.service;version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
                             org.wso2.carbon.identity.organization.management.role.management.service.models;version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.management.ext;version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
                             org.wso2.carbon.user.api;version="${carbon.user.api.imp.pkg.version.range}",
                             org.wso2.carbon.user.core;version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.user.core.common;version="${carbon.kernel.package.import.version.range}",

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/SharingOrganizationCreatorUserEventHandler.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/SharingOrganizationCreatorUserEventHandler.java
@@ -39,10 +39,7 @@ import org.wso2.carbon.identity.organization.management.role.management.service.
 import org.wso2.carbon.identity.organization.management.role.management.service.models.Role;
 import org.wso2.carbon.identity.organization.management.role.management.service.models.User;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
-import org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
-import org.wso2.carbon.identity.organization.management.service.model.Organization;
-import org.wso2.carbon.identity.organization.management.service.model.OrganizationAttribute;
 import org.wso2.carbon.identity.organization.management.service.model.TenantTypeOrganization;
 import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
 import org.wso2.carbon.identity.organization.management.service.util.Utils;
@@ -105,11 +102,7 @@ public class SharingOrganizationCreatorUserEventHandler extends AbstractEventHan
                     if (!OrganizationManagementUtil.isOrganization(tenantDomain)) {
                         return;
                     }
-                    /* User sharing is not required when on-boarding organizations from a B2B app than Console app
-                       without owner information in the organization creation request. */
-                    if (!isAuthenticatedFromConsoleApp() && !isOrgOnboardWithOwnerInformation(orgId)) {
-                        return;
-                    }
+
                     RealmConfiguration realmConfiguration = OrganizationUserSharingDataHolder.getInstance()
                             .getRealmService().getTenantUserRealm(IdentityTenantUtil.getTenantId(tenantDomain))
                             .getRealmConfiguration();
@@ -147,22 +140,6 @@ public class SharingOrganizationCreatorUserEventHandler extends AbstractEventHan
         String authenticatedApp = (String) IdentityUtil.threadLocalProperties.get()
                 .get(FrameworkConstants.SERVICE_PROVIDER);
         return FrameworkConstants.Application.CONSOLE_APP.equals(authenticatedApp);
-    }
-
-    private boolean isOrgOnboardWithOwnerInformation(String organizationID) throws IdentityEventException {
-
-        try {
-            Organization organization = getOrganizationManager().getOrganization(organizationID, false, false);
-            for (OrganizationAttribute attribute : organization.getAttributes()) {
-                if (OrganizationManagementConstants.CREATOR_ID.equals(attribute.getKey())) {
-                    return true;
-                }
-            }
-        } catch (OrganizationManagementException e) {
-            throw new IdentityEventException("An error occurred while fetching the organization by ID: " +
-                    organizationID, e);
-        }
-        return false;
     }
 
     private Role buildOrgCreatorRole(String adminUUID) {

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/SharingOrganizationCreatorUserEventHandler.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/SharingOrganizationCreatorUserEventHandler.java
@@ -137,8 +137,12 @@ public class SharingOrganizationCreatorUserEventHandler extends AbstractEventHan
 
     private boolean isAuthenticatedFromConsoleApp() {
 
-        String authenticatedApp = (String) IdentityUtil.threadLocalProperties.get()
+        Object authenticatedAppFromThreadLocal = IdentityUtil.threadLocalProperties.get()
                 .get(FrameworkConstants.SERVICE_PROVIDER);
+        if (!(authenticatedAppFromThreadLocal instanceof String)) {
+            return false;
+        }
+        String authenticatedApp = (String) authenticatedAppFromThreadLocal;
         return FrameworkConstants.Application.CONSOLE_APP.equals(authenticatedApp);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -507,7 +507,7 @@
         <org.wso2.identity.organization.mgt.imp.pkg.version.range>[1.0.0,2.0.0)
         </org.wso2.identity.organization.mgt.imp.pkg.version.range>
 
-        <identity.organization.management.core.version>1.0.90</identity.organization.management.core.version>
+        <identity.organization.management.core.version>1.0.94</identity.organization.management.core.version>
         <org.wso2.identity.organization.mgt.core.imp.pkg.version.range>[1.0.0,2.0.0)
         </org.wso2.identity.organization.mgt.core.imp.pkg.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -507,7 +507,7 @@
         <org.wso2.identity.organization.mgt.imp.pkg.version.range>[1.0.0,2.0.0)
         </org.wso2.identity.organization.mgt.imp.pkg.version.range>
 
-        <identity.organization.management.core.version>1.0.93-SNAPSHOT</identity.organization.management.core.version>
+        <identity.organization.management.core.version>1.0.90</identity.organization.management.core.version>
         <org.wso2.identity.organization.mgt.core.imp.pkg.version.range>[1.0.0,2.0.0)
         </org.wso2.identity.organization.mgt.core.imp.pkg.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -507,7 +507,7 @@
         <org.wso2.identity.organization.mgt.imp.pkg.version.range>[1.0.0,2.0.0)
         </org.wso2.identity.organization.mgt.imp.pkg.version.range>
 
-        <identity.organization.management.core.version>1.0.90</identity.organization.management.core.version>
+        <identity.organization.management.core.version>1.0.93-SNAPSHOT</identity.organization.management.core.version>
         <org.wso2.identity.organization.mgt.core.imp.pkg.version.range>[1.0.0,2.0.0)
         </org.wso2.identity.organization.mgt.core.imp.pkg.version.range>
 


### PR DESCRIPTION
## Purpose
> 1. Previously, the shared user information was retrieved from the carbon context. But retrieving the shared user information from the organization owner details which stored in the corresponding tenant's realm config will be more reliable.
Ex - There can be use cases where the organization onboarding by self service portal and the request initiator is not the owner of the created organization.

> 2. The console admin role should be assigned for the organization creator only if the authenticated application is console.

### Depends on
- https://github.com/wso2/identity-organization-management-core/pull/118

### Related Issues
- https://github.com/wso2/product-is/issues/18073

![Untitled-2022-10-29-2045](https://github.com/wso2-extensions/identity-organization-management/assets/35717390/0a456ec6-fa59-465e-827d-f9b456192933)
