### PR TITLE
Fix system role deleting issue in sub orgs when app is deleting

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/listener/SharedRoleMgtListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/listener/SharedRoleMgtListener.java
@@ -473,8 +473,11 @@ public class SharedRoleMgtListener extends AbstractApplicationMgtListener {
         if (mainApplicationOrgId == null) {
             mainApplicationOrgId = SUPER_ORG_ID;
         }
-        List<String> sharedRoleDeletionExcludeList = new ArrayList<>(Arrays.asList(RoleConstants.SYSTEM,
-                resolveEveryoneOrganizationRole(mainApplicationTenantDomain)));
+        List<String> sharedRoleDeletionExcludeList = new ArrayList<>();
+        if (!OrganizationManagementUtil.isOrganization(sharedAppOrgId)) {
+            sharedRoleDeletionExcludeList.add(RoleConstants.SYSTEM);
+            sharedRoleDeletionExcludeList.add(resolveEveryoneOrganizationRole(mainApplicationTenantDomain));
+        }
         rolesList = rolesList.stream().filter(role -> !sharedRoleDeletionExcludeList.contains(role.getName()))
                 .collect(Collectors.toList());
         String sharedAppTenantDomain = organizationManager.resolveTenantDomain(sharedAppOrgId);

--- a/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/listener/SharedRoleMgtListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/listener/SharedRoleMgtListener.java
@@ -474,10 +474,10 @@ public class SharedRoleMgtListener extends AbstractApplicationMgtListener {
             mainApplicationOrgId = SUPER_ORG_ID;
         }
         List<String> sharedRoleDeletionExcludeList = new ArrayList<>();
-        sharedRoleDeletionExcludeList.add(resolveEveryoneOrganizationRole(mainApplicationTenantDomain));
 
         if (!OrganizationManagementUtil.isOrganization(sharedAppOrgId)) {
             sharedRoleDeletionExcludeList.add(RoleConstants.SYSTEM);
+            sharedRoleDeletionExcludeList.add(resolveEveryoneOrganizationRole(mainApplicationTenantDomain));
         }
         rolesList = rolesList.stream().filter(role -> !sharedRoleDeletionExcludeList.contains(role.getName()))
                 .collect(Collectors.toList());

--- a/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/listener/SharedRoleMgtListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/listener/SharedRoleMgtListener.java
@@ -531,7 +531,6 @@ public class SharedRoleMgtListener extends AbstractApplicationMgtListener {
                 if (!isRoleUsedByAnotherSharedApp) {
                     // Delete the role in org.
                     roleManagementService.deleteRole(sharedRoleId, sharedAppTenantDomain);
-                    break;
                 }
             }
         }

--- a/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/listener/SharedRoleMgtListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/listener/SharedRoleMgtListener.java
@@ -474,9 +474,10 @@ public class SharedRoleMgtListener extends AbstractApplicationMgtListener {
             mainApplicationOrgId = SUPER_ORG_ID;
         }
         List<String> sharedRoleDeletionExcludeList = new ArrayList<>();
+        sharedRoleDeletionExcludeList.add(resolveEveryoneOrganizationRole(mainApplicationTenantDomain));
+
         if (!OrganizationManagementUtil.isOrganization(sharedAppOrgId)) {
             sharedRoleDeletionExcludeList.add(RoleConstants.SYSTEM);
-            sharedRoleDeletionExcludeList.add(resolveEveryoneOrganizationRole(mainApplicationTenantDomain));
         }
         rolesList = rolesList.stream().filter(role -> !sharedRoleDeletionExcludeList.contains(role.getName()))
                 .collect(Collectors.toList());

--- a/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/listener/SharedRoleMgtListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/listener/SharedRoleMgtListener.java
@@ -473,14 +473,6 @@ public class SharedRoleMgtListener extends AbstractApplicationMgtListener {
         if (mainApplicationOrgId == null) {
             mainApplicationOrgId = SUPER_ORG_ID;
         }
-        List<String> sharedRoleDeletionExcludeList = new ArrayList<>();
-
-        if (!OrganizationManagementUtil.isOrganization(sharedAppOrgId)) {
-            sharedRoleDeletionExcludeList.add(RoleConstants.SYSTEM);
-            sharedRoleDeletionExcludeList.add(resolveEveryoneOrganizationRole(mainApplicationTenantDomain));
-        }
-        rolesList = rolesList.stream().filter(role -> !sharedRoleDeletionExcludeList.contains(role.getName()))
-                .collect(Collectors.toList());
         String sharedAppTenantDomain = organizationManager.resolveTenantDomain(sharedAppOrgId);
         List<String> mainAppRoleIds =
                 rolesList.stream().map(RoleV2::getId).collect(Collectors.toList());

--- a/pom.xml
+++ b/pom.xml
@@ -520,7 +520,7 @@
         <carbon.multitenancy.package.import.version.range>[4.7.0,5.0.0)
         </carbon.multitenancy.package.import.version.range>
 
-        <carbon.identity.framework.version>7.1.33</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.2.9</carbon.identity.framework.version>
         <carbon.identity.package.import.version.range>[5.20.0, 8.0.0)
         </carbon.identity.package.import.version.range>
 


### PR DESCRIPTION
## Purpose
> $purpose

## Changes from this PR
- The roles admin and everyone in sub org is created when the application is shared with the sub orgs.
- Then if there only one app shared with the sub org, when we are deleting the app, the relevant roles also should be deleted.
- So we need to exclude the everyone and system role from the roles for deleting when the org is not a suborg.

## When the PR should merge
- Merge after this PR : https://github.com/wso2/carbon-identity-framework/pull/5694
- https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/2464