### PR TITLE
Validate user store domain of the parent user invitation flow

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Adopt JDK 8
+      - name: Set up Adopt JDK 11
         uses: actions/setup-java@v2
         with:
-          java-version: "8"
+          java-version: "11"
           distribution: "adopt"
       - name: Cache local Maven repository
         id: cache-maven-m2
@@ -39,8 +39,11 @@ jobs:
       - name: Build with Maven
         run: mvn clean install -U -B
 
+      - name: Generate coverage report
+        run: mvn test jacoco:report
+
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: components/**/target/site/jacoco/jacoco.xml
+          files: target/site/jacoco/jacoco.xml

--- a/components/org.wso2.carbon.identity.organization.discovery.service/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.discovery.service/pom.xml
@@ -138,48 +138,16 @@
                 <version>${jacoco.version}</version>
                 <executions>
                     <execution>
-                        <id>default-instrument</id>
                         <goals>
-                            <goal>instrument</goal>
+                            <goal>prepare-agent</goal>
                         </goals>
                     </execution>
                     <execution>
-                        <id>default-restore-instrumented-classes</id>
-                        <goals>
-                            <goal>restore-instrumented-classes</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-report</id>
-                        <phase>prepare-package</phase>
+                        <id>report</id>
+                        <phase>test</phase>
                         <goals>
                             <goal>report</goal>
                         </goals>
-                    </execution>
-                    <execution>
-                        <id>default-report-integration</id>
-                        <goals>
-                            <goal>report-integration</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-check</id>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                        <configuration>
-                            <rules>
-                                <rule implementation="org.jacoco.maven.RuleConfiguration">
-                                    <element>BUNDLE</element>
-                                    <limits>
-                                        <limit implementation="org.jacoco.report.check.Limit">
-                                            <counter>COMPLEXITY</counter>
-                                            <value>COVEREDRATIO</value>
-                                        </limit>
-                                    </limits>
-                                </rule>
-                            </rules>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/components/org.wso2.carbon.identity.organization.management.application/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.application/pom.xml
@@ -205,28 +205,15 @@
                 <version>${jacoco.version}</version>
                 <executions>
                     <execution>
-                        <id>default-instrument</id>
                         <goals>
-                            <goal>instrument</goal>
+                            <goal>prepare-agent</goal>
                         </goals>
                     </execution>
                     <execution>
-                        <id>default-restore-instrumented-classes</id>
-                        <goals>
-                            <goal>restore-instrumented-classes</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-report</id>
-                        <phase>prepare-package</phase>
+                        <id>report</id>
+                        <phase>test</phase>
                         <goals>
                             <goal>report</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-report-integration</id>
-                        <goals>
-                            <goal>report-integration</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/components/org.wso2.carbon.identity.organization.management.handler/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.handler/pom.xml
@@ -161,28 +161,15 @@
                 <version>${jacoco.version}</version>
                 <executions>
                     <execution>
-                        <id>default-instrument</id>
                         <goals>
-                            <goal>instrument</goal>
+                            <goal>prepare-agent</goal>
                         </goals>
                     </execution>
                     <execution>
-                        <id>default-restore-instrumented-classes</id>
-                        <goals>
-                            <goal>restore-instrumented-classes</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-report</id>
-                        <phase>prepare-package</phase>
+                        <id>report</id>
+                        <phase>test</phase>
                         <goals>
                             <goal>report</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-report-integration</id>
-                        <goals>
-                            <goal>report-integration</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/pom.xml
@@ -96,16 +96,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-testng</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/pom.xml
@@ -84,16 +84,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-testng</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>
@@ -101,6 +91,11 @@
         <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <version>${jacoco.version}</version>
         </dependency>
     </dependencies>
 

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/InvitationCoreServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/InvitationCoreServiceImpl.java
@@ -103,6 +103,7 @@ import static org.wso2.carbon.identity.organization.user.invitation.management.c
 import static org.wso2.carbon.identity.organization.user.invitation.management.constant.UserInvitationMgtConstants.ErrorMessage.ERROR_CODE_INVALID_GROUP;
 import static org.wso2.carbon.identity.organization.user.invitation.management.constant.UserInvitationMgtConstants.ErrorMessage.ERROR_CODE_INVALID_INVITATION_ID;
 import static org.wso2.carbon.identity.organization.user.invitation.management.constant.UserInvitationMgtConstants.ErrorMessage.ERROR_CODE_INVALID_ROLE;
+import static org.wso2.carbon.identity.organization.user.invitation.management.constant.UserInvitationMgtConstants.ErrorMessage.ERROR_CODE_INVALID_USER_STORE_DOMAIN;
 import static org.wso2.carbon.identity.organization.user.invitation.management.constant.UserInvitationMgtConstants.ErrorMessage.ERROR_CODE_INVITATION_EXPIRED;
 import static org.wso2.carbon.identity.organization.user.invitation.management.constant.UserInvitationMgtConstants.ErrorMessage.ERROR_CODE_INVITED_USER_EMAIL_NOT_FOUND;
 import static org.wso2.carbon.identity.organization.user.invitation.management.constant.UserInvitationMgtConstants.ErrorMessage.ERROR_CODE_NO_INVITATION_FOR_USER;
