### PR TITLE
Skip application sharing if child org list is empty.

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManagerImpl.java
@@ -167,6 +167,9 @@ public class OrgApplicationManagerImpl implements OrgApplicationManager {
         }
 
         List<BasicOrganization> childOrganizations = getOrganizationManager().getChildOrganizations(ownerOrgId, true);
+        if (childOrganizations.isEmpty()) {
+            return;
+        }
         // Filter the child organization in case user send a list of organizations to share the original application.
         List<BasicOrganization> filteredChildOrgs = shareWithAllChildren
                 ? childOrganizations


### PR DESCRIPTION
### Description
Application sharing logic should not be executed if child org list is empty.
