### PR TITLE
Fix tenant deletion listener NPE for username.

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/OrganizationCreationHandler.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/OrganizationCreationHandler.java
@@ -172,8 +172,10 @@ public class OrganizationCreationHandler extends AbstractEventHandler {
         }
         List<String> mainAppIds = new ArrayList<>();
         try {
+            String username = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
             PrivilegedCarbonContext.startTenantFlow();
             PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(tenantDomain, true);
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(username);
             ApplicationBasicInfo[] applicationBasicInfos = getApplicationManagementService()
                     .getAllApplicationBasicInfo(tenantDomain, getAuthenticatedUsername());
             for (ApplicationBasicInfo applicationBasicInfo : applicationBasicInfos) {
@@ -201,8 +203,10 @@ public class OrganizationCreationHandler extends AbstractEventHandler {
             int rootTenantId = getApplicationManagementService().getTenantIdByApp(mainAppIds.get(0));
             String rootTenantDomain = IdentityTenantUtil.getTenantDomain(rootTenantId);
             String rootOrganizationId = getOrganizationManager().resolveOrganizationId(rootTenantDomain);
+            String username = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
             PrivilegedCarbonContext.startTenantFlow();
             PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(rootTenantDomain, true);
+            PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(username);
             for (String mainAppId : mainAppIds) {
                 List<BasicOrganization> applicationSharedOrganizations = getOrgApplicationManager()
                         .getApplicationSharedOrganizations(rootOrganizationId, mainAppId);


### PR DESCRIPTION
### Description
Fix sub organization deletion with selected shared applications lead to NPE with username in the thread local context in the application update listeners.