### PR TITLE
FIX NPE in audit logs for organization creation

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManagerImpl.java
@@ -603,6 +603,7 @@ public class OrgApplicationManagerImpl implements OrgApplicationManager {
                         .orElse(MultitenantUtils.getTenantAwareUsername(mainApplication.getOwner()
                                 .toFullQualifiedUsername()));
                 PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(domainQualifiedUserName);
+                PrivilegedCarbonContext.getThreadLocalCarbonContext().setUserId(adminUserId);
             } catch (UserStoreException e) {
                 throw handleServerException(ERROR_CODE_ERROR_SHARING_APPLICATION, e,
                         mainApplication.getApplicationResourceId(), sharedOrgId);


### PR DESCRIPTION
### Description
FIX NPE due to missing userId in carbon context at https://github.com/wso2/carbon-identity-framework/blob/master/components/application-mgt/org.wso2.carbon.identity.application.mgt/src/main/java/org/wso2/carbon/identity/application/mgt/ApplicationManagementServiceImpl.java#L257