### PR TITLE
Fix callback generation issue for shared apps

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManagerImpl.java
@@ -96,6 +96,7 @@ import static org.wso2.carbon.identity.organization.management.application.const
 import static org.wso2.carbon.identity.organization.management.application.constant.OrgApplicationMgtConstants.ORGANIZATION_LOGIN_AUTHENTICATOR;
 import static org.wso2.carbon.identity.organization.management.application.constant.OrgApplicationMgtConstants.SHARE_WITH_ALL_CHILDREN;
 import static org.wso2.carbon.identity.organization.management.application.constant.OrgApplicationMgtConstants.TENANT;
+import static org.wso2.carbon.identity.organization.management.application.constant.OrgApplicationMgtConstants.TENANT_CONTEXT_PATH_COMPONENT;
 import static org.wso2.carbon.identity.organization.management.application.constant.OrgApplicationMgtConstants.UPDATE_SP_METADATA_SHARE_WITH_ALL_CHILDREN;
 import static org.wso2.carbon.identity.organization.management.application.constant.OrgApplicationMgtConstants.USER_ORGANIZATION_CLAIM;
 import static org.wso2.carbon.identity.organization.management.application.constant.OrgApplicationMgtConstants.USER_ORGANIZATION_CLAIM_URI;
@@ -659,9 +660,9 @@ public class OrgApplicationManagerImpl implements OrgApplicationManager {
     private String resolveCallbackURL(String ownerOrgId) throws URLBuilderException, OrganizationManagementException {
 
         String tenantDomain = getOrganizationManager().resolveTenantDomain(ownerOrgId);
-        ServiceURLBuilder commonAuthServiceUrl = ServiceURLBuilder.create().addPath(FrameworkConstants.COMMONAUTH)
-                .setTenant(tenantDomain);
-        return commonAuthServiceUrl.build().getAbsolutePublicURL();
+        String context = String.format(TENANT_CONTEXT_PATH_COMPONENT, tenantDomain) + "/" +
+                FrameworkConstants.COMMONAUTH;
+        return ServiceURLBuilder.create().addPath(context).build().getAbsolutePublicURL();
     }
 
     private void removeOAuthApplication(OAuthConsumerAppDTO oauthApp)

--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/constant/OrgApplicationMgtConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/constant/OrgApplicationMgtConstants.java
@@ -64,4 +64,5 @@ public class OrgApplicationMgtConstants {
             "POST_GET_APPLICATION_SHARED_ORGANIZATIONS";
     public static final String EVENT_PRE_GET_SHARED_APPLICATIONS = "PRE_GET_SHARED_APPLICATIONS";
     public static final String EVENT_POST_GET_SHARED_APPLICATIONS = "POST_GET_SHARED_APPLICATIONS";
+    public static final String TENANT_CONTEXT_PATH_COMPONENT = "/t/%s";
 }


### PR DESCRIPTION
## Purpose
Instead of letting service URL builder to generate the context based on the information had, the path can be generated upto some extent (relative path) and pass it to the service URL builder. 

As the apps can be created from a tenant, the shared app's callback URL should be always point to the commonauth endpoint of the app resides tenant.