### PR TITLE
Fix organization owner not assigned for role when user-id set in organization attributes

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/SharingOrganizationCreatorUserEventHandler.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/SharingOrganizationCreatorUserEventHandler.java
@@ -77,10 +77,10 @@ public class SharingOrganizationCreatorUserEventHandler extends AbstractEventHan
                 if (Constants.EVENT_POST_ADD_ORGANIZATION.equals(eventName)) {
                     Map<String, Object> eventProperties = event.getEventProperties();
                     TenantTypeOrganization organization = (TenantTypeOrganization) eventProperties.get("ORGANIZATION");
-                    boolean orgOwnerSetInAttributes = checkOrgCreatorSetInOrgAttributes(organization);
+                    boolean isOrgOwnerSetInAttributes = checkOrgCreatorSetInOrgAttributes(organization);
                     String authenticationType = (String) IdentityUtil.threadLocalProperties.get()
                             .get(UserSharingConstants.AUTHENTICATION_TYPE);
-                    if (!orgOwnerSetInAttributes && StringUtils.isNotEmpty(authenticationType) &&
+                    if (!isOrgOwnerSetInAttributes && StringUtils.isNotEmpty(authenticationType) &&
                             UserSharingConstants.APPLICATION_AUTHENTICATION_TYPE.equals(authenticationType)) {
                         return;
                     }
@@ -109,10 +109,10 @@ public class SharingOrganizationCreatorUserEventHandler extends AbstractEventHan
                     Map<String, Object> eventProperties = event.getEventProperties();
                     orgId = (String) eventProperties.get(EVENT_PROP_ORGANIZATION_ID);
                     TenantTypeOrganization organization = (TenantTypeOrganization) eventProperties.get("ORGANIZATION");
-                    boolean orgOwnerSetInAttributes = checkOrgCreatorSetInOrgAttributes(organization);
+                    boolean isOrgOwnerSetInAttributes = checkOrgCreatorSetInOrgAttributes(organization);
                     String authenticationType = (String) IdentityUtil.threadLocalProperties.get()
                             .get(UserSharingConstants.AUTHENTICATION_TYPE);
-                    if (!orgOwnerSetInAttributes && StringUtils.isNotEmpty(authenticationType) &&
+                    if (!isOrgOwnerSetInAttributes && StringUtils.isNotEmpty(authenticationType) &&
                             UserSharingConstants.APPLICATION_AUTHENTICATION_TYPE.equals(authenticationType)) {
                         return;
                     }

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/SharingOrganizationCreatorUserEventHandler.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/SharingOrganizationCreatorUserEventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023-2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -239,6 +239,6 @@ public class SharingOrganizationCreatorUserEventHandler extends AbstractEventHan
             return false;
         }
         return organization.getAttributes().stream()
-                .anyMatch(x->x.getKey().equals(OrganizationManagementConstants.CREATOR_ID));
+                .anyMatch(x -> x.getKey().equals(OrganizationManagementConstants.CREATOR_ID));
     }
 }

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/SharingOrganizationCreatorUserEventHandler.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/SharingOrganizationCreatorUserEventHandler.java
@@ -77,6 +77,13 @@ public class SharingOrganizationCreatorUserEventHandler extends AbstractEventHan
                 if (Constants.EVENT_POST_ADD_ORGANIZATION.equals(eventName)) {
                     Map<String, Object> eventProperties = event.getEventProperties();
                     TenantTypeOrganization organization = (TenantTypeOrganization) eventProperties.get("ORGANIZATION");
+                    boolean orgOwnerSetInAttributes = checkOrgCreatorSetInOrgAttributes(organization);
+                    String authenticationType = (String) IdentityUtil.threadLocalProperties.get()
+                            .get(UserSharingConstants.AUTHENTICATION_TYPE);
+                    if (!orgOwnerSetInAttributes && StringUtils.isNotEmpty(authenticationType) &&
+                            UserSharingConstants.APPLICATION_AUTHENTICATION_TYPE.equals(authenticationType)) {
+                        return;
+                    }
                     orgId = organization.getId();
                     String tenantDomain = OrganizationUserSharingDataHolder.getInstance().getOrganizationManager()
                             .resolveTenantDomain(orgId);


### PR DESCRIPTION
## Purpose
>  When the organization is created with m2m token, the previous logic was set to not to share the user and assign roles even the owner ID is mentioned in the organization attributes.

With this PR it is improved to share and assign the role only if the organization owner ID is mentioned in the organization creation payload.