### PR TITLE
Inherit APIBasedAuthenticationEnabled property from parent application to the shared application

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManagerImpl.java
@@ -902,8 +902,6 @@ public class OrgApplicationManagerImpl implements OrgApplicationManager {
         delegatedApplication.setApplicationName(oAuthConsumerApp.getApplicationName());
         delegatedApplication.setDescription(mainApplication.getDescription());
         delegatedApplication.setInboundAuthenticationConfig(inboundAuthConfig);
-        delegatedApplication.setAPIBasedAuthenticationEnabled(mainApplication.isAPIBasedAuthenticationEnabled());
-
         if (ApplicationMgtUtil.isConsole(mainApplication.getApplicationName())) {
             delegatedApplication.setAccessUrl(resolveAccessURL(mainApplication.getTenantDomain(), sharedOrgId,
                     FrameworkConstants.Application.CONSOLE_APP_PATH));

--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManagerImpl.java
@@ -902,6 +902,8 @@ public class OrgApplicationManagerImpl implements OrgApplicationManager {
         delegatedApplication.setApplicationName(oAuthConsumerApp.getApplicationName());
         delegatedApplication.setDescription(mainApplication.getDescription());
         delegatedApplication.setInboundAuthenticationConfig(inboundAuthConfig);
+        delegatedApplication.setAPIBasedAuthenticationEnabled(mainApplication.isAPIBasedAuthenticationEnabled());
+
         if (ApplicationMgtUtil.isConsole(mainApplication.getApplicationName())) {
             delegatedApplication.setAccessUrl(resolveAccessURL(mainApplication.getTenantDomain(), sharedOrgId,
                     FrameworkConstants.Application.CONSOLE_APP_PATH));

--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
@@ -360,6 +360,7 @@ public class FragmentApplicationMgtListener extends AbstractApplicationMgtListen
                 }
             }
             sharedApplication.setSpProperties(properties);
+            sharedApplication.setAPIBasedAuthenticationEnabled(mainApplication.isAPIBasedAuthenticationEnabled());
         }
     }
 

--- a/components/org.wso2.carbon.identity.organization.management.application/src/test/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListenerTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/test/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2024, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -23,23 +23,35 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.testng.AssertJUnit;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementClientException;
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
+import org.wso2.carbon.identity.application.common.model.Claim;
+import org.wso2.carbon.identity.application.common.model.ClaimConfig;
+import org.wso2.carbon.identity.application.common.model.ClaimMapping;
+import org.wso2.carbon.identity.application.common.model.LocalAndOutboundAuthenticationConfig;
 import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.common.model.ServiceProviderProperty;
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.organization.management.application.dao.OrgApplicationMgtDAO;
 import org.wso2.carbon.identity.organization.management.application.internal.OrgApplicationMgtDataHolder;
+import org.wso2.carbon.identity.organization.management.application.model.MainApplicationDO;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertTrue;
 import static org.testng.AssertJUnit.assertEquals;
