### PR TITLE
Disable shared role deletion for legacy runtime

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.handler/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.handler/pom.xml
@@ -150,6 +150,7 @@
                             version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.core.util;version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.context;version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon;version="${carbon.kernel.package.import.version.range}",
                         </Import-Package>
                     </instructions>
                 </configuration>

--- a/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/listener/SharedRoleMgtListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/listener/SharedRoleMgtListener.java
@@ -23,6 +23,7 @@ import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.model.AssociatedRolesConfig;
@@ -464,6 +465,10 @@ public class SharedRoleMgtListener extends AbstractApplicationMgtListener {
                                                                String sharedAppOrgId)
             throws IdentityRoleManagementException, OrganizationManagementException {
 
+        // Avoid the execution for legacy runtime.
+        if (CarbonConstants.ENABLE_LEGACY_AUTHZ_RUNTIME) {
+            return;
+        }
         String mainApplicationOrgId = organizationManager.resolveOrganizationId(mainApplicationTenantDomain);
         if (mainApplicationOrgId == null) {
             mainApplicationOrgId = SUPER_ORG_ID;


### PR DESCRIPTION
### Description
Shared roles are not available for legacy runtime and leads to errors when trying to unshare applications.