### PR TITLE
Return confirmation code if notification handling is managed externally

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/util/OrganizationSharedUserUtil.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/util/OrganizationSharedUserUtil.java
@@ -42,11 +42,11 @@ public class OrganizationSharedUserUtil {
     public static String getUserManagedOrganizationClaim(AbstractUserStoreManager userStoreManager, String userId)
             throws UserStoreException {
 
-        String userDomain = userStoreManager.getUser(userId, null).getUserStoreDomain();
+        //String userDomain = userStoreManager.getUser(userId, null).getUserStoreDomain();
         Map<String, String> claimsMap;
         try {
             claimsMap = userStoreManager
-                    .getUserClaimValuesWithID(userId, new String[]{CLAIM_MANAGED_ORGANIZATION}, userDomain);
+                    .getUserClaimValuesWithID(userId, new String[]{CLAIM_MANAGED_ORGANIZATION}, null);
         } catch (UserStoreException e) {
             if (LOG.isDebugEnabled()) {
                 String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/util/OrganizationSharedUserUtil.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/util/OrganizationSharedUserUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023-2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -39,10 +39,8 @@ public class OrganizationSharedUserUtil {
 
     private static final Log LOG = LogFactory.getLog(OrganizationSharedUserUtil.class);
 
-    public static String getUserManagedOrganizationClaim(AbstractUserStoreManager userStoreManager, String userId)
-            throws UserStoreException {
+    public static String getUserManagedOrganizationClaim(AbstractUserStoreManager userStoreManager, String userId) {
 
-        //String userDomain = userStoreManager.getUser(userId, null).getUserStoreDomain();
         Map<String, String> claimsMap;
         try {
             claimsMap = userStoreManager

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/util/OrganizationSharedUserUtil.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/util/OrganizationSharedUserUtil.java
@@ -39,7 +39,8 @@ public class OrganizationSharedUserUtil {
 
     private static final Log LOG = LogFactory.getLog(OrganizationSharedUserUtil.class);
 
-    public static String getUserManagedOrganizationClaim(AbstractUserStoreManager userStoreManager, String userId) {
+    public static String getUserManagedOrganizationClaim(AbstractUserStoreManager userStoreManager, String userId)
+            throws UserStoreException {
 
         Map<String, String> claimsMap;
         try {

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+  ~ Copyright (c) 2023-2024, WSO2 LLC. (http://www.wso2.com).
   ~
   ~ WSO2 LLC. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/pom.xml
@@ -68,6 +68,10 @@
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.role.v2.mgt.core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.governance</groupId>
+            <artifactId>org.wso2.carbon.identity.recovery</artifactId>
+        </dependency>
         <!--Test Dependencies-->
         <dependency>
             <groupId>org.testng</groupId>
@@ -151,7 +155,8 @@
                             org.wso2.carbon.identity.organization.management.organization.user.sharing;version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
                             org.wso2.carbon.identity.organization.management.organization.user.sharing.constant;version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
                             org.wso2.carbon.identity.organization.management.organization.user.sharing.models;version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
-                            org.wso2.carbon.identity.organization.management.organization.user.sharing.util;version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}"
+                            org.wso2.carbon.identity.organization.management.organization.user.sharing.util;version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.recovery.*; version="${identity.governance.imp.pkg.version.range}"
                         </Import-Package>
                     </instructions>
                 </configuration>

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/InvitationCoreServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/InvitationCoreServiceImpl.java
@@ -799,7 +799,7 @@ public class InvitationCoreServiceImpl implements InvitationCoreService {
      * named 'manageNotificationsInternally'. If not check on the server configuration.
      * Always the configuration is read from the root organization.
      *
-     * @param organizationId Organization ID.
+     * @param organizationId       Organization ID.
      * @param invitationProperties key value pairs of invitation properties.
      * @return True if the notifications are managed internally. False otherwise.
      * @throws UserInvitationMgtServerException Error while checking the notification management configuration.

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/InvitationCoreServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/InvitationCoreServiceImpl.java
@@ -798,10 +798,10 @@ public class InvitationCoreServiceImpl implements InvitationCoreService {
             // Get root organization of the given org.
             String primaryOrganizationId = getOrganizationManager().getPrimaryOrganizationId(organizationId);
             String rootOrgTenantDomain = resolveTenantDomain(primaryOrganizationId);
-            boolean manageNotificationsInternally =
-                    Boolean.parseBoolean(org.wso2.carbon.identity.recovery.util.Utils.getConnectorConfig
-                            (IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_NOTIFICATION_INTERNALLY_MANAGE,
-                                    rootOrgTenantDomain));
+            boolean manageNotificationsInternally = Boolean.parseBoolean(
+                    org.wso2.carbon.identity.recovery.util.Utils.getConnectorConfig(
+                            IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_NOTIFICATION_INTERNALLY_MANAGE,
+                            rootOrgTenantDomain));
             if (LOG.isDebugEnabled()) {
                 if (manageNotificationsInternally) {
                     LOG.debug("Notification will be managed internally for the organization: " + organizationId);

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/InvitationCoreServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/InvitationCoreServiceImpl.java
@@ -810,10 +810,8 @@ public class InvitationCoreServiceImpl implements InvitationCoreService {
                 }
             }
             return manageNotificationsInternally;
-        } catch (OrganizationManagementServerException e) {
-            throw new UserInvitationMgtServerException(e.getErrorCode(), e.getMessage(), e);
-        } catch (IdentityEventException e) {
-            throw new UserInvitationMgtServerException(e.getErrorCode(), e.getMessage(), e);
+        } catch (OrganizationManagementServerException | IdentityEventException e) {
+            throw new UserInvitationMgtServerException(e.getMessage());
         }
     }
 }

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/InvitationCoreServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/InvitationCoreServiceImpl.java
@@ -377,8 +377,10 @@ public class InvitationCoreServiceImpl implements InvitationCoreService {
             if (invitation != null) {
                 Timestamp currentTime = new Timestamp(new Date().getTime());
                 if (invitation.getExpiredAt().after(currentTime)) {
-                    // Trigger the event for invitation resend
-                    triggerInvitationAddNotification(invitation);
+                    if (isNotificationsInternallyManaged(organizationId)) {
+                        // Trigger the event for invitation resend.
+                        triggerInvitationAddNotification(invitation);
+                    }
                     return invitation;
                 }
                 throw new UserInvitationMgtClientException(ERROR_CODE_INVITATION_EXPIRED.getCode(),

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/InvitationCoreServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/InvitationCoreServiceImpl.java
@@ -806,7 +806,7 @@ public class InvitationCoreServiceImpl implements InvitationCoreService {
                 if (manageNotificationsInternally) {
                     LOG.debug("Notification will be managed internally for the organization: " + organizationId);
                 } else {
-                    LOG.debug("Notification will be managed externally  for the organization: " + organizationId);
+                    LOG.debug("Notification will be managed externally for the organization: " + organizationId);
                 }
             }
             return manageNotificationsInternally;

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/InvitationCoreServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/InvitationCoreServiceImpl.java
@@ -831,8 +831,8 @@ public class InvitationCoreServiceImpl implements InvitationCoreService {
 
         try {
             // Get root organization of the given org.
-            String primaryOrganizationId = getOrganizationManager().getPrimaryOrganizationId(organizationId);
-            String rootOrgTenantDomain = resolveTenantDomain(primaryOrganizationId);
+            String rootOrganizationId = getOrganizationManager().getPrimaryOrganizationId(organizationId);
+            String rootOrgTenantDomain = resolveTenantDomain(rootOrganizationId);
             boolean manageNotificationsInternally = Boolean.parseBoolean(
                     org.wso2.carbon.identity.recovery.util.Utils.getConnectorConfig(
                             IdentityRecoveryConstants.ConnectorConfig.

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/InvitationCoreServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/InvitationCoreServiceImpl.java
@@ -784,26 +784,36 @@ public class InvitationCoreServiceImpl implements InvitationCoreService {
         return result;
     }
 
+    /**
+     * Check whether the notifications are managed internally for the given organization.
+     * Always the configuration is read from the root organization.
+     *
+     * @param organizationId Organization ID.
+     * @return True if the notifications are managed internally. False otherwise.
+     * @throws UserInvitationMgtServerException Error while checking the notification management configuration.
+     */
     private boolean isNotificationsInternallyManaged(String organizationId) throws UserInvitationMgtServerException {
 
         try {
             // Get root organization of the given org.
             String primaryOrganizationId = getOrganizationManager().getPrimaryOrganizationId(organizationId);
             String rootOrgTenantDomain = resolveTenantDomain(primaryOrganizationId);
-            boolean manageNotificationsInternally = Boolean.parseBoolean(org.wso2.carbon.identity.recovery.util.Utils.getConnectorConfig
-                    (IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_NOTIFICATION_INTERNALLY_MANAGE, rootOrgTenantDomain));
+            boolean manageNotificationsInternally =
+                    Boolean.parseBoolean(org.wso2.carbon.identity.recovery.util.Utils.getConnectorConfig
+                            (IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_NOTIFICATION_INTERNALLY_MANAGE,
+                                    rootOrgTenantDomain));
             if (LOG.isDebugEnabled()) {
                 if (manageNotificationsInternally) {
-                    LOG.debug("Notification will be managed internally");
+                    LOG.debug("Notification will be managed internally for the organization: " + organizationId);
                 } else {
-                    LOG.debug("Notification will be managed externally");
+                    LOG.debug("Notification will be managed externally  for the organization: " + organizationId);
                 }
             }
             return manageNotificationsInternally;
         } catch (OrganizationManagementServerException e) {
-            throw new UserInvitationMgtServerException("Error occurred while resolving the root organization.");
+            throw new UserInvitationMgtServerException(e.getErrorCode(), e.getMessage(), e);
         } catch (IdentityEventException e) {
-            throw new UserInvitationMgtServerException("Error occurred while retrieving the notification management configurations.");
+            throw new UserInvitationMgtServerException(e.getErrorCode(), e.getMessage(), e);
         }
     }
 }

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/constant/UserInvitationMgtConstants.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/constant/UserInvitationMgtConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023-2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -46,6 +46,7 @@ public class UserInvitationMgtConstants {
     public static final String EVENT_PROP_CONFIRMATION_CODE = "confirmation-code";
     public static final String EVENT_PROP_TENANT_DOMAIN = "tenant-domain";
     public static final String EVENT_PROP_REDIRECT_URL = "redirect-url";
+    public static final String EVENT_PROP_PROPERTIES = "invitation-properties";
     public static final String EVENT_PROP_SEND_TO = "send-to";
     public static final String EVENT_PROP_TEMPLATE_TYPE = "TEMPLATE_TYPE";
     public static final String ORGANIZATION_USER_INVITATION_EMAIL_TEMPLATE_TYPE = "OrganizationUserInvitation";

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/models/Invitation.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/models/Invitation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023-2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -19,6 +19,8 @@
 package org.wso2.carbon.identity.organization.user.invitation.management.models;
 
 import java.sql.Timestamp;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Model that contains the invitation related details.
@@ -40,6 +42,7 @@ public class Invitation {
     private String userRedirectUrl;
     private RoleAssignments[] roleAssignments;
     private GroupAssignments[] groupAssignments;
+    private Map<String, String> invitationProperties = new HashMap();
 
     public String getInvitationId() {
 
@@ -192,5 +195,15 @@ public class Invitation {
     public void setGroupAssignments(GroupAssignments[] groupAssignments) {
 
         this.groupAssignments = groupAssignments != null ? groupAssignments.clone() : null;
+    }
+
+    public Map<String, String> getInvitationProperties() {
+
+        return invitationProperties;
+    }
+
+    public void setInvitationProperties(Map<String, String> invitationProperties) {
+
+        this.invitationProperties = invitationProperties;
     }
 }

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/models/Invitation.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/models/Invitation.java
@@ -197,11 +197,21 @@ public class Invitation {
         this.groupAssignments = groupAssignments != null ? groupAssignments.clone() : null;
     }
 
+    /**
+     * Get the invitation properties.
+     *
+     * @return Invitation properties.
+     */
     public Map<String, String> getInvitationProperties() {
 
         return invitationProperties;
     }
 
+    /**
+     * Set the invitation properties.
+     *
+     * @param invitationProperties Invitation properties.
+     */
     public void setInvitationProperties(Map<String, String> invitationProperties) {
 
         this.invitationProperties = invitationProperties;

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/models/InvitationDO.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/models/InvitationDO.java
@@ -87,11 +87,21 @@ public class InvitationDO {
         this.groupAssignments = groupAssignments != null ? groupAssignments.clone() : null;
     }
 
+    /**
+     * Get the invitation properties.
+     *
+     * @return Invitation properties.
+     */
     public Map<String, String> getInvitationProperties() {
 
         return invitationProperties;
     }
 
+    /**
+     * Set the invitation properties.
+     *
+     * @param invitationProperties Invitation properties.
+     */
     public void setInvitationProperties(Map<String, String> invitationProperties) {
 
         this.invitationProperties = invitationProperties;

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/models/InvitationDO.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/models/InvitationDO.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023-2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -18,7 +18,9 @@
 
 package org.wso2.carbon.identity.organization.user.invitation.management.models;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Model that contains the invitation data object.
@@ -30,6 +32,7 @@ public class InvitationDO {
     private RoleAssignments[] roleAssignments;
     private GroupAssignments[] groupAssignments;
     private String userRedirectUrl;
+    private Map<String, String> invitationProperties = new HashMap();
 
     public String getUserRedirectUrl() {
 
@@ -82,5 +85,15 @@ public class InvitationDO {
     public void setGroupAssignments(GroupAssignments[] groupAssignments) {
 
         this.groupAssignments = groupAssignments != null ? groupAssignments.clone() : null;
+    }
+
+    public Map<String, String> getInvitationProperties() {
+
+        return invitationProperties;
+    }
+
+    public void setInvitationProperties(Map<String, String> invitationProperties) {
+
+        this.invitationProperties = invitationProperties;
     }
 }

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/models/InvitationResult.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/models/InvitationResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023-2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/models/InvitationResult.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/models/InvitationResult.java
@@ -60,11 +60,21 @@ public class InvitationResult {
         this.username = username;
     }
 
+    /**
+     * Get the confirmation code.
+     *
+     * @return Confirmation code.
+     */
     public String getConfirmationCode() {
 
         return confirmationCode;
     }
 
+    /**
+     * Set the confirmation code.
+     *
+     * @param confirmationCode Confirmation code.
+     */
     public void setConfirmationCode(String confirmationCode) {
 
         this.confirmationCode = confirmationCode;

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/models/InvitationResult.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/models/InvitationResult.java
@@ -28,6 +28,7 @@ public class InvitationResult {
     private String username;
     private UserInvitationMgtConstants.ErrorMessage errorMsg;
     private String status;
+    private String confirmationCode;
 
     public UserInvitationMgtConstants.ErrorMessage getErrorMsg() {
 
@@ -57,5 +58,15 @@ public class InvitationResult {
     public void setUsername(String username) {
 
         this.username = username;
+    }
+
+    public String getConfirmationCode() {
+
+        return confirmationCode;
+    }
+
+    public void setConfirmationCode(String confirmationCode) {
+
+        this.confirmationCode = confirmationCode;
     }
 }


### PR DESCRIPTION
## Purpose
Part of https://github.com/wso2/product-is/issues/20014

If the invitation has
```
"properties": [
        {
            "key": "manageNotificationsInternally",
            "value": "false"
        }
    ]
```

Give the priority to this config regarding notification handling mechanism before checking on server level configuration.