### PR TITLE
Remove unwanted legacy authz runtime checks

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
@@ -23,7 +23,6 @@ import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementClientException;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
@@ -282,10 +281,8 @@ public class FragmentApplicationMgtListener extends AbstractApplicationMgtListen
                         // Add application roles to the filtered claim mappings (if any
                         filteredClaimMappings = addApplicationRolesToFilteredClaimMappings(filteredClaimMappings);
                     }
-                    if (!CarbonConstants.ENABLE_LEGACY_AUTHZ_RUNTIME) {
-                        // Add roles to the filtered claim mappings.
-                        filteredClaimMappings = addRolesClaimToFilteredClaimMappings(filteredClaimMappings);
-                    }
+                    // Add roles to the filtered claim mappings.
+                    filteredClaimMappings = addRolesClaimToFilteredClaimMappings(filteredClaimMappings);
                     ClaimConfig claimConfig = new ClaimConfig();
                     claimConfig.setClaimMappings(filteredClaimMappings);
                     claimConfig.setAlwaysSendMappedLocalSubjectId(

--- a/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/listener/SharedRoleMgtListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/listener/SharedRoleMgtListener.java
@@ -23,7 +23,6 @@ import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.wso2.carbon.CarbonConstants;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.model.AssociatedRolesConfig;
@@ -106,8 +105,7 @@ public class SharedRoleMgtListener extends AbstractApplicationMgtListener {
 
             String updatedAllowedAudienceForRoleAssociation = ((serviceProvider.getAssociatedRolesConfig() == null) ||
                     (serviceProvider.getAssociatedRolesConfig().getAllowedAudience() == null)) ?
-                    (CarbonConstants.ENABLE_LEGACY_AUTHZ_RUNTIME ? RoleConstants.ORGANIZATION :
-                    RoleConstants.APPLICATION) : serviceProvider.getAssociatedRolesConfig().getAllowedAudience();
+                    RoleConstants.APPLICATION : serviceProvider.getAssociatedRolesConfig().getAllowedAudience();
 
             // If the existing and updated audiences are both organization, no need to update the roles.
             if (RoleConstants.ORGANIZATION.equalsIgnoreCase(existingAllowedAudienceForRoleAssociation) &&
@@ -515,10 +513,6 @@ public class SharedRoleMgtListener extends AbstractApplicationMgtListener {
                                                                String sharedAppOrgId)
             throws IdentityRoleManagementException, OrganizationManagementException {
 
-        // Avoid the execution for legacy runtime.
-        if (CarbonConstants.ENABLE_LEGACY_AUTHZ_RUNTIME) {
-            return;
-        }
         String mainApplicationOrgId = organizationManager.resolveOrganizationId(mainApplicationTenantDomain);
         if (mainApplicationOrgId == null) {
             mainApplicationOrgId = SUPER_ORG_ID;

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/SharingOrganizationCreatorUserEventHandler.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/SharingOrganizationCreatorUserEventHandler.java
@@ -30,19 +30,14 @@ import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.event.Event;
 import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
-import org.wso2.carbon.identity.organization.management.ext.Constants;
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.OrganizationUserSharingService;
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.OrganizationUserSharingServiceImpl;
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants;
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.internal.OrganizationUserSharingDataHolder;
-import org.wso2.carbon.identity.organization.management.role.management.service.RoleManager;
-import org.wso2.carbon.identity.organization.management.role.management.service.models.Role;
-import org.wso2.carbon.identity.organization.management.role.management.service.models.User;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 import org.wso2.carbon.identity.organization.management.service.model.Organization;
-import org.wso2.carbon.identity.organization.management.service.model.TenantTypeOrganization;
 import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
 import org.wso2.carbon.identity.organization.management.service.util.Utils;
 import org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants;
@@ -50,13 +45,10 @@ import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagemen
 import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.api.UserStoreException;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Map;
 
 import static org.wso2.carbon.identity.organization.management.ext.Constants.EVENT_PROP_ORGANIZATION_ID;
-import static org.wso2.carbon.identity.organization.management.role.management.service.constant.RoleManagementConstants.ORG_ADMINISTRATOR_ROLE;
-import static org.wso2.carbon.identity.organization.management.role.management.service.constant.RoleManagementConstants.ORG_CREATOR_ROLE;
 
 /**
  * The event handler for sharing the organization creator to the child organization.
@@ -71,81 +63,52 @@ public class SharingOrganizationCreatorUserEventHandler extends AbstractEventHan
         String eventName = event.getEventName();
         String orgId = null;
 
+        if (!"POST_SHARED_CONSOLE_APP".equals(eventName)) {
+            return;
+        }
+
         try {
-            if (Constants.EVENT_POST_ADD_ORGANIZATION.equals(eventName)) {
-                Map<String, Object> eventProperties = event.getEventProperties();
-                TenantTypeOrganization organization = (TenantTypeOrganization) eventProperties.get("ORGANIZATION");
-                boolean isOrgOwnerSetInAttributes = checkOrgCreatorSetInOrgAttributes(organization);
-                String authenticationType = (String) IdentityUtil.threadLocalProperties.get()
-                        .get(UserSharingConstants.AUTHENTICATION_TYPE);
-                if (!isOrgOwnerSetInAttributes && StringUtils.isNotEmpty(authenticationType) &&
-                        UserSharingConstants.APPLICATION_AUTHENTICATION_TYPE.equals(authenticationType)) {
-                    return;
-                }
-                orgId = organization.getId();
-                String tenantDomain = OrganizationUserSharingDataHolder.getInstance().getOrganizationManager()
-                        .resolveTenantDomain(orgId);
-                if (!OrganizationManagementUtil.isOrganization(tenantDomain)) {
-                    return;
-                }
-                String associatedUserId = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUserId();
-                String associatedUserName = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
-                try {
-                    PrivilegedCarbonContext.startTenantFlow();
-                    PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(tenantDomain, true);
-                    PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(associatedUserName);
-                    Role organizationCreatorRole = buildOrgCreatorRole(associatedUserId);
-                    Role administratorRole = buildAdministratorRole(associatedUserId);
-                    getRoleManager().createRole(orgId, organizationCreatorRole);
-                    getRoleManager().createRole(orgId, administratorRole);
-                } finally {
-                    PrivilegedCarbonContext.endTenantFlow();
-                }
-            } else {
-                if ("POST_SHARED_CONSOLE_APP".equals(eventName)) {
-                    Map<String, Object> eventProperties = event.getEventProperties();
-                    orgId = (String) eventProperties.get(EVENT_PROP_ORGANIZATION_ID);
-                    Organization organization = OrganizationUserSharingDataHolder.getInstance()
-                            .getOrganizationManager().getOrganization(orgId, false, false);
-                    boolean isOrgOwnerSetInAttributes = checkOrgCreatorSetInOrgAttributes(organization);
-                    String authenticationType = (String) IdentityUtil.threadLocalProperties.get()
-                            .get(UserSharingConstants.AUTHENTICATION_TYPE);
-                    if (!isOrgOwnerSetInAttributes && StringUtils.isNotEmpty(authenticationType) &&
-                            UserSharingConstants.APPLICATION_AUTHENTICATION_TYPE.equals(authenticationType)) {
-                        return;
-                    }
+            Map<String, Object> eventProperties = event.getEventProperties();
+            orgId = (String) eventProperties.get(EVENT_PROP_ORGANIZATION_ID);
+            Organization organization = OrganizationUserSharingDataHolder.getInstance()
+                    .getOrganizationManager().getOrganization(orgId, false, false);
+            boolean isOrgOwnerSetInAttributes = checkOrgCreatorSetInOrgAttributes(organization);
+            String authenticationType = (String) IdentityUtil.threadLocalProperties.get()
+                    .get(UserSharingConstants.AUTHENTICATION_TYPE);
+            if (!isOrgOwnerSetInAttributes && StringUtils.isNotEmpty(authenticationType) &&
+                    UserSharingConstants.APPLICATION_AUTHENTICATION_TYPE.equals(authenticationType)) {
+                return;
+            }
 
-                    String tenantDomain = OrganizationUserSharingDataHolder.getInstance().getOrganizationManager()
-                            .resolveTenantDomain(orgId);
-                    if (!OrganizationManagementUtil.isOrganization(tenantDomain)) {
-                        return;
-                    }
+            String tenantDomain = OrganizationUserSharingDataHolder.getInstance().getOrganizationManager()
+                    .resolveTenantDomain(orgId);
+            if (!OrganizationManagementUtil.isOrganization(tenantDomain)) {
+                return;
+            }
 
-                    RealmConfiguration realmConfiguration = OrganizationUserSharingDataHolder.getInstance()
-                            .getRealmService().getTenantUserRealm(IdentityTenantUtil.getTenantId(tenantDomain))
-                            .getRealmConfiguration();
-                    String associatedUserName = realmConfiguration.getAdminUserName();
-                    String associatedUserId = realmConfiguration.getAdminUserId();
-                    String associatedOrgId = PrivilegedCarbonContext.getThreadLocalCarbonContext()
-                            .getUserResidentOrganizationId();
-                    if (StringUtils.isEmpty(associatedOrgId)) {
-                        associatedOrgId = getOrganizationManager().resolveOrganizationId(Utils.getTenantDomain());
-                    }
-                    try {
-                        PrivilegedCarbonContext.startTenantFlow();
-                        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(tenantDomain, true);
-                        PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(associatedUserName);
-                        userSharingService.shareOrganizationUser(orgId, associatedUserId, associatedOrgId);
-                        String userId = userSharingService
-                                .getUserAssociationOfAssociatedUserByOrgId(associatedUserId, orgId)
-                                .getUserId();
-                        if (allowAssignConsoleAdministratorRole()) {
-                            assignUserToConsoleAppAdminRole(userId, tenantDomain);
-                        }
-                    } finally {
-                        PrivilegedCarbonContext.endTenantFlow();
-                    }
+            RealmConfiguration realmConfiguration = OrganizationUserSharingDataHolder.getInstance()
+                    .getRealmService().getTenantUserRealm(IdentityTenantUtil.getTenantId(tenantDomain))
+                    .getRealmConfiguration();
+            String associatedUserName = realmConfiguration.getAdminUserName();
+            String associatedUserId = realmConfiguration.getAdminUserId();
+            String associatedOrgId = PrivilegedCarbonContext.getThreadLocalCarbonContext()
+                    .getUserResidentOrganizationId();
+            if (StringUtils.isEmpty(associatedOrgId)) {
+                associatedOrgId = getOrganizationManager().resolveOrganizationId(Utils.getTenantDomain());
+            }
+            try {
+                PrivilegedCarbonContext.startTenantFlow();
+                PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(tenantDomain, true);
+                PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(associatedUserName);
+                userSharingService.shareOrganizationUser(orgId, associatedUserId, associatedOrgId);
+                String userId = userSharingService
+                        .getUserAssociationOfAssociatedUserByOrgId(associatedUserId, orgId)
+                        .getUserId();
+                if (allowAssignConsoleAdministratorRole()) {
+                    assignUserToConsoleAppAdminRole(userId, tenantDomain);
                 }
+            } finally {
+                PrivilegedCarbonContext.endTenantFlow();
             }
         } catch (OrganizationManagementException | UserStoreException e) {
             throw new IdentityEventException("An error occurred while sharing the organization creator to the " +
@@ -169,48 +132,6 @@ public class SharingOrganizationCreatorUserEventHandler extends AbstractEventHan
         }
         String authenticatedApp = (String) authenticatedAppFromThreadLocal;
         return FrameworkConstants.Application.CONSOLE_APP.equals(authenticatedApp);
-    }
-
-    private Role buildOrgCreatorRole(String adminUUID) {
-
-        Role organizationCreatorRole = new Role();
-        organizationCreatorRole.setDisplayName(ORG_CREATOR_ROLE);
-        User orgCreator = new User(adminUUID);
-        organizationCreatorRole.setUsers(Collections.singletonList(orgCreator));
-        // Set permissions for org-creator role.
-        ArrayList<String> orgCreatorRolePermissions = new ArrayList<>();
-        // Adding mandatory permissions for the org-creator role.
-        orgCreatorRolePermissions.add(UserSharingConstants.ORG_MGT_PERMISSION);
-        orgCreatorRolePermissions.add(UserSharingConstants.ORG_ROLE_MGT_PERMISSION);
-        /*
-        Adding the bear minimum permission set that org creator should have to logged in to the console and view
-        user, groups, roles, SP, IDP sections.
-         */
-        orgCreatorRolePermissions.addAll(UserSharingConstants.MINIMUM_PERMISSIONS_REQUIRED_FOR_ORG_CREATOR_VIEW);
-        // Add user create permission to organization creator to delegate permissions to other org users.
-        // This permission is assigned until https://github.com/wso2/product-is/issues/14439 is fixed
-        orgCreatorRolePermissions.add(UserSharingConstants.USER_MGT_CREATE_PERMISSION);
-        organizationCreatorRole.setPermissions(orgCreatorRolePermissions);
-        return organizationCreatorRole;
-    }
-
-    private Role buildAdministratorRole(String adminUUID) {
-
-        Role organizationAdministratorRole = new Role();
-        organizationAdministratorRole.setDisplayName(ORG_ADMINISTRATOR_ROLE);
-        User orgAdministrator = new User(adminUUID);
-        organizationAdministratorRole.setUsers(Collections.singletonList(orgAdministrator));
-        // Set permissions for org-administrator role.
-        ArrayList<String> orgAdministratorRolePermissions = new ArrayList<>();
-        // Setting all administrative permissions for the Administrator role
-        orgAdministratorRolePermissions.add(UserSharingConstants.ADMINISTRATOR_ROLE_PERMISSION);
-        organizationAdministratorRole.setPermissions(orgAdministratorRolePermissions);
-        return organizationAdministratorRole;
-    }
-
-    private RoleManager getRoleManager() {
-
-        return OrganizationUserSharingDataHolder.getInstance().getRoleManager();
     }
 
     private void assignUserToConsoleAppAdminRole(String userId, String tenantDomain)


### PR DESCRIPTION
## Purpose
> $subject

No need to add previous organization roles for the sub-organization creator as the authorization runtime is enabled by default and there is no recommondation for switch back to the old authorization runtime.
