### PR TITLE
Set tenant domain when building service url

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManagerImpl.java
@@ -779,7 +779,7 @@ public class OrgApplicationManagerImpl implements OrgApplicationManager {
         }
         String context =
                 String.format(TENANT_CONTEXT_PATH_COMPONENT, tenantDomain) + "/" + FrameworkConstants.COMMONAUTH;
-        return ServiceURLBuilder.create().addPath(context).build().getAbsolutePublicURL();
+        return ServiceURLBuilder.create().addPath(context).setTenant(tenantDomain).build().getAbsolutePublicURL();
     }
 
     private void removeOAuthApplication(OAuthConsumerAppDTO oauthApp)


### PR DESCRIPTION
## Purpose
The tenant domain is set here after creating an ServiceURLBuilder instance to ensure the expected tenant domain is considered when building the service url