### PR TITLE
Set the request initiator as the shared app deletion initiator

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
@@ -486,6 +486,8 @@ public class FragmentApplicationMgtListener extends AbstractApplicationMgtListen
                         PrivilegedCarbonContext.startTenantFlow();
                         PrivilegedCarbonContext.getThreadLocalCarbonContext()
                                 .setTenantDomain(sharedAppTenantDomain, true);
+                        // Set the request initiator as the downstream application deletion request initiator.
+                        PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(username);
                         getApplicationMgtService().deleteApplication(application.getApplicationName(),
                                 sharedAppTenantDomain, username);
                     } finally {


### PR DESCRIPTION
## Purpose
When trying to delete an application, its corresponding shared apps are required to be deleted. The shared apps are deleted within a tenant flow started against the corresponding organization each shared app exist.

The audit log events are published upon certain operations like application deletion, where the request initiator information is required to be logged in order to track the operations. 

When starting a tenant flow, the request initiator information will be cleared from the context, hence we can add the username into the context, so that information can be used for the places where audit logs are published.