### PR TITLE
Fix shared MyAccount portal path issue

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManagerImpl.java
@@ -91,6 +91,7 @@ import static org.wso2.carbon.identity.application.authentication.framework.util
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.TENANT_CONTEXT_PREFIX;
 import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.AUTH_TYPE_DEFAULT;
 import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.AUTH_TYPE_FLOW;
+import static org.wso2.carbon.identity.application.mgt.ApplicationConstants.MYACCOUNT_PORTAL_PATH;
 import static org.wso2.carbon.identity.base.IdentityConstants.SKIP_CONSENT;
 import static org.wso2.carbon.identity.oauth.Error.DUPLICATE_OAUTH_CLIENT;
 import static org.wso2.carbon.identity.organization.management.application.constant.OrgApplicationMgtConstants.AUTH_TYPE_OAUTH_2;
@@ -791,8 +792,12 @@ public class OrgApplicationManagerImpl implements OrgApplicationManager {
             delegatedApplication.setAccessUrl(resolveAccessURL(mainApplication.getTenantDomain(), sharedOrgId,
                     FrameworkConstants.Application.CONSOLE_APP_PATH));
         } else if (ApplicationMgtUtil.isMyAccount(mainApplication.getApplicationName())) {
+            String portalPath = IdentityUtil.getProperty(MYACCOUNT_PORTAL_PATH);
+            if (StringUtils.isEmpty(portalPath)) {
+                portalPath = FrameworkConstants.Application.MY_ACCOUNT_APP_PATH;
+            }
             delegatedApplication.setAccessUrl(resolveAccessURL(mainApplication.getTenantDomain(), sharedOrgId,
-                    FrameworkConstants.Application.MY_ACCOUNT_APP_PATH));
+                    portalPath));
         }
         appendFragmentAppProperties(delegatedApplication);
 

--- a/pom.xml
+++ b/pom.xml
@@ -520,7 +520,7 @@
         <carbon.multitenancy.package.import.version.range>[4.7.0,5.0.0)
         </carbon.multitenancy.package.import.version.range>
 
-        <carbon.identity.framework.version>7.3.1</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.3.3</carbon.identity.framework.version>
         <carbon.identity.package.import.version.range>[5.20.0, 8.0.0)
         </carbon.identity.package.import.version.range>
 


### PR DESCRIPTION
## Purpose

Previous Behaviour : `<PROTOCOL>://<HOSTNAME>:<PORT>/t/<tenant-domain>/o/<org-id>/myaccount`

For the IDaaS setups it will be required to have the access URL in the form of below.
Ex: `<PROTOCOL>://<HOSTNAME>:<PORT>/t/<tenant-domain>/o/<org-id>/app`

With this PR it is fixed only for the MyAccount as the access URL of MyAccount of the sub-organization is used widely than the access URL of the shared console app.

There are few improvements to be made to have proper access URL for the console app. After fixing that, migration task is required to properly update the already created Console & MyAccount access URLs which might have been incorrectly set.

### Depends on
- https://github.com/wso2/carbon-identity-framework/pull/5749