@@ -149,6 +150,7 @@ public class InvitationCoreServiceImpl implements InvitationCoreService {
             String parentTenantDomain = resolveTenantDomain(parentOrgId);
             int parentTenantId = IdentityTenantUtil.getTenantId(parentTenantDomain);
             AbstractUserStoreManager userStoreManager = getAbstractUserStoreManager(parentTenantId);
+            validateInvitedUserStoreDomain(userStoreManager, invitationDO.getUserDomain());
             for (String username : invitationDO.getUsernamesList()) {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("Creating invitation for the user: " + username + " in the organization: " +
@@ -729,6 +731,17 @@ public class InvitationCoreServiceImpl implements InvitationCoreService {
         } catch (UserStoreException e) {
             throw new UserInvitationMgtServerException(ERROR_CODE_GROUP_EXISTENCE.getCode(),
                     ERROR_CODE_GROUP_EXISTENCE.getMessage(), ERROR_CODE_GROUP_EXISTENCE.getDescription());
+        }
+    }
+
+    private void validateInvitedUserStoreDomain(AbstractUserStoreManager userStoreManager, String domain)
+            throws UserInvitationMgtException {
+
+        LOG.debug("Validating the user store domain of the invitation.");
+        if (userStoreManager.getSecondaryUserStoreManager(domain) == null) {
+            throw new UserInvitationMgtClientException(ERROR_CODE_INVALID_USER_STORE_DOMAIN.getCode(),
+                    ERROR_CODE_INVALID_USER_STORE_DOMAIN.getMessage(),
+                    String.format(ERROR_CODE_INVALID_USER_STORE_DOMAIN.getDescription(), domain));
         }
     }
 

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/constant/UserInvitationMgtConstants.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/constant/UserInvitationMgtConstants.java
@@ -153,6 +153,9 @@ public class UserInvitationMgtConstants {
         ERROR_CODE_GROUP_EXISTENCE("10035",
                 "Error while checking the group existence.",
                 "Could not resolve the group existence from the given list."),
+        ERROR_CODE_INVALID_USER_STORE_DOMAIN("10036",
+                "Invalid user store domain specified in the invitation.",
+                "Could not find a user store domain with identifier %s."),
 
         // DAO layer errors
         ERROR_CODE_STORE_INVITATION("10501",

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/test/java/org/wso2/carbon/identity/organization/user/invitation/management/InvitationCoreServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/test/java/org/wso2/carbon/identity/organization/user/invitation/management/InvitationCoreServiceImplTest.java
@@ -18,19 +18,21 @@
 
 package org.wso2.carbon.identity.organization.user.invitation.management;
 
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.testng.PowerMockTestCase;
-import org.powermock.reflect.Whitebox;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.base.CarbonBaseConstants;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
-import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.core.util.IdentityDatabaseUtil;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.event.event.Event;
+import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.util.OrganizationSharedUserUtil;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
@@ -45,36 +47,32 @@ import org.wso2.carbon.identity.organization.user.invitation.management.models.I
 import org.wso2.carbon.identity.organization.user.invitation.management.models.InvitationResult;
 import org.wso2.carbon.identity.organization.user.invitation.management.models.RoleAssignments;
 import org.wso2.carbon.identity.organization.user.invitation.management.util.TestUtils;
+import org.wso2.carbon.identity.recovery.util.Utils;
 import org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService;
 import org.wso2.carbon.identity.role.v2.mgt.core.model.Role;
-import org.wso2.carbon.identity.role.v2.mgt.core.model.RoleBasicInfo;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
-import org.wso2.carbon.user.core.common.Group;
 import org.wso2.carbon.user.core.service.RealmService;
-import org.wso2.carbon.user.core.util.UserCoreUtil;
 
 import java.nio.file.Paths;
-import java.sql.Connection;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.support.membermodification.MemberMatcher.method;
-import static org.powermock.api.support.membermodification.MemberModifier.stub;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
+import static org.testng.AssertJUnit.assertNotNull;
 import static org.wso2.carbon.identity.organization.user.invitation.management.constant.UserInvitationMgtConstants.CLAIM_EMAIL_ADDRESS;
 import static org.wso2.carbon.identity.organization.user.invitation.management.constants.InvitationTestConstants.INV_01_CONF_CODE;
 import static org.wso2.carbon.identity.organization.user.invitation.management.constants.InvitationTestConstants.INV_01_EMAIL;
@@ -100,46 +98,47 @@ import static org.wso2.carbon.identity.organization.user.invitation.management.c
 import static org.wso2.carbon.identity.organization.user.invitation.management.constants.InvitationTestConstants.INV_04_INV_ORG_ID;
 import static org.wso2.carbon.identity.organization.user.invitation.management.constants.InvitationTestConstants.INV_04_UN;
 import static org.wso2.carbon.identity.organization.user.invitation.management.constants.InvitationTestConstants.INV_04_USER_ORG_ID;
-import static org.wso2.carbon.identity.organization.user.invitation.management.constants.InvitationTestConstants.USER_ID;
 import static org.wso2.carbon.identity.organization.user.invitation.management.util.TestUtils.closeH2Base;
 import static org.wso2.carbon.identity.organization.user.invitation.management.util.TestUtils.getConnection;
-import static org.wso2.carbon.user.core.UserCoreConstants.APPLICATION_DOMAIN;
-import static org.wso2.carbon.user.core.UserCoreConstants.INTERNAL_DOMAIN;
-import static org.wso2.carbon.user.core.UserCoreConstants.PRIMARY_DEFAULT_DOMAIN_NAME;
+import static org.wso2.carbon.identity.recovery.IdentityRecoveryConstants.ConnectorConfig.EMAIL_VERIFICATION_NOTIFICATION_INTERNALLY_MANAGE;
 
-@PrepareForTest({PrivilegedCarbonContext.class,
-        RoleManagementService.class,
-        IdentityDatabaseUtil.class,
-        UserInvitationMgtDataHolder.class,
-        IdentityTenantUtil.class,
-        UserInvitationMgtDataHolder.class,
-        IdentityUtil.class,
-        OrganizationSharedUserUtil.class,
-        UserCoreUtil.class,
-        InvitationCoreServiceImpl.class})
-public class InvitationCoreServiceImplTest extends PowerMockTestCase {
+public class InvitationCoreServiceImplTest {
 
     private final UserInvitationDAO userInvitationDAO = new UserInvitationDAOImpl();
     private InvitationCoreServiceImpl invitationCoreService;
     private final String [] roleList = {"1224", "12345"};
 
     private final String [] groupList = {"4321", "54321"};
+
+    @Mock
+    private RealmService realmService;
+    @Mock
+    private UserRealm userRealm;
+    @Mock
+    private AbstractUserStoreManager userStoreManager;
+    @Mock
+    private IdentityEventService identityEventService;
+
+    private MockedStatic<IdentityUtil> identityUtilMockedStatic;
+    private MockedStatic<OrganizationSharedUserUtil> organizationSharedUserUtilMockedStatic;
+    private MockedStatic<Utils> utilsMockedStatic;
+
     @BeforeClass
     public void setUp() throws Exception {
+
+        // Initialize mocks
+        MockitoAnnotations.initMocks(this);
 
         invitationCoreService = new InvitationCoreServiceImpl();
         TestUtils.initiateH2Base();
         setUpCarbonHome();
         mockCarbonContextForTenant();
-        mockStatic(IdentityTenantUtil.class);
-        mockStatic(IdentityDatabaseUtil.class);
-        mockStatic(IdentityUtil.class);
-        mockStatic(OrganizationSharedUserUtil.class);
 
-        Connection connection1 = getConnection();
-        Connection connection2 = getConnection();
-        Connection connection3 = getConnection();
-        Connection connection4 = getConnection();
+        identityUtilMockedStatic = mockStatic(IdentityUtil.class);
+        identityUtilMockedStatic.when(() -> IdentityUtil.getProperty(anyString())).thenReturn("1440");
+
+        organizationSharedUserUtilMockedStatic = mockStatic(OrganizationSharedUserUtil.class);
+        utilsMockedStatic = mockStatic(Utils.class);
 
         Invitation invitation1 = buildInvitation(INV_01_INVITATION_ID, INV_01_CONF_CODE, INV_01_UN,
                 "DEFAULT", INV_01_EMAIL,
@@ -161,10 +160,17 @@ public class InvitationCoreServiceImplTest extends PowerMockTestCase {
                 INV_04_INV_ORG_ID, new RoleAssignments[]{roleAssignments2}, new GroupAssignments[]{groupAssignments},
                 "PENDING");
 
-        populateH2Base(connection1, invitation1);
-        populateH2Base(connection2, invitation2);
-        populateH2Base(connection3, invitation3);
-        populateH2Base(connection4, invitation4);
+        storeParentUserInvitation(invitation1);
+        storeParentUserInvitation(invitation2);
+        storeParentUserInvitation(invitation3);
+        storeParentUserInvitation(invitation4);
+
+        UserInvitationMgtDataHolder.getInstance().setRealmService(realmService);
+        UserInvitationMgtDataHolder.getInstance().setIdentityEventService(identityEventService);
+        when(realmService.getTenantUserRealm(anyInt())).thenReturn(userRealm);
+        when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
+        when(userStoreManager.getSecondaryUserStoreManager(anyString())).thenReturn(userStoreManager);
+        doNothing().when(identityEventService).handleEvent(isA(Event.class));
     }
 
     private Role buildRoleInfo() {
@@ -181,7 +187,12 @@ public class InvitationCoreServiceImplTest extends PowerMockTestCase {
     public void tearDown() throws Exception {
 
         closeH2Base();
+        Mockito.reset(realmService);
+        Mockito.reset(userRealm);
+        Mockito.reset(userStoreManager);
+        Mockito.reset(identityEventService);
     }
+
 
     @DataProvider(name = "getInvitationFilter")
     public Object[][] getInvitationFilter() {
@@ -195,107 +206,121 @@ public class InvitationCoreServiceImplTest extends PowerMockTestCase {
     @Test(priority = 1)
     public void testGetInvitation() throws Exception {
 
-        when(IdentityDatabaseUtil.getDBConnection(anyBoolean())).thenReturn(getConnection());
-        RoleManagementService roleManagementService = mock(RoleManagementService.class);
-        UserInvitationMgtDataHolder.getInstance().setRoleManagementService(roleManagementService);
-        when(roleManagementService.getRoleWithoutUsers(anyString(), anyString())).thenReturn(buildRoleInfo());
-        OrganizationManager organizationManager = mock(OrganizationManager.class);
-        UserInvitationMgtDataHolder.getInstance().setOrganizationManagerService(organizationManager);
-        when(organizationManager.resolveTenantDomain(anyString())).thenReturn("carbon.super");
+        try (MockedStatic<IdentityDatabaseUtil> identityDBUtil = Mockito.mockStatic(IdentityDatabaseUtil.class);
+             MockedStatic<IdentityTenantUtil> identityUtil = Mockito.mockStatic(IdentityTenantUtil.class)) {
 
-        RealmService realmService = mock(RealmService.class);
-        UserInvitationMgtDataHolder.getInstance().setRealmService(realmService);
-        UserRealm userRealm = mock(UserRealm.class);
-        AbstractUserStoreManager userStoreManager = mock(AbstractUserStoreManager.class);
-        when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
-        when(realmService.getTenantUserRealm(anyInt())).thenReturn(userRealm);
+            identityUtil.when(() -> IdentityTenantUtil.getTenantId(anyString())).thenReturn(-1234);
+            identityDBUtil.when(() -> IdentityDatabaseUtil.getDBConnection(anyBoolean())).thenReturn(getConnection());
+            RoleManagementService roleManagementService = mock(RoleManagementService.class);
+            UserInvitationMgtDataHolder.getInstance().setRoleManagementService(roleManagementService);
+            when(roleManagementService.getRoleWithoutUsers(anyString(), anyString())).thenReturn(buildRoleInfo());
+            OrganizationManager organizationManager = mock(OrganizationManager.class);
+            UserInvitationMgtDataHolder.getInstance().setOrganizationManagerService(organizationManager);
+            when(organizationManager.resolveTenantDomain(anyString())).thenReturn("carbon.super");
 
-        List<Invitation> invitationList = invitationCoreService.getInvitations(null);
-        // Checking whether the size of the Invitation list is not empty.
-        assertFalse(invitationList.isEmpty());
+            List<Invitation> invitationList = invitationCoreService.getInvitations(null);
+            // Checking whether the size of the Invitation list is not empty.
+            assertFalse(invitationList.isEmpty());
 
-        Invitation invitation0 = invitationList.get(0);
-        assertEquals(invitation0.getInvitationId(), INV_02_INVITATION_ID);
-        assertEquals(invitation0.getConfirmationCode(), INV_02_CONF_CODE);
-        assertEquals(invitation0.getUsername(), INV_02_UN);
+            Invitation invitation0 = invitationList.get(0);
+            assertEquals(invitation0.getInvitationId(), INV_02_INVITATION_ID);
+            assertEquals(invitation0.getConfirmationCode(), INV_02_CONF_CODE);
+            assertEquals(invitation0.getUsername(), INV_02_UN);
 
-        Invitation invitation1 = invitationList.get(1);
-        assertEquals(invitation1.getInvitationId(), INV_03_INVITATION_ID);
-        assertEquals(invitation1.getConfirmationCode(), INV_03_CONF_CODE);
-        assertEquals(invitation1.getUsername(), INV_03_UN);
+            Invitation invitation1 = invitationList.get(1);
+            assertEquals(invitation1.getInvitationId(), INV_03_INVITATION_ID);
+            assertEquals(invitation1.getConfirmationCode(), INV_03_CONF_CODE);
+            assertEquals(invitation1.getUsername(), INV_03_UN);
+        }
     }
 
     @Test(priority = 2)
     public void testIntrospectInvitation() throws Exception {
 
-        when(IdentityDatabaseUtil.getDBConnection(anyBoolean())).thenReturn(getConnection());
-        Invitation invitation = invitationCoreService.introspectInvitation(INV_01_CONF_CODE);
-        assertEquals(invitation.getInvitationId(), INV_01_INVITATION_ID);
-        assertEquals(invitation.getUsername(), INV_01_UN);
-        assertEquals(invitation.getEmail(), INV_01_EMAIL);
-        assertEquals(invitation.getStatus(), "PENDING");
+        try (MockedStatic<IdentityDatabaseUtil> identityDBUtil = Mockito.mockStatic(IdentityDatabaseUtil.class)) {
+
+            identityDBUtil.when(() -> IdentityDatabaseUtil.getDBConnection(anyBoolean())).thenReturn(getConnection());
+            Invitation invitation = invitationCoreService.introspectInvitation(INV_01_CONF_CODE);
+            assertEquals(invitation.getInvitationId(), INV_01_INVITATION_ID);
+            assertEquals(invitation.getUsername(), INV_01_UN);
+            assertEquals(invitation.getEmail(), INV_01_EMAIL);
+            assertEquals(invitation.getStatus(), "PENDING");
+        }
     }
 
     @Test(priority = 3)
     public void testGetInvitationWithFilter() throws Exception {
 
         String filter = "status eq PENDING";
-        when(IdentityDatabaseUtil.getDBConnection(anyBoolean())).thenReturn(getConnection());
-        List<Invitation> invitationList = invitationCoreService.getInvitations(filter);
-        // Checking whether the size of the Invitation list is not empty.
-        assertFalse(invitationList.isEmpty());
+        try (MockedStatic<IdentityDatabaseUtil> identityDBUtil = Mockito.mockStatic(IdentityDatabaseUtil.class);
+             MockedStatic<IdentityTenantUtil> identityUtil = Mockito.mockStatic(IdentityTenantUtil.class)) {
 
-        Invitation invitation0 = invitationList.get(0);
-        assertEquals(invitation0.getStatus(), "PENDING");
+            identityUtil.when(() -> IdentityTenantUtil.getTenantId(anyString())).thenReturn(-1234);
+            identityDBUtil.when(() -> IdentityDatabaseUtil.getDBConnection(anyBoolean())).thenReturn(getConnection());
+            List<Invitation> invitationList = invitationCoreService.getInvitations(filter);
+            // Checking whether the size of the Invitation list is not empty.
+            assertFalse(invitationList.isEmpty());
+
+            Invitation invitation0 = invitationList.get(0);
+            assertEquals(invitation0.getStatus(), "PENDING");
+        }
     }
 
     @Test(priority = 4)
     public void testDeleteInvitation() throws Exception {
 
-        Connection connection = getConnection();
-        Connection connection1 = getConnection();
-        when(IdentityDatabaseUtil.getDBConnection(false)).thenReturn(connection);
-        when(IdentityDatabaseUtil.getDBConnection(true)).thenReturn(connection1);
-        assertTrue(invitationCoreService.deleteInvitation(INV_02_INVITATION_ID));
+        try (MockedStatic<IdentityDatabaseUtil> identityDBUtil = Mockito.mockStatic(IdentityDatabaseUtil.class)) {
+
+            identityDBUtil.when(() -> IdentityDatabaseUtil.getDBConnection(anyBoolean())).thenReturn(getConnection())
+                    .thenReturn(getConnection());
+            assertTrue(invitationCoreService.deleteInvitation(INV_02_INVITATION_ID));
+        }
     }
 
     @Test(priority = 5, expectedExceptions = UserInvitationMgtClientException.class,
             dataProvider = "getInvitationFilter")
     public void testGetInvitationWithInvalidFilter(String filter) throws Exception {
 
-        when(IdentityDatabaseUtil.getDBConnection(anyBoolean())).thenReturn(getConnection());
-        invitationCoreService.getInvitations(filter);
-        fail("Expected: " + UserInvitationMgtClientException.class.getName());
+        try (MockedStatic<IdentityDatabaseUtil> identityDBUtil = Mockito.mockStatic(IdentityDatabaseUtil.class)) {
+
+            identityDBUtil.when(() -> IdentityDatabaseUtil.getDBConnection(anyBoolean())).thenReturn(getConnection());
+            invitationCoreService.getInvitations(filter);
+            fail("Expected: " + UserInvitationMgtClientException.class.getName());
+        }
     }
 
     @Test(priority = 6, expectedExceptions = UserInvitationMgtException.class)
     public void testIntrospectWithInvalidConfirmationCode() throws Exception {
 
-        when(IdentityDatabaseUtil.getDBConnection(anyBoolean())).thenReturn(getConnection());
-        invitationCoreService.introspectInvitation("1234");
-        fail("Expected: " + UserInvitationMgtException.class.getName());
+        try (MockedStatic<IdentityDatabaseUtil> identityDBUtil = Mockito.mockStatic(IdentityDatabaseUtil.class)) {
+
+            identityDBUtil.when(() -> IdentityDatabaseUtil.getDBConnection(anyBoolean())).thenReturn(getConnection());
+            invitationCoreService.introspectInvitation("1234");
+            fail("Expected: " + UserInvitationMgtException.class.getName());
+        }
     }
 
     @Test(priority = 7, expectedExceptions = UserInvitationMgtException.class)
     public void testDeleteInvitationWithInvalidInvitationId() throws Exception {
 
-        Connection connection = getConnection();
-        Connection connection1 = getConnection();
-        when(IdentityDatabaseUtil.getDBConnection(false)).thenReturn(connection);
-        when(IdentityDatabaseUtil.getDBConnection(true)).thenReturn(connection1);
-        invitationCoreService.deleteInvitation("23446012-18c7-4cd6-a757-16c39dbf4053");
-        fail("Expected: " + UserInvitationMgtException.class.getName());
+        try (MockedStatic<IdentityDatabaseUtil> identityDBUtil = Mockito.mockStatic(IdentityDatabaseUtil.class)) {
+
+            identityDBUtil.when(() -> IdentityDatabaseUtil.getDBConnection(anyBoolean())).thenReturn(getConnection());
+            invitationCoreService.deleteInvitation("23446012-18c7-4cd6-a757-16c39dbf4053");
+            fail("Expected: " + UserInvitationMgtException.class.getName());
+        }
     }
 
     @Test(priority = 8, expectedExceptions = UserInvitationMgtException.class)
     public void testDeleteInvitationWithNotOwnedInvitationId() throws Exception {
 
-        Connection connection = getConnection();
-        Connection connection1 = getConnection();
-        when(IdentityDatabaseUtil.getDBConnection(false)).thenReturn(connection);
-        when(IdentityDatabaseUtil.getDBConnection(true)).thenReturn(connection1);
-        assertTrue(invitationCoreService.deleteInvitation("1234"));
+        try (MockedStatic<IdentityDatabaseUtil> identityDBUtil = Mockito.mockStatic(IdentityDatabaseUtil.class)) {
+
+            identityDBUtil.when(() -> IdentityDatabaseUtil.getDBConnection(anyBoolean())).thenReturn(getConnection());
+            assertTrue(invitationCoreService.deleteInvitation("1234"));
+        }
     }
+
     @Test(priority = 9)
     public void testCreateInvitationWithNonExistingUserInParent() throws Exception {
 
@@ -306,14 +331,8 @@ public class InvitationCoreServiceImplTest extends PowerMockTestCase {
         invitation1.setUserRedirectUrl("https://localhost:8080/travel-manager-001/invitations/accept");
 
         OrganizationManager organizationManager = mock(OrganizationManager.class);
-        RealmService realmService = mock(RealmService.class);
-        UserRealm userRealm = mock(UserRealm.class);
-        AbstractUserStoreManager userStoreManager = mock(AbstractUserStoreManager.class);
 
         when(userStoreManager.isExistingUser("samson")).thenReturn(false);
-        when(userRealm.getUserStoreManager()).thenReturn(userStoreManager);
-        when(realmService.getTenantUserRealm(anyInt())).thenReturn(userRealm);
-        UserInvitationMgtDataHolder.getInstance().setRealmService(realmService);
         UserInvitationMgtDataHolder.getInstance().setOrganizationManagerService(organizationManager);
 
         List<String> ancestors = new ArrayList<>();
@@ -321,13 +340,15 @@ public class InvitationCoreServiceImplTest extends PowerMockTestCase {
         ancestors.add("8d94ff8a-031f-4719-8713-c6a9819b23b2");
         when(organizationManager.getAncestorOrganizationIds(anyString())).thenReturn(ancestors);
 
-        when(IdentityDatabaseUtil.getDBConnection(false)).thenReturn(getConnection());
-        when(IdentityDatabaseUtil.getDBConnection(true)).thenReturn(getConnection());
-        when(IdentityTenantUtil.getTenantId(anyString())).thenReturn(-1234);
-        mockIdentityTenantUtil();
-        List<InvitationResult> createdInvitation = invitationCoreService.createInvitations(invitation1);
-        assertNotNull(createdInvitation);
-        assertEquals(createdInvitation.get(0).getStatus(), "Failed");
+        try (MockedStatic<IdentityDatabaseUtil> identityDBUtil = Mockito.mockStatic(IdentityDatabaseUtil.class);
+             MockedStatic<IdentityTenantUtil> identityUtil = Mockito.mockStatic(IdentityTenantUtil.class)) {
+
+            identityUtil.when(() -> IdentityTenantUtil.getTenantId(anyString())).thenReturn(-1234);
+            identityDBUtil.when(() -> IdentityDatabaseUtil.getDBConnection(anyBoolean())).thenReturn(getConnection());
+            List<InvitationResult> createdInvitation = invitationCoreService.createInvitations(invitation1);
+            assertNotNull(createdInvitation);
+            assertEquals(createdInvitation.get(0).getStatus(), "Failed");
+        }
     }
 
     @DataProvider(name = "testConfirmationCodeReturnOnInviteCreationDataProvider")
@@ -335,22 +356,22 @@ public class InvitationCoreServiceImplTest extends PowerMockTestCase {
 
         return new Object[][]{
                 {
-                        true, "false", true, true
+                        true, "false", "true", true
                 },
                 {
-                        true, "false", false, true
+                        true, "false", "false", true
                 },
                 {
-                        true, "true", true, false
+                        false, null, "false", true
                 },
                 {
-                        true, "true", false, false
+                        true, "true", "false", false
                 },
                 {
-                        false, null, false, true
+                        true, "true", "true", false
                 },
                 {
-                        false, null, true, false
+                        false, null, "true", false
                 }
         };
     }
@@ -358,7 +379,7 @@ public class InvitationCoreServiceImplTest extends PowerMockTestCase {
     @Test(priority = 10, dataProvider = "testConfirmationCodeReturnOnInviteCreationDataProvider")
     public void testConfirmationCodeReturnOnInviteCreation(boolean setNotificationManagingProperty,
                                                            String propertyValue,
-                                                           boolean isNotificationManagedInternallyForOrg,
+                                                           String isNotificationManagedInternallyForOrg,
                                                            boolean isConfirmationCodeReturnInResponse)
             throws Exception {
 
@@ -382,23 +403,7 @@ public class InvitationCoreServiceImplTest extends PowerMockTestCase {
         }
 
         OrganizationManager organizationManager = mock(OrganizationManager.class);
-        RealmService realmService = mock(RealmService.class);
 
-        UserRealm userRealmSubOrg = mock(UserRealm.class);
-        AbstractUserStoreManager userStoreManagerSubOrg = mock(AbstractUserStoreManager.class);
-        mockSubOrgDetails(userStoreManagerSubOrg, userStoreQualifiedUsername, userRealmSubOrg, realmService,
-                tenantDomainOfSubOrg, organizationManager, subOrgId);
-
-        UserRealm userRealmParentOrg = mock(UserRealm.class);
-        AbstractUserStoreManager userStoreManagerParentOrg = mock(AbstractUserStoreManager.class);
-        mockParentOrgDetails(userStoreManagerParentOrg, userStoreQualifiedUsername, userId, userRealmParentOrg,
-                realmService, tenantDomainOfParentOrg, organizationManager, parentOrgId);
-
-        OrganizationSharedUserUtil organizationSharedUserUtil = mock(OrganizationSharedUserUtil.class);
-        when(organizationSharedUserUtil.getUserManagedOrganizationClaim(userStoreManagerSubOrg, userId)).thenReturn(
-                parentOrgId);
-
-        UserInvitationMgtDataHolder.getInstance().setRealmService(realmService);
         UserInvitationMgtDataHolder.getInstance().setOrganizationManagerService(organizationManager);
         List<String> ancestors = new ArrayList<>();
         ancestors.add(subOrgId);
@@ -407,128 +412,87 @@ public class InvitationCoreServiceImplTest extends PowerMockTestCase {
         when(organizationManager.getAncestorOrganizationIds(anyString())).thenReturn(ancestors);
         when(organizationManager.getParentOrganizationId(subOrgId)).thenReturn(parentOrgId);
 
-        stub(method(InvitationCoreServiceImpl.class, "isActiveInvitationAvailable",
-                String.class, String.class, String.class, String.class)).toReturn(false);
-        stub(method(InvitationCoreServiceImpl.class, "isUserExistAtInvitedOrganization",
-                String.class)).toReturn(false);
-        stub(method(InvitationCoreServiceImpl.class, "triggerInvitationAddNotification", Invitation.class))
-                .toReturn(true);
-        stub(method(InvitationCoreServiceImpl.class, "isNotificationsInternallyManagedForOrganization",
-                String.class)).toReturn(isNotificationManagedInternallyForOrg);
+        utilsMockedStatic.when(() -> Utils.getConnectorConfig(EMAIL_VERIFICATION_NOTIFICATION_INTERNALLY_MANAGE,
+                "carbon.super")).thenReturn(isNotificationManagedInternallyForOrg);
 
-        when(IdentityDatabaseUtil.getDBConnection(true)).thenReturn(getConnection());
-        when(IdentityDatabaseUtil.getDBConnection(false)).thenReturn(getConnection());
+        try (MockedStatic<IdentityDatabaseUtil> identityDBUtil = Mockito.mockStatic(IdentityDatabaseUtil.class);
+             MockedStatic<IdentityTenantUtil> identityUtil = Mockito.mockStatic(IdentityTenantUtil.class)) {
 
-        List<InvitationResult> createdInvitation = invitationCoreService.createInvitations(invitation);
-        assertNotNull(createdInvitation);
-        assertEquals(createdInvitation.get(0).getStatus(), "Successful");
-        if (isConfirmationCodeReturnInResponse) {
-            assertNotNull(createdInvitation.get(0).getConfirmationCode());
+            identityUtil.when(() -> IdentityTenantUtil.getTenantId(anyString())).thenReturn(-1234);
+            identityDBUtil.when(() -> IdentityDatabaseUtil.getDBConnection(true))
+                    .thenReturn(getConnection());
+            identityDBUtil.when(() -> IdentityDatabaseUtil.getDBConnection(false))
+                    .thenReturn(getConnection()).thenReturn(getConnection());
+
+            UserRealm userRealmParentOrg = mock(UserRealm.class);
+            AbstractUserStoreManager userStoreManagerParentOrg = mock(AbstractUserStoreManager.class);
+            mockParentOrgDetails(userStoreManagerParentOrg, userStoreQualifiedUsername, userId, userRealmParentOrg,
+                    realmService, tenantDomainOfParentOrg, organizationManager, parentOrgId, identityDBUtil);
+            when(userStoreManagerParentOrg.getSecondaryUserStoreManager(anyString()))
+                    .thenReturn(userStoreManagerParentOrg);
+
+            UserRealm userRealmSubOrg = mock(UserRealm.class);
+            AbstractUserStoreManager userStoreManagerSubOrg = mock(AbstractUserStoreManager.class);
+            mockSubOrgDetails(userStoreManagerSubOrg, userStoreQualifiedUsername, userRealmSubOrg, realmService,
+                    tenantDomainOfSubOrg, organizationManager, subOrgId, identityDBUtil);
+
+            when(userStoreManagerParentOrg.getSecondaryUserStoreManager(anyString()))
+                    .thenReturn(userStoreManagerParentOrg);
+
+            organizationSharedUserUtilMockedStatic
+                    .when(() -> OrganizationSharedUserUtil
+                            .getUserManagedOrganizationClaim(userStoreManagerSubOrg, userId))
+                    .thenReturn(parentOrgId);
+
+            List<InvitationResult> createdInvitation = invitationCoreService.createInvitations(invitation);
+            assertNotNull(createdInvitation);
+            assertEquals(createdInvitation.get(0).getStatus(), "Successful");
+
+            // Clean the stored invitation.
+            identityDBUtil.when(() -> IdentityDatabaseUtil.getDBConnection(false))
+                    .thenReturn(getConnection()).thenReturn(getConnection());
+            identityDBUtil.when(() -> IdentityDatabaseUtil.getDBConnection(true))
+                    .thenReturn(getConnection());
+            Invitation storedInvitation;
+            if (isConfirmationCodeReturnInResponse) {
+                assertNotNull(createdInvitation.get(0).getConfirmationCode());
+                storedInvitation = userInvitationDAO
+                        .getInvitationWithAssignmentsByConfirmationCode(createdInvitation.get(0).getConfirmationCode());
+            } else {
+                String invitedUsername = createdInvitation.get(0).getUsername();
+                storedInvitation = userInvitationDAO.getActiveInvitationByUser(invitedUsername, "DEFAULT",
+                        parentOrgId, subOrgId);
+            }
+            userInvitationDAO.deleteInvitation(storedInvitation.getInvitationId());
         }
     }
 
-    @Test(priority = 11)
-    public void testGetUserGroups() throws Exception {
 
-        // Mocking IdentityTenantUtil.getTenantId static method
-        when(IdentityTenantUtil.getTenantId(anyString())).thenReturn(1);
 
-        // Mocking the getAbstractUserStoreManager method
-        AbstractUserStoreManager userStoreManager = mock(AbstractUserStoreManager.class);
-        stub(method(InvitationCoreServiceImpl.class, "getAbstractUserStoreManager", int.class))
-                .toReturn(userStoreManager);
+    @Test(priority = 13, expectedExceptions = UserInvitationMgtClientException.class,
+            expectedExceptionsMessageRegExp = ".*Invalid user store domain specified in the invitation.*")
+    public void testCreateInvitationWithInvalidUserStoreDomain() throws Exception {
 
-        // Mocking the userStoreManager.getGroupListOfUser method
-        Group group1 = mock(Group.class);
-        Group group2 = mock(Group.class);
-        Group group3 = mock(Group.class);
-        when(group1.getGroupName()).thenReturn("Application/group1");
-        when(group2.getGroupName()).thenReturn("Internal/group2");
-        when(group3.getGroupName()).thenReturn("Primary/group3");
-        when(group1.getGroupID()).thenReturn("1");
-        when(group2.getGroupID()).thenReturn("2");
-        when(group3.getGroupID()).thenReturn("3");
-        List<Group> groups = Arrays.asList(group1, group2, group3);
-        when(userStoreManager.getGroupListOfUser(USER_ID, null, null)).thenReturn(groups);
+        InvitationDO invitation1 = new InvitationDO();
+        invitation1.setUserDomain("INVALID");
+        invitation1.setUserRedirectUrl("https://localhost:8080/travel-manager-001/invitations/accept");
 
-        // Mocking UserCoreUtil.extractDomainFromName
-        mockStatic(UserCoreUtil.class);
-        when(UserCoreUtil.extractDomainFromName("Application/group1")).thenReturn(APPLICATION_DOMAIN);
-        when(UserCoreUtil.extractDomainFromName("Internal/group2")).thenReturn(INTERNAL_DOMAIN);
-        when(UserCoreUtil.extractDomainFromName("Primary/group3"))
-                .thenReturn(PRIMARY_DEFAULT_DOMAIN_NAME);
+        OrganizationManager organizationManager = mock(OrganizationManager.class);
+        UserInvitationMgtDataHolder.getInstance().setOrganizationManagerService(organizationManager);
+        when(userStoreManager.getSecondaryUserStoreManager(invitation1.getUserDomain())).thenReturn(null);
 
-        // Invoking the method
-        List<String> resultUserGroups = Whitebox.invokeMethod(
-                invitationCoreService, "getUserGroups", USER_ID, CarbonBaseConstants.CARBON_HOME);
+        try (MockedStatic<IdentityTenantUtil> identityUtil = Mockito.mockStatic(IdentityTenantUtil.class)) {
 
-        // Assertion
-        List<String> expectedUserGroups = Collections.singletonList("3");
-        assertEquals(resultUserGroups, expectedUserGroups);
+            identityUtil.when(() -> IdentityTenantUtil.getTenantId(anyString())).thenReturn(-1234);
+            invitationCoreService.createInvitations(invitation1);
+        }
     }
 
-    @Test(priority = 12)
-    public void testIsInvitedUserHasConsoleAccess() throws Exception {
-
-        // Mocking Role List
-        RoleBasicInfo role1 = new RoleBasicInfo("1", "Role1");
-        RoleBasicInfo role2 = new RoleBasicInfo("2", "Role2");
-        RoleBasicInfo role3 = new RoleBasicInfo("3", "Role3");
-        RoleBasicInfo role4 = new RoleBasicInfo("4", "Role4");
-        role2.setAudienceName(FrameworkConstants.Application.CONSOLE_APP);
-        List<RoleBasicInfo> roleList = new ArrayList<>(Arrays.asList(role1, role2));
-
-        // Mocking Group List
-        List<String> groupList = Arrays.asList("groupID1", "groupID2");
-
-        // Mocking RoleManagementService getRoleListOfUser
-        RoleManagementService roleManagementService = mock(RoleManagementService.class);
-        stub(method(InvitationCoreServiceImpl.class, "getRoleManagementService"))
-                .toReturn(roleManagementService);
-        when(roleManagementService.getRoleListOfUser(USER_ID, CarbonBaseConstants.CARBON_HOME)).thenReturn(roleList);
-
-        // Stubbing getUserGroups Method
-        stub(method(InvitationCoreServiceImpl.class, "getUserGroups")).toReturn(groupList);
-
-        // Mocking RoleManagementService getRoleListOfGroups
-        List<RoleBasicInfo> roleListFromUserGroups = Arrays.asList(role3, role4);
-        when(roleManagementService.getRoleListOfGroups(groupList, CarbonBaseConstants.CARBON_HOME))
-                .thenReturn(roleListFromUserGroups);
-
-        // Invoke the method under test
-        boolean resultWithDirectConsoleAccess = Whitebox.invokeMethod(invitationCoreService,
-                "isInvitedUserHasConsoleAccess", USER_ID, CarbonBaseConstants.CARBON_HOME);
-
-        // Assertion
-        assertTrue(resultWithDirectConsoleAccess);
-
-        // Test case where user does inherit have console access via a group role
-        role2.setAudienceName("App1");
-        role4.setAudienceName(FrameworkConstants.Application.CONSOLE_APP);
-
-        // Re-invoke the method under test
-        Boolean resultWithConsoleAccessViaGroup = Whitebox.invokeMethod(invitationCoreService,
-                "isInvitedUserHasConsoleAccess", USER_ID, CarbonBaseConstants.CARBON_HOME);
-
-        // Assertion
-        assertTrue(resultWithConsoleAccessViaGroup);
-
-        // Test case where user does not have console access
-        role4.setAudienceName("App1");
-
-        // Re-invoke the method under test
-        Boolean resultWithoutConsoleAccess = Whitebox.invokeMethod(invitationCoreService,
-                "isInvitedUserHasConsoleAccess", USER_ID, CarbonBaseConstants.CARBON_HOME);
-
-        // Assertion
-        assertFalse(resultWithoutConsoleAccess);
-    }
-
-    private static void mockParentOrgDetails(AbstractUserStoreManager userStoreManagerParentOrg,
+    private void mockParentOrgDetails(AbstractUserStoreManager userStoreManagerParentOrg,
                                              String userStoreQualifiedUsername,
                                              String userId, UserRealm userRealmParentOrg, RealmService realmService,
                                              String tenantDomainOfParentOrg, OrganizationManager organizationManager,
-                                             String parentOrgId)
+                                             String parentOrgId, MockedStatic<IdentityDatabaseUtil> identityDBUtil)
             throws UserStoreException, OrganizationManagementException {
 
         when(userStoreManagerParentOrg.isExistingUser(userStoreQualifiedUsername)).thenReturn(true);
@@ -538,23 +502,24 @@ public class InvitationCoreServiceImplTest extends PowerMockTestCase {
                 "alex@gmail.com");
         when(userRealmParentOrg.getUserStoreManager()).thenReturn(userStoreManagerParentOrg);
         when(realmService.getTenantUserRealm(1)).thenReturn(userRealmParentOrg);
-        when(IdentityTenantUtil.getTenantId(tenantDomainOfParentOrg)).thenReturn(1);
-        when(IdentityTenantUtil.getTenantDomain(1)).thenReturn(tenantDomainOfParentOrg);
+        identityDBUtil.when(() -> IdentityTenantUtil.getTenantId(tenantDomainOfParentOrg)).thenReturn(1);
+        identityDBUtil.when(() -> IdentityTenantUtil.getTenantDomain(1)).thenReturn(tenantDomainOfParentOrg);
         when(organizationManager.resolveTenantDomain(parentOrgId)).thenReturn(tenantDomainOfParentOrg);
     }
 
-    private static void mockSubOrgDetails(AbstractUserStoreManager userStoreManagerSubOrg,
+    private void mockSubOrgDetails(AbstractUserStoreManager userStoreManagerSubOrg,
                                           String userStoreQualifiedUsername,
                                           UserRealm userRealmSubOrg, RealmService realmService,
                                           String tenantDomainOfSubOrg,
-                                          OrganizationManager organizationManager, String subOrgId)
+                                          OrganizationManager organizationManager, String subOrgId,
+                                   MockedStatic<IdentityDatabaseUtil> identityDBUtil)
             throws UserStoreException, OrganizationManagementException {
 
         when(userStoreManagerSubOrg.isExistingUser(userStoreQualifiedUsername)).thenReturn(false);
         when(userRealmSubOrg.getUserStoreManager()).thenReturn(userStoreManagerSubOrg);
         when(realmService.getTenantUserRealm(2)).thenReturn(userRealmSubOrg);
-        when(IdentityTenantUtil.getTenantId(tenantDomainOfSubOrg)).thenReturn(2);
-        when(IdentityTenantUtil.getTenantDomain(2)).thenReturn(tenantDomainOfSubOrg);
+        identityDBUtil.when(() -> IdentityTenantUtil.getTenantId(tenantDomainOfSubOrg)).thenReturn(2);
+        identityDBUtil.when(() -> IdentityTenantUtil.getTenantDomain(2)).thenReturn(tenantDomainOfSubOrg);
         when(organizationManager.resolveTenantDomain(subOrgId)).thenReturn(tenantDomainOfSubOrg);
     }
 
@@ -566,23 +531,20 @@ public class InvitationCoreServiceImplTest extends PowerMockTestCase {
                 "repository/conf").toString());
     }
 
-    private static void mockIdentityTenantUtil() {
+    private void storeParentUserInvitation(Invitation invitation) throws Exception {
 
-        when(IdentityTenantUtil.getTenantDomain(anyInt())).thenReturn("carbon.super");
-    }
-
-    private void populateH2Base(Connection connection, Invitation invitation) throws Exception {
-
-        when(IdentityDatabaseUtil.getDBConnection(anyBoolean())).thenReturn(connection);
-        when(IdentityUtil.getProperty(anyString())).thenReturn("1440");
-        if (invitation.getRoleAssignments() != null) {
-            for (RoleAssignments roleAssignments : invitation.getRoleAssignments()) {
-                for (String role : roleList) {
-                    roleAssignments.setRole(role);
+        try (MockedStatic<IdentityDatabaseUtil> identityDBUtil = Mockito.mockStatic(IdentityDatabaseUtil.class)) {
+            identityDBUtil.when(() -> IdentityDatabaseUtil.getDBConnection(anyBoolean())).thenReturn(getConnection());
+            when(IdentityUtil.getProperty(anyString())).thenReturn("1440");
+            if (invitation.getRoleAssignments() != null) {
+                for (RoleAssignments roleAssignments : invitation.getRoleAssignments()) {
+                    for (String role : roleList) {
+                        roleAssignments.setRole(role);
+                    }
                 }
             }
+            userInvitationDAO.createInvitation(invitation);
         }
-        userInvitationDAO.createInvitation(invitation);
     }
 
     private void mockCarbonContextForTenant() {

--- a/pom.xml
+++ b/pom.xml
@@ -297,25 +297,7 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-inline</artifactId>
-                <version>${mockito-core.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-core</artifactId>
-                <version>${powermock.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-api-mockito2</artifactId>
-                <version>${powermock.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.powermock</groupId>
-                <artifactId>powermock-module-testng</artifactId>
-                <version>${powermock.version}</version>
+                <version>${mockito-inline.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -428,6 +410,25 @@
                         <doUpdate>false</doUpdate>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>${jacoco.version}</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>prepare-agent</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>report</id>
+                            <phase>test</phase>
+                            <goals>
+                                <goal>report</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
 
@@ -475,6 +476,25 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>
@@ -557,12 +577,11 @@
         <oltu.oauth2.client.version>1.0.0</oltu.oauth2.client.version>
         <oltu.oauth2.client.version.range>[1.0.0,1.0.3)</oltu.oauth2.client.version.range>
 
-        <mockito-core.version>4.6.1</mockito-core.version>
-        <jacoco.version>0.8.2</jacoco.version>
+        <mockito-core.version>5.3.1</mockito-core.version>
+        <mockito-inline.version>5.2.0</mockito-inline.version>
         <testng.version>6.9.10</testng.version>
         <maven.surefire.plugin.version>2.22.0</maven.surefire.plugin.version>
         <h2database.version>1.4.199</h2database.version>
-        <powermock.version>2.0.9</powermock.version>
 
         <openapi.tools.version>4.1.2</openapi.tools.version>
 
@@ -574,7 +593,7 @@
         <findbugs.annotations.version>3.0.1</findbugs.annotations.version>
         <carbon.p2.plugin.version>5.1.2</carbon.p2.plugin.version>
         <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
-        <jacoco.version>0.8.2</jacoco.version>
+        <jacoco.version>0.8.12</jacoco.version>
 
         <compiler-source.version>1.8</compiler-source.version>
         <compiler-target.version>1.8</compiler-target.version>


### PR DESCRIPTION
## Purpose
> Add a validation logic to verify the provided invitation user store domain is valid or not https://github.com/wso2-extensions/identity-organization-management/pull/402/files#diff-ebba2067b3fa55047938aa6006a6864220dd3d4de3854fc2894d203714e0e926R737-R746

In this effort the following improvements are made.
- [x] Fix codecov plugin and report generation issue.
- [x] Remove powermock and replace tests with Mockito
- [x] Oraganize the invitation core test class.

### Related Issues
- https://github.com/wso2/product-is/issues/21460
