### PR TITLE
Fix: Enable Group-Assigned Organization Admins to Be Invited as Sub-Org Admins

### DIFF
--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/InvitationCoreServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/InvitationCoreServiceImpl.java
@@ -74,7 +74,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import static org.wso2.carbon.identity.organization.user.invitation.management.constant.UserInvitationMgtConstants.APPLICATION_DOMAIN;
 import static org.wso2.carbon.identity.organization.user.invitation.management.constant.UserInvitationMgtConstants.CLAIM_EMAIL_ADDRESS;
 import static org.wso2.carbon.identity.organization.user.invitation.management.constant.UserInvitationMgtConstants.DEFAULT_USER_STORE_DOMAIN;
 import static org.wso2.carbon.identity.organization.user.invitation.management.constant.UserInvitationMgtConstants.EVENT_NAME_POST_ADD_INVITATION;
@@ -116,13 +115,14 @@ import static org.wso2.carbon.identity.organization.user.invitation.management.c
 import static org.wso2.carbon.identity.organization.user.invitation.management.constant.UserInvitationMgtConstants.ErrorMessage.ERROR_CODE_USER_NOT_FOUND;
 import static org.wso2.carbon.identity.organization.user.invitation.management.constant.UserInvitationMgtConstants.FAIL_STATUS;
 import static org.wso2.carbon.identity.organization.user.invitation.management.constant.UserInvitationMgtConstants.FILTER_STATUS_EQ;
-import static org.wso2.carbon.identity.organization.user.invitation.management.constant.UserInvitationMgtConstants.INTERNAL_DOMAIN;
 import static org.wso2.carbon.identity.organization.user.invitation.management.constant.UserInvitationMgtConstants.INVITED_USER_GROUP_NAME_PREFIX;
 import static org.wso2.carbon.identity.organization.user.invitation.management.constant.UserInvitationMgtConstants.ORG_USER_INVITATION_DEFAULT_REDIRECT_URL;
 import static org.wso2.carbon.identity.organization.user.invitation.management.constant.UserInvitationMgtConstants.ORG_USER_INVITATION_USER_DOMAIN;
 import static org.wso2.carbon.identity.organization.user.invitation.management.constant.UserInvitationMgtConstants.STATUS_EXPIRED;
 import static org.wso2.carbon.identity.organization.user.invitation.management.constant.UserInvitationMgtConstants.STATUS_PENDING;
 import static org.wso2.carbon.identity.organization.user.invitation.management.constant.UserInvitationMgtConstants.SUCCESS_STATUS;
