### PR TITLE
Handle OAuth Client Exists Error due to stale data

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManagerImpl.java
@@ -629,13 +629,14 @@ public class OrgApplicationManagerImpl implements OrgApplicationManager {
 
     private boolean isOAuthClientExistsError(IdentityException e) {
 
-        return e.getErrorCode().equals(DUPLICATE_OAUTH_CLIENT.getErrorCode());
+        return DUPLICATE_OAUTH_CLIENT.getErrorCode().equals(e.getErrorCode());
     }
 
     /**
      * This method is to handle the exception due to an app already existing during the Oauth app creation process.
      * It is possible that the error is due to stale data, hence a retry mechanism is implemented to check
      * whether it is a stale app and if so, delete the stale app and retry the oauth app creation.
+     *
      * @param ownerOrgId        ID of the owner organization.
      * @param sharedOrgId       ID of the shared sub organization.
      * @param mainApplication   The application that is being shared.


### PR DESCRIPTION
## Purpose
A retry mechanism is needed due to the possibility of stale data in the IDN_OAUTH_CONSUMER_APPS table which would cause issues in the flow of sharing applications with sub organizations.

Stale apps exist due to the previous error where the OAuth app was not deleted while the SP was deleted as mentioned above and would cause issues to users who have previously unshared applications before the initial fix was onboarded.

A fix is done in the app sharing flow where, if there is an error related to the OAuth app already existing during the OAuth app creation, there will be a check to validate whether it is a stale app and if it is deemed to be a stale app, it will be deleted and the OAuth app creation will be retried.

## Issue

- https://github.com/wso2/product-is/issues/18941

