### PR TITLE
Improve shared role creation in sub organization level

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/SharedRoleMgtHandler.java
+++ b/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/SharedRoleMgtHandler.java
@@ -271,7 +271,12 @@ public class SharedRoleMgtHandler extends AbstractEventHandler {
                     for (BasicOrganization organization : applicationSharedOrganizations) {
                         String shareAppTenantDomain =
                                 getOrganizationManager().resolveTenantDomain(organization.getId());
-                        RoleBasicInfo sharedRoleInfo = getRoleManagementServiceV2().addRole(mainRoleName,
+                        String sharedOrgRoleName = mainRoleName;
+                        if (getRoleManagementServiceV2().isExistingRoleName(mainRoleName, RoleConstants.ORGANIZATION,
+                                organization.getId(), shareAppTenantDomain)) {
+                            sharedOrgRoleName = mainRoleName + "_shared_to_" + shareAppTenantDomain;
+                        }
+                        RoleBasicInfo sharedRoleInfo = getRoleManagementServiceV2().addRole(sharedOrgRoleName,
                                 Collections.emptyList(),
                                 Collections.emptyList(),
                                 Collections.emptyList(), RoleConstants.ORGANIZATION, organization.getId(),


### PR DESCRIPTION
## Purpose
> When there is a role already available in the sub organization level, then a new role will be created in the sub organization level by appending the `_shared_to_ + sharedSubOrgTenantDomain` to the role name.

## Goals
> Resolve the conflict when the roles are shared to the sub organizations when the a role is available with the same name in the sub organization level.