+import static org.wso2.carbon.user.core.UserCoreConstants.APPLICATION_DOMAIN;
+import static org.wso2.carbon.user.core.UserCoreConstants.INTERNAL_DOMAIN;
 
 /**
  * Implementation of the invitation core service which manages the invitations of the organization users.

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/constant/UserInvitationMgtConstants.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/constant/UserInvitationMgtConstants.java
@@ -57,6 +57,8 @@ public class UserInvitationMgtConstants {
     public static final String EVENT_POST_ADD_INVITED_ORG_USER = "POST_ADD_INVITED_ORG_USER";
     public static final int SQL_FK_CONSTRAINT_VIOLATION_ERROR_CODE = 547;
     public static final String INVITATION_EVENT_HANDLER_ENABLED = "UserInvitationEventHandler.enable";
+    public static final String INTERNAL_DOMAIN = "Internal";
+    public static final String APPLICATION_DOMAIN = "Application";
 
     // Configurations
     public static final String ORG_USER_INVITATION_USER_DOMAIN = "OrganizationUserInvitation.PrimaryUserDomain";

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/constant/UserInvitationMgtConstants.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/constant/UserInvitationMgtConstants.java
@@ -57,8 +57,6 @@ public class UserInvitationMgtConstants {
     public static final String EVENT_POST_ADD_INVITED_ORG_USER = "POST_ADD_INVITED_ORG_USER";
     public static final int SQL_FK_CONSTRAINT_VIOLATION_ERROR_CODE = 547;
     public static final String INVITATION_EVENT_HANDLER_ENABLED = "UserInvitationEventHandler.enable";
-    public static final String INTERNAL_DOMAIN = "Internal";
-    public static final String APPLICATION_DOMAIN = "Application";
 
     // Configurations
     public static final String ORG_USER_INVITATION_USER_DOMAIN = "OrganizationUserInvitation.PrimaryUserDomain";

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/test/java/org/wso2/carbon/identity/organization/user/invitation/management/InvitationCoreServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/test/java/org/wso2/carbon/identity/organization/user/invitation/management/InvitationCoreServiceImplTest.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.identity.organization.user.invitation.management;
 
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.testng.PowerMockTestCase;
+import org.powermock.reflect.Whitebox;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -45,14 +46,18 @@ import org.wso2.carbon.identity.organization.user.invitation.management.models.R
 import org.wso2.carbon.identity.organization.user.invitation.management.util.TestUtils;
 import org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService;
 import org.wso2.carbon.identity.role.v2.mgt.core.model.Role;
+import org.wso2.carbon.identity.role.v2.mgt.core.model.RoleBasicInfo;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
+import org.wso2.carbon.user.core.common.Group;
 import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
 
 import java.nio.file.Paths;
 import java.sql.Connection;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -70,6 +75,9 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import static org.wso2.carbon.identity.organization.user.invitation.management.constant.UserInvitationMgtConstants.CLAIM_EMAIL_ADDRESS;
+import static org.wso2.carbon.identity.organization.user.invitation.management.constants.InvitationTestConstants.APPLICATION_DOMAIN;
+import static org.wso2.carbon.identity.organization.user.invitation.management.constants.InvitationTestConstants.CONSOLE_DOMAIN;
+import static org.wso2.carbon.identity.organization.user.invitation.management.constants.InvitationTestConstants.INTERNAL_DOMAIN;
 import static org.wso2.carbon.identity.organization.user.invitation.management.constants.InvitationTestConstants.INV_01_CONF_CODE;
 import static org.wso2.carbon.identity.organization.user.invitation.management.constants.InvitationTestConstants.INV_01_EMAIL;
 import static org.wso2.carbon.identity.organization.user.invitation.management.constants.InvitationTestConstants.INV_01_INVITATION_ID;
@@ -94,6 +102,10 @@ import static org.wso2.carbon.identity.organization.user.invitation.management.c
 import static org.wso2.carbon.identity.organization.user.invitation.management.constants.InvitationTestConstants.INV_04_INV_ORG_ID;
 import static org.wso2.carbon.identity.organization.user.invitation.management.constants.InvitationTestConstants.INV_04_UN;
 import static org.wso2.carbon.identity.organization.user.invitation.management.constants.InvitationTestConstants.INV_04_USER_ORG_ID;
+import static org.wso2.carbon.identity.organization.user.invitation.management.constants.InvitationTestConstants.PRIMARY_DOMAIN;
+import static org.wso2.carbon.identity.organization.user.invitation.management.constants.InvitationTestConstants.TENANT_DOMAIN;
+import static org.wso2.carbon.identity.organization.user.invitation.management.constants.InvitationTestConstants.TENANT_ID;
+import static org.wso2.carbon.identity.organization.user.invitation.management.constants.InvitationTestConstants.USER_ID;
 import static org.wso2.carbon.identity.organization.user.invitation.management.util.TestUtils.closeH2Base;
 import static org.wso2.carbon.identity.organization.user.invitation.management.util.TestUtils.getConnection;
 
@@ -103,7 +115,9 @@ import static org.wso2.carbon.identity.organization.user.invitation.management.u
         UserInvitationMgtDataHolder.class,
         IdentityTenantUtil.class,
         UserInvitationMgtDataHolder.class,
-        IdentityUtil.class, OrganizationSharedUserUtil.class,
+        IdentityUtil.class,
+        OrganizationSharedUserUtil.class,
+        UserCoreUtil.class,
         InvitationCoreServiceImpl.class})
 public class InvitationCoreServiceImplTest extends PowerMockTestCase {
 
@@ -523,5 +537,100 @@ public class InvitationCoreServiceImplTest extends PowerMockTestCase {
             groupAssignments.setGroupId(group);
         }
         return groupAssignments;
+    }
+
+    @Test(priority = 11)
+    public void testGetUserGroups() throws Exception {
+
+        // Mocking IdentityTenantUtil.getTenantId static method
+        when(IdentityTenantUtil.getTenantId(TENANT_DOMAIN)).thenReturn(TENANT_ID);
+
+        // Mocking the getAbstractUserStoreManager method
+        AbstractUserStoreManager userStoreManager = mock(AbstractUserStoreManager.class);
+        stub(method(InvitationCoreServiceImpl.class, "getAbstractUserStoreManager", int.class))
+                .toReturn(userStoreManager);
+
+        // Mocking the userStoreManager.getGroupListOfUser method
+        Group group1 = mock(Group.class);
+        Group group2 = mock(Group.class);
+        Group group3 = mock(Group.class);
+        when(group1.getGroupName()).thenReturn("Application/group1");
+        when(group2.getGroupName()).thenReturn("Internal/group2");
+        when(group3.getGroupName()).thenReturn("Primary/group3");
+        when(group1.getGroupID()).thenReturn("1");
+        when(group2.getGroupID()).thenReturn("2");
+        when(group3.getGroupID()).thenReturn("3");
+        List<Group> groups = Arrays.asList(group1, group2, group3);
+        when(userStoreManager.getGroupListOfUser(USER_ID, null, null)).thenReturn(groups);
+
+        // Mocking UserCoreUtil.extractDomainFromName
+        mockStatic(UserCoreUtil.class);
+        when(UserCoreUtil.extractDomainFromName("Application/group1")).thenReturn(APPLICATION_DOMAIN);
+        when(UserCoreUtil.extractDomainFromName("Internal/group2")).thenReturn(INTERNAL_DOMAIN);
+        when(UserCoreUtil.extractDomainFromName("Primary/group3")).thenReturn(PRIMARY_DOMAIN);
+
+        // Invoking the method
+        List<String> resultUserGroups = Whitebox.invokeMethod(
+                invitationCoreService, "getUserGroups", USER_ID, TENANT_DOMAIN);
+
+        // Assertion
+        List<String> expectedUserGroups = Collections.singletonList("3");
+        assertEquals(resultUserGroups, expectedUserGroups);
+    }
+
+    @Test(priority = 12)
+    public void testIsInvitedUserHasConsoleAccess() throws Exception {
+
+        // Mocking Role List
+        RoleBasicInfo role1 = new RoleBasicInfo("1", "Role1");
+        RoleBasicInfo role2 = new RoleBasicInfo("2", "Role2");
+        RoleBasicInfo role3 = new RoleBasicInfo("3", "Role3");
+        RoleBasicInfo role4 = new RoleBasicInfo("4", "Role4");
+        role2.setAudienceName(CONSOLE_DOMAIN);
+        List<RoleBasicInfo> roleList = new ArrayList<>(Arrays.asList(role1, role2));
+
+        // Mocking Group List
+        List<String> groupList = Arrays.asList("groupID1", "groupID2");
+
+        // Mocking RoleManagementService getRoleListOfUser
+        RoleManagementService roleManagementService = mock(RoleManagementService.class);
+        stub(method(InvitationCoreServiceImpl.class, "getRoleManagementService"))
+                .toReturn(roleManagementService);
+        when(roleManagementService.getRoleListOfUser(USER_ID, TENANT_DOMAIN)).thenReturn(roleList);
+
+        // Stubbing getUserGroups Method
+        stub(method(InvitationCoreServiceImpl.class, "getUserGroups")).toReturn(groupList);
+
+        // Mocking RoleManagementService getRoleListOfGroups
+        List<RoleBasicInfo> roleListFromUserGroups = Arrays.asList(role3, role4);
+        when(roleManagementService.getRoleListOfGroups(groupList, TENANT_DOMAIN)).thenReturn(roleListFromUserGroups);
+
+        // Invoke the method under test
+        boolean resultWithDirectConsoleAccess = Whitebox.invokeMethod(invitationCoreService,
+                        "isInvitedUserHasConsoleAccess", USER_ID, TENANT_DOMAIN);
+
+        // Assertion
+        assertTrue(resultWithDirectConsoleAccess);
+
+        // Test case where user does inherit have console access via a group role
+        role2.setAudienceName(APPLICATION_DOMAIN);
+        role4.setAudienceName(CONSOLE_DOMAIN);
+
+        // Re-invoke the method under test
+        Boolean resultWithConsoleAccessViaGroup = Whitebox.invokeMethod(invitationCoreService,
+                "isInvitedUserHasConsoleAccess", USER_ID, TENANT_DOMAIN);
+
+        // Assertion
+        assertTrue(resultWithConsoleAccessViaGroup);
+
+        // Test case where user does not have console access
+        role4.setAudienceName(APPLICATION_DOMAIN);
+
+        // Re-invoke the method under test
+        Boolean resultWithoutConsoleAccess = Whitebox.invokeMethod(invitationCoreService,
+                "isInvitedUserHasConsoleAccess", USER_ID, TENANT_DOMAIN);
+
+        // Assertion
+        assertFalse(resultWithoutConsoleAccess);
     }
 }

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/test/java/org/wso2/carbon/identity/organization/user/invitation/management/InvitationCoreServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/test/java/org/wso2/carbon/identity/organization/user/invitation/management/InvitationCoreServiceImplTest.java
@@ -27,6 +27,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.base.CarbonBaseConstants;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
@@ -75,9 +76,6 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import static org.wso2.carbon.identity.organization.user.invitation.management.constant.UserInvitationMgtConstants.CLAIM_EMAIL_ADDRESS;
-import static org.wso2.carbon.identity.organization.user.invitation.management.constants.InvitationTestConstants.APPLICATION_DOMAIN;
-import static org.wso2.carbon.identity.organization.user.invitation.management.constants.InvitationTestConstants.CONSOLE_DOMAIN;
-import static org.wso2.carbon.identity.organization.user.invitation.management.constants.InvitationTestConstants.INTERNAL_DOMAIN;
 import static org.wso2.carbon.identity.organization.user.invitation.management.constants.InvitationTestConstants.INV_01_CONF_CODE;
 import static org.wso2.carbon.identity.organization.user.invitation.management.constants.InvitationTestConstants.INV_01_EMAIL;
 import static org.wso2.carbon.identity.organization.user.invitation.management.constants.InvitationTestConstants.INV_01_INVITATION_ID;
@@ -102,12 +100,12 @@ import static org.wso2.carbon.identity.organization.user.invitation.management.c
 import static org.wso2.carbon.identity.organization.user.invitation.management.constants.InvitationTestConstants.INV_04_INV_ORG_ID;
 import static org.wso2.carbon.identity.organization.user.invitation.management.constants.InvitationTestConstants.INV_04_UN;
 import static org.wso2.carbon.identity.organization.user.invitation.management.constants.InvitationTestConstants.INV_04_USER_ORG_ID;
-import static org.wso2.carbon.identity.organization.user.invitation.management.constants.InvitationTestConstants.PRIMARY_DOMAIN;
-import static org.wso2.carbon.identity.organization.user.invitation.management.constants.InvitationTestConstants.TENANT_DOMAIN;
-import static org.wso2.carbon.identity.organization.user.invitation.management.constants.InvitationTestConstants.TENANT_ID;
 import static org.wso2.carbon.identity.organization.user.invitation.management.constants.InvitationTestConstants.USER_ID;
 import static org.wso2.carbon.identity.organization.user.invitation.management.util.TestUtils.closeH2Base;
 import static org.wso2.carbon.identity.organization.user.invitation.management.util.TestUtils.getConnection;
+import static org.wso2.carbon.user.core.UserCoreConstants.APPLICATION_DOMAIN;
+import static org.wso2.carbon.user.core.UserCoreConstants.INTERNAL_DOMAIN;
+import static org.wso2.carbon.user.core.UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME;
 
 @PrepareForTest({PrivilegedCarbonContext.class,
         RoleManagementService.class,
@@ -429,6 +427,103 @@ public class InvitationCoreServiceImplTest extends PowerMockTestCase {
         }
     }
 
+    @Test(priority = 11)
+    public void testGetUserGroups() throws Exception {
+
+        // Mocking IdentityTenantUtil.getTenantId static method
+        when(IdentityTenantUtil.getTenantId(anyString())).thenReturn(1);
+
+        // Mocking the getAbstractUserStoreManager method
+        AbstractUserStoreManager userStoreManager = mock(AbstractUserStoreManager.class);
+        stub(method(InvitationCoreServiceImpl.class, "getAbstractUserStoreManager", int.class))
+                .toReturn(userStoreManager);
+
+        // Mocking the userStoreManager.getGroupListOfUser method
+        Group group1 = mock(Group.class);
+        Group group2 = mock(Group.class);
+        Group group3 = mock(Group.class);
+        when(group1.getGroupName()).thenReturn("Application/group1");
+        when(group2.getGroupName()).thenReturn("Internal/group2");
+        when(group3.getGroupName()).thenReturn("Primary/group3");
+        when(group1.getGroupID()).thenReturn("1");
+        when(group2.getGroupID()).thenReturn("2");
+        when(group3.getGroupID()).thenReturn("3");
+        List<Group> groups = Arrays.asList(group1, group2, group3);
+        when(userStoreManager.getGroupListOfUser(USER_ID, null, null)).thenReturn(groups);
+
+        // Mocking UserCoreUtil.extractDomainFromName
+        mockStatic(UserCoreUtil.class);
+        when(UserCoreUtil.extractDomainFromName("Application/group1")).thenReturn(APPLICATION_DOMAIN);
+        when(UserCoreUtil.extractDomainFromName("Internal/group2")).thenReturn(INTERNAL_DOMAIN);
+        when(UserCoreUtil.extractDomainFromName("Primary/group3"))
+                .thenReturn(PRIMARY_DEFAULT_DOMAIN_NAME);
+
+        // Invoking the method
+        List<String> resultUserGroups = Whitebox.invokeMethod(
+                invitationCoreService, "getUserGroups", USER_ID, CarbonBaseConstants.CARBON_HOME);
+
+        // Assertion
+        List<String> expectedUserGroups = Collections.singletonList("3");
+        assertEquals(resultUserGroups, expectedUserGroups);
+    }
+
+    @Test(priority = 12)
+    public void testIsInvitedUserHasConsoleAccess() throws Exception {
+
+        // Mocking Role List
+        RoleBasicInfo role1 = new RoleBasicInfo("1", "Role1");
+        RoleBasicInfo role2 = new RoleBasicInfo("2", "Role2");
+        RoleBasicInfo role3 = new RoleBasicInfo("3", "Role3");
+        RoleBasicInfo role4 = new RoleBasicInfo("4", "Role4");
+        role2.setAudienceName(FrameworkConstants.Application.CONSOLE_APP);
+        List<RoleBasicInfo> roleList = new ArrayList<>(Arrays.asList(role1, role2));
+
+        // Mocking Group List
+        List<String> groupList = Arrays.asList("groupID1", "groupID2");
+
+        // Mocking RoleManagementService getRoleListOfUser
+        RoleManagementService roleManagementService = mock(RoleManagementService.class);
+        stub(method(InvitationCoreServiceImpl.class, "getRoleManagementService"))
+                .toReturn(roleManagementService);
+        when(roleManagementService.getRoleListOfUser(USER_ID, CarbonBaseConstants.CARBON_HOME)).thenReturn(roleList);
+
+        // Stubbing getUserGroups Method
+        stub(method(InvitationCoreServiceImpl.class, "getUserGroups")).toReturn(groupList);
+
+        // Mocking RoleManagementService getRoleListOfGroups
+        List<RoleBasicInfo> roleListFromUserGroups = Arrays.asList(role3, role4);
+        when(roleManagementService.getRoleListOfGroups(groupList, CarbonBaseConstants.CARBON_HOME))
+                .thenReturn(roleListFromUserGroups);
+
+        // Invoke the method under test
+        boolean resultWithDirectConsoleAccess = Whitebox.invokeMethod(invitationCoreService,
+                "isInvitedUserHasConsoleAccess", USER_ID, CarbonBaseConstants.CARBON_HOME);
+
+        // Assertion
+        assertTrue(resultWithDirectConsoleAccess);
+
+        // Test case where user does inherit have console access via a group role
+        role2.setAudienceName("App1");
+        role4.setAudienceName(FrameworkConstants.Application.CONSOLE_APP);
+
+        // Re-invoke the method under test
+        Boolean resultWithConsoleAccessViaGroup = Whitebox.invokeMethod(invitationCoreService,
+                "isInvitedUserHasConsoleAccess", USER_ID, CarbonBaseConstants.CARBON_HOME);
+
+        // Assertion
+        assertTrue(resultWithConsoleAccessViaGroup);
+
+        // Test case where user does not have console access
+        role4.setAudienceName("App1");
+
+        // Re-invoke the method under test
+        Boolean resultWithoutConsoleAccess = Whitebox.invokeMethod(invitationCoreService,
+                "isInvitedUserHasConsoleAccess", USER_ID, CarbonBaseConstants.CARBON_HOME);
+
+        // Assertion
+        assertFalse(resultWithoutConsoleAccess);
+    }
+
     private static void mockParentOrgDetails(AbstractUserStoreManager userStoreManagerParentOrg,
                                              String userStoreQualifiedUsername,
                                              String userId, UserRealm userRealmParentOrg, RealmService realmService,
@@ -537,100 +632,5 @@ public class InvitationCoreServiceImplTest extends PowerMockTestCase {
             groupAssignments.setGroupId(group);
         }
         return groupAssignments;
-    }
-
-    @Test(priority = 11)
-    public void testGetUserGroups() throws Exception {
-
-        // Mocking IdentityTenantUtil.getTenantId static method
-        when(IdentityTenantUtil.getTenantId(TENANT_DOMAIN)).thenReturn(TENANT_ID);
-
-        // Mocking the getAbstractUserStoreManager method
-        AbstractUserStoreManager userStoreManager = mock(AbstractUserStoreManager.class);
-        stub(method(InvitationCoreServiceImpl.class, "getAbstractUserStoreManager", int.class))
-                .toReturn(userStoreManager);
-
-        // Mocking the userStoreManager.getGroupListOfUser method
-        Group group1 = mock(Group.class);
-        Group group2 = mock(Group.class);
-        Group group3 = mock(Group.class);
-        when(group1.getGroupName()).thenReturn("Application/group1");
-        when(group2.getGroupName()).thenReturn("Internal/group2");
-        when(group3.getGroupName()).thenReturn("Primary/group3");
-        when(group1.getGroupID()).thenReturn("1");
-        when(group2.getGroupID()).thenReturn("2");
-        when(group3.getGroupID()).thenReturn("3");
-        List<Group> groups = Arrays.asList(group1, group2, group3);
-        when(userStoreManager.getGroupListOfUser(USER_ID, null, null)).thenReturn(groups);
-
-        // Mocking UserCoreUtil.extractDomainFromName
-        mockStatic(UserCoreUtil.class);
-        when(UserCoreUtil.extractDomainFromName("Application/group1")).thenReturn(APPLICATION_DOMAIN);
-        when(UserCoreUtil.extractDomainFromName("Internal/group2")).thenReturn(INTERNAL_DOMAIN);
-        when(UserCoreUtil.extractDomainFromName("Primary/group3")).thenReturn(PRIMARY_DOMAIN);
-
-        // Invoking the method
-        List<String> resultUserGroups = Whitebox.invokeMethod(
-                invitationCoreService, "getUserGroups", USER_ID, TENANT_DOMAIN);
-
-        // Assertion
-        List<String> expectedUserGroups = Collections.singletonList("3");
-        assertEquals(resultUserGroups, expectedUserGroups);
-    }
-
-    @Test(priority = 12)
-    public void testIsInvitedUserHasConsoleAccess() throws Exception {
-
-        // Mocking Role List
-        RoleBasicInfo role1 = new RoleBasicInfo("1", "Role1");
-        RoleBasicInfo role2 = new RoleBasicInfo("2", "Role2");
-        RoleBasicInfo role3 = new RoleBasicInfo("3", "Role3");
-        RoleBasicInfo role4 = new RoleBasicInfo("4", "Role4");
-        role2.setAudienceName(CONSOLE_DOMAIN);
-        List<RoleBasicInfo> roleList = new ArrayList<>(Arrays.asList(role1, role2));
-
-        // Mocking Group List
-        List<String> groupList = Arrays.asList("groupID1", "groupID2");
-
-        // Mocking RoleManagementService getRoleListOfUser
-        RoleManagementService roleManagementService = mock(RoleManagementService.class);
-        stub(method(InvitationCoreServiceImpl.class, "getRoleManagementService"))
-                .toReturn(roleManagementService);
-        when(roleManagementService.getRoleListOfUser(USER_ID, TENANT_DOMAIN)).thenReturn(roleList);
-
-        // Stubbing getUserGroups Method
-        stub(method(InvitationCoreServiceImpl.class, "getUserGroups")).toReturn(groupList);
-
-        // Mocking RoleManagementService getRoleListOfGroups
-        List<RoleBasicInfo> roleListFromUserGroups = Arrays.asList(role3, role4);
-        when(roleManagementService.getRoleListOfGroups(groupList, TENANT_DOMAIN)).thenReturn(roleListFromUserGroups);
-
-        // Invoke the method under test
-        boolean resultWithDirectConsoleAccess = Whitebox.invokeMethod(invitationCoreService,
-                        "isInvitedUserHasConsoleAccess", USER_ID, TENANT_DOMAIN);
-
-        // Assertion
-        assertTrue(resultWithDirectConsoleAccess);
-
-        // Test case where user does inherit have console access via a group role
-        role2.setAudienceName(APPLICATION_DOMAIN);
-        role4.setAudienceName(CONSOLE_DOMAIN);
-
-        // Re-invoke the method under test
-        Boolean resultWithConsoleAccessViaGroup = Whitebox.invokeMethod(invitationCoreService,
-                "isInvitedUserHasConsoleAccess", USER_ID, TENANT_DOMAIN);
-
-        // Assertion
-        assertTrue(resultWithConsoleAccessViaGroup);
-
-        // Test case where user does not have console access
-        role4.setAudienceName(APPLICATION_DOMAIN);
-
-        // Re-invoke the method under test
-        Boolean resultWithoutConsoleAccess = Whitebox.invokeMethod(invitationCoreService,
-                "isInvitedUserHasConsoleAccess", USER_ID, TENANT_DOMAIN);
-
-        // Assertion
-        assertFalse(resultWithoutConsoleAccess);
     }
 }

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/test/java/org/wso2/carbon/identity/organization/user/invitation/management/constants/InvitationTestConstants.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/test/java/org/wso2/carbon/identity/organization/user/invitation/management/constants/InvitationTestConstants.java
@@ -50,4 +50,12 @@ public class InvitationTestConstants {
     public static final String INV_03_INV_ORG_ID = "dc828181-e1a8-4f5e-8936-f154f4aefa75";
     public static final String INV_04_USER_ORG_ID = "7388393-031f-4719-8713-73j8ddd76h33";
     public static final String INV_04_INV_ORG_ID = "6ty62311-7yt5-h543-8976-h1yh6424hhh9";
+
+    public static final String USER_ID = "de828181-e1a8-4f5e-8936-f154f4ae1234";
+    public static final String TENANT_DOMAIN = "carbon.super";
+    public static final Integer TENANT_ID = 1;
+    public static final String CONSOLE_DOMAIN = "Console";
+    public static final String APPLICATION_DOMAIN = "Application";
+    public static final String INTERNAL_DOMAIN = "Internal";
+    public static final String PRIMARY_DOMAIN = "Primary";
 }

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/test/java/org/wso2/carbon/identity/organization/user/invitation/management/constants/InvitationTestConstants.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/test/java/org/wso2/carbon/identity/organization/user/invitation/management/constants/InvitationTestConstants.java
@@ -52,10 +52,4 @@ public class InvitationTestConstants {
     public static final String INV_04_INV_ORG_ID = "6ty62311-7yt5-h543-8976-h1yh6424hhh9";
 
     public static final String USER_ID = "de828181-e1a8-4f5e-8936-f154f4ae1234";
-    public static final String TENANT_DOMAIN = "carbon.super";
-    public static final Integer TENANT_ID = 1;
-    public static final String CONSOLE_DOMAIN = "Console";
-    public static final String APPLICATION_DOMAIN = "Application";
-    public static final String INTERNAL_DOMAIN = "Internal";
-    public static final String PRIMARY_DOMAIN = "Primary";
 }


### PR DESCRIPTION
## Purpose
> This PR addresses the issue where users assigned to an organization admin role via groups cannot be invited to join as sub-org level admins. [issue #20377](https://github.com/wso2/product-is/issues/20377).

## Goals
> Ensure that all users, regardless of whether their admin role is assigned directly or via a group, can be invited as sub-org admins from the sub-organization console.

## Approach
1. **Added `getUserGroups()` method**:
   - Introduced a private method `getUserGroups(String userId, String tenantDomain)` to retrieve the list of groups a user belongs to.
   
2. **Updated `isInvitedUserHasConsoleAccess()` method**:
   - Modified this method to call `getUserGroups()`, retrieve the roles from the groups via `roleListFromUserGroups()`, and incorporate these roles into the user's total role list.
   - Ensured that roles inherited from groups are considered when checking for console access.

> 

## Implementation Details
- **Code Changes**:
  ```java
  private List<String> getUserGroups(String userId, String tenantDomain) {
      // Implementation to return user's groups list
  }
  
  private boolean isInvitedUserHasConsoleAccess(String userId, String tenantDomain) {
      List<String> groupList = getUserGroups(userId, tenantDomain);
      // Extract roles from groups
      List<String> roleListFromUserGroups = roleListFromUserGroups(userGroups);
      // Add those roles to the total role list
     if (!roleListFromUserGroups.isEmpty()) {
            roleList.addAll(roleListFromUserGroups);
        }
      // Existing logic to check console access
  }

## Unit Tests
> Added tests to cover the `isInvitedUserHasConsoleAccess()` and `getUserGroups()` methods.

## Test environment
> JDK version: 11.0.23
> Product Version: IS 7.0.1