### PR TITLE
Skip adding SSO authenticator if child organization list is empty

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManagerImpl.java
@@ -167,9 +167,6 @@ public class OrgApplicationManagerImpl implements OrgApplicationManager {
         }
 
         List<BasicOrganization> childOrganizations = getOrganizationManager().getChildOrganizations(ownerOrgId, true);
-        if (childOrganizations.isEmpty()) {
-            return;
-        }
         // Filter the child organization in case user send a list of organizations to share the original application.
         List<BasicOrganization> filteredChildOrgs = shareWithAllChildren
                 ? childOrganizations
@@ -191,6 +188,11 @@ public class OrgApplicationManagerImpl implements OrgApplicationManager {
             } finally {
                 IdentityUtil.threadLocalProperties.get().remove(UPDATE_SP_METADATA_SHARE_WITH_ALL_CHILDREN);
             }
+        }
+
+        // Skip adding the SSO if there are no sub orgs.
+        if (childOrganizations.isEmpty()) {
+            return;
         }
 
         if (shareWithAllChildren || !filteredChildOrgs.isEmpty()) {


### PR DESCRIPTION
### Description
If set share with all children property for an application even the tenant don't have any sub organization, the property should not be changed to `do not share`. Only change would be SSO login option should not be in the login flow. It should be seen in the login flow when you create the first sub org.

### Related PR
- https://github.com/wso2-extensions/identity-organization-management/pull/365