+import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.IS_API_BASED_AUTHENTICATION_ENABLED_PROPERTY_NAME;
 import static org.wso2.carbon.identity.organization.management.application.constant.OrgApplicationMgtConstants.IS_FRAGMENT_APP;
 
 /**
@@ -50,15 +62,25 @@ public class FragmentApplicationMgtListenerTest {
     @Mock
     private OrganizationManager organizationManager;
 
+    @Mock
+    private OrgApplicationMgtDAO orgApplicationMgtDAO;
+
+    @Mock
+    private ApplicationManagementService applicationManagementService;
+
     @InjectMocks
     private FragmentApplicationMgtListener fragmentApplicationMgtListener;
 
     private MockedStatic<IdentityTenantUtil> mockedUtilities;
 
     private ServiceProvider serviceProvider;
-    private static String primaryTenantDomain = "primaryTenantDomain";
-    private static String tenantDomain = "sampleTenantDomain";
-    private static String userName = "sampleUser";
+    private static final String primaryTenantDomain = "primaryTenantDomain";
+    private static final String tenantDomain = "sampleTenantDomain";
+    private static final String userName = "sampleUser";
+    private static final String applicationName = "sampleApp";
+    private static final String applicationResourceID = "fcb0c1d7-28c0-46f7-bc2d-345678a1b23c";
+    private static final String organizationID = "10084a8d-113f-4211-a0d5-efe36b082211";
+    private static final String sampleClaimURI = "http://wso2.org/claims/sampleClaim1";
 
     @BeforeMethod
     public void setUp() {
@@ -66,6 +88,8 @@ public class FragmentApplicationMgtListenerTest {
         MockitoAnnotations.openMocks(this);
         serviceProvider = mock(ServiceProvider.class);
         OrgApplicationMgtDataHolder.getInstance().setOrganizationManager(organizationManager);
+        OrgApplicationMgtDataHolder.getInstance().setOrgApplicationMgtDAO(orgApplicationMgtDAO);
+        OrgApplicationMgtDataHolder.getInstance().setApplicationManagementService(applicationManagementService);
     }
 
     @DataProvider(name = "subOrganizationMetaData")
@@ -89,10 +113,9 @@ public class FragmentApplicationMgtListenerTest {
         when(organizationManager.resolveOrganizationId(tenantDomain)).thenReturn(organizationId);
         when(organizationManager.getOrganizationDepthInHierarchy(organizationId)).thenReturn(hierarchyDepth);
         if (isSharedApp) {
-            ServiceProviderProperty[] spProperties = new ServiceProviderProperty[1];
-            spProperties[0] = new ServiceProviderProperty();
-            spProperties[0].setName(IS_FRAGMENT_APP);
-            spProperties[0].setValue(String.valueOf(true));
+            ServiceProviderProperty[] spProperties = new ServiceProviderProperty[]{
+                    mockServiceProviderProperty(IS_FRAGMENT_APP, "true"),
+            };
             when(serviceProvider.getSpProperties()).thenReturn(spProperties);
         }
         mockUtils(requestInitiatedDomain);
@@ -115,6 +138,80 @@ public class FragmentApplicationMgtListenerTest {
         boolean result =
                 fragmentApplicationMgtListener.doPreCreateApplication(serviceProvider, primaryTenantDomain, userName);
         assertTrue(result);
+    }
+
+    @DataProvider(name = "testAPIBasedAuthPropertyInheritanceDataProvider")
+    public Object[][] testAPIBasedAuthPropertyInheritanceDataProvider() {
+
+        return new Object[][]{
+                // Both shared app and main app API Based Authentication property is enabled.
+                {true, true, true},
+                // Only main app API Based Authentication property is enabled.
+                {true, false, true},
+                // Only shared app API Based Authentication property is enabled.
+                {false, true, false},
+                // Both shared app and main app API Based Authentication property is disabled.
+                {false, false, false}
+        };
+    }
+
+    @Test(dataProvider = "testAPIBasedAuthPropertyInheritanceDataProvider")
+    public void testAPIBasedAuthPropertyInheritance(boolean isMainAppAPIAuthEnabled, boolean isSharedAppAPIAuthEnabled,
+                                                    boolean expectedResult)
+            throws IdentityApplicationManagementException, OrganizationManagementException {
+
+        mockClaimConfig(serviceProvider);
+        mockUtils(primaryTenantDomain);
+
+        MainApplicationDO mainApplicationDO = new MainApplicationDO(organizationID, applicationResourceID);
+        ServiceProvider sharedApplication = new ServiceProvider();
+        ServiceProviderProperty[] spProperties = new ServiceProviderProperty[]{
+                mockServiceProviderProperty(IS_FRAGMENT_APP, "true"),
+                mockServiceProviderProperty(IS_API_BASED_AUTHENTICATION_ENABLED_PROPERTY_NAME,
+                        String.valueOf(isSharedAppAPIAuthEnabled))
+        };
+        ServiceProviderProperty[] mainSPProperties = new ServiceProviderProperty[]{
+                mockServiceProviderProperty(IS_API_BASED_AUTHENTICATION_ENABLED_PROPERTY_NAME,
+                        String.valueOf(isMainAppAPIAuthEnabled))
+        };
+        sharedApplication.setSpProperties(spProperties);
+        sharedApplication.setLocalAndOutBoundAuthenticationConfig(new LocalAndOutboundAuthenticationConfig());
+        sharedApplication.setApplicationResourceId(applicationResourceID);
+
+        when(serviceProvider.getSpProperties()).thenReturn(mainSPProperties);
+        when(serviceProvider.isAPIBasedAuthenticationEnabled()).thenReturn(isMainAppAPIAuthEnabled);
+        when(organizationManager.resolveOrganizationId(tenantDomain)).thenReturn(organizationID);
+        when(organizationManager.resolveTenantDomain(organizationID)).thenReturn(tenantDomain);
+        when(orgApplicationMgtDAO.getMainApplication(applicationResourceID, organizationID))
+                .thenReturn(Optional.of(mainApplicationDO));
+        when(applicationManagementService.getApplicationByResourceId(anyString(), anyString()))
+                .thenReturn(serviceProvider);
+
+        boolean result = fragmentApplicationMgtListener
+                .doPostGetServiceProvider(sharedApplication, applicationName, tenantDomain);
+        AssertJUnit.assertTrue(result);
+        AssertJUnit.assertEquals(expectedResult, sharedApplication.isAPIBasedAuthenticationEnabled());
+    }
+
+    private void mockClaimConfig(ServiceProvider mainApplication) {
+
+        ClaimConfig claimConfig = mock(ClaimConfig.class);
+        ClaimMapping claimMapping1 = mock(ClaimMapping.class);
+        Claim claim1 = new Claim();
+        claim1.setClaimUri(sampleClaimURI);
+
+        when(mainApplication.getClaimConfig()).thenReturn(claimConfig);
+        when(claimConfig.getClaimMappings()).thenReturn(new ClaimMapping[]{claimMapping1});
+        when(claimMapping1.getLocalClaim()).thenReturn(claim1);
+        when(claimConfig.isAlwaysSendMappedLocalSubjectId()).thenReturn(true);
+    }
+
+    private ServiceProviderProperty mockServiceProviderProperty(String name, String value) {
+
+        ServiceProviderProperty property = new ServiceProviderProperty();
+        property.setName(name);
+        property.setValue(String.valueOf(value));
+        return property;
     }
 
     private void mockUtils(String requestInitiatedDomain) {


### PR DESCRIPTION
## Purpose
$subject

Issue: https://github.com/wso2/product-is/issues/21222

Fixes the first task of the above issue.
1. If the root application is marked as an API based authentication enabled application, inherit that configuration for shared apps as well

## Goals

- The shared application will inherit the main application's APIBasedAuthenticationEnabled property during the shared application creation. 
- When retrieving the shared application it will inherit the main application's APIBasedAuthenticationEnabled property, **if and only if, the APIBasedAuthenticationEnabled property in the main application is true.**

| Root App APIBasedAuthenticationEnabled Property | Shared App APIBasedAuthenticationEnabled Property | Impact                                                                 |
|--------------------------------|----------------------------------|------------------------------------------------------------------------|
| False                             | False                                | Doesn't inherit property from root app.         |
| False                              | True                                | Doesn't inherit property from root app.                   |
| True                              | False                                | Inherit property from root app **has a behavior change**. |
| True                              | True                                | Inherit property from root app but doesn't make any behavior change.         |

## Approach

- The `prepareSharedApplication()` is updated to add the APIBasedAuthenticationEnabled property.
- The `inheritAPIBasedAuthenticationEnabledProperty()` in FragmentApplicationMgtListener is updated to send the APIBasedAuthenticationEnabled property of the parent application if it's enabled in parent.
