### PR TITLE
Resolve role sharing conflicts in app sharing

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.handler/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.handler/pom.xml
@@ -80,6 +80,10 @@
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.application.mgt</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.central.log.mgt</artifactId>
+        </dependency>
         <!--Test Dependencies-->
         <dependency>
             <groupId>org.testng</groupId>

--- a/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/listener/SharedRoleMgtListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/listener/SharedRoleMgtListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023-2024, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -608,11 +608,13 @@ public class SharedRoleMgtListener extends AbstractApplicationMgtListener {
             throws IdentityApplicationManagementException {
 
         try {
-            if (!OrganizationManagementUtil.isOrganization(tenantDomain)) {
+            String mainAppId = applicationManagementService.getMainAppId(applicationUUID);
+            // If the main application id is null, then this is the main application. We can skip this operation based
+            // on that.
+            if (StringUtils.isEmpty(mainAppId)) {
                 return true;
             }
             // Resolve the associated roles of shared application from main application details.
-            String mainAppId = applicationManagementService.getMainAppId(applicationUUID);
             int mainAppTenantId = applicationManagementService.getTenantIdByApp(mainAppId);
             String mainAppTenantDomain = IdentityTenantUtil.getTenantDomain(mainAppTenantId);
             List<RoleV2> resolvedAssociatedRolesFromMainApp =
@@ -641,7 +643,7 @@ public class SharedRoleMgtListener extends AbstractApplicationMgtListener {
                     .collect(Collectors.toList());
             associatedRolesOfApplication.clear();
             associatedRolesOfApplication.addAll(associatedRolesOfSharedApplication);
-        } catch (OrganizationManagementException | IdentityRoleManagementException e) {
+        } catch (IdentityRoleManagementException e) {
             throw new IdentityApplicationManagementException(String.format(
                     "Error while fetching the allowed audience for role association of application with: %s.",
                     applicationUUID), e);

--- a/components/org.wso2.carbon.identity.organization.management.handler/src/test/java/org/wso2/carbon/identity/organization/management/handler/tests/SharedRoleMgtHandlerTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.handler/src/test/java/org/wso2/carbon/identity/organization/management/handler/tests/SharedRoleMgtHandlerTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.management.handler.tests;
+
+import org.mockito.MockedStatic;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.base.CarbonBaseConstants;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.application.common.model.RoleV2;
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.identity.central.log.mgt.utils.LoggerUtils;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.event.event.Event;
+import org.wso2.carbon.identity.organization.management.application.constant.OrgApplicationMgtConstants;
+import org.wso2.carbon.identity.organization.management.handler.SharedRoleMgtHandler;
+import org.wso2.carbon.identity.organization.management.handler.internal.OrganizationManagementHandlerDataHolder;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService;
+
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.wso2.carbon.identity.organization.management.application.constant.OrgApplicationMgtConstants.EVENT_PROP_PARENT_APPLICATION_ID;
+import static org.wso2.carbon.identity.organization.management.application.constant.OrgApplicationMgtConstants.EVENT_PROP_PARENT_ORGANIZATION_ID;
+import static org.wso2.carbon.identity.organization.management.application.constant.OrgApplicationMgtConstants.EVENT_PROP_SHARED_APPLICATION_ID;
+import static org.wso2.carbon.identity.organization.management.application.constant.OrgApplicationMgtConstants.EVENT_PROP_SHARED_ORGANIZATION_ID;
+
+/**
+ * Unit tests for SharedRoleMgtHandler.
+ */
+public class SharedRoleMgtHandlerTest {
+
+    private static final String PARENT_ORG_TENANT_DOMAIN = "parent-org-tenant-domain";
+    private static final String PARENT_ORG_ID = "parent-org-id";
+    private static final String PARENT_ORG_USER_NAME = "parent-org-user";
+    private static final String PARENT_ORG_USER_ID = "parent-org-user-id";
+    private static final String PARENT_ORG_APP_ID = "parent-application-id";
+    private static final String SHARED_ORG_TENANT_DOMAIN = "shared-org-tenant-domain";
+    private static final String SHARED_ORG_ID = "shared-org-id";
+    private static final String SHARED_ORG_APP_ID = "shared-app-id";
+    private static final String ORGANIZATION_AUD = "organization";
+
+    private static MockedStatic<LoggerUtils> loggerUtils = null;
+    private static MockedStatic<IdentityUtil> identityUtil = null;
+
+    @BeforeClass
+    public void setUp() {
+
+        initPrivilegedCarbonContext();
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(PARENT_ORG_TENANT_DOMAIN);
+        PrivilegedCarbonContext.getThreadLocalCarbonContext().setUsername(PARENT_ORG_USER_NAME);
+
+        loggerUtils = mockStatic(LoggerUtils.class);
+        identityUtil = mockStatic(IdentityUtil.class);
+    }
+
+    @DataProvider(name = "v2AuditLogsEnabled")
+    public Object[][] v2AuditLogsEnabled() {
+
+        return new Object[][]{
+                {false},
+                {true}
+        };
+    }
+
+    @Test(dataProvider = "v2AuditLogsEnabled", expectedExceptions = IdentityEventException.class,
+            expectedExceptionsMessageRegExp = ".*has a non shared role with.*")
+    public void testHandleEventForPreShareApplicationEventWithConflictingRoles(boolean isV2AuditLogsEnabled)
+            throws Exception {
+
+        Event event = createPreShareApplicationEvent();
+
+        OrganizationManager mockedOrganizationManager = mock(OrganizationManager.class);
+        OrganizationManagementHandlerDataHolder.getInstance().setOrganizationManager(mockedOrganizationManager);
+        lenient().when(mockedOrganizationManager.resolveTenantDomain(SHARED_ORG_ID)).
+                thenReturn(SHARED_ORG_TENANT_DOMAIN);
+        lenient().when(mockedOrganizationManager.resolveTenantDomain(PARENT_ORG_ID)).
+                thenReturn(PARENT_ORG_TENANT_DOMAIN);
+
+        List<RoleV2> roles = new ArrayList<>();
+        RoleV2 role = new RoleV2();
+        role.setId("role-id");
+        role.setName("role-name");
+        roles.add(role);
+
+        ApplicationManagementService mockedApplicationManagementService = mock(ApplicationManagementService.class);
+        OrganizationManagementHandlerDataHolder.getInstance()
+                .setApplicationManagementService(mockedApplicationManagementService);
+        lenient().when(mockedApplicationManagementService.getAllowedAudienceForRoleAssociation(PARENT_ORG_APP_ID,
+                PARENT_ORG_TENANT_DOMAIN)).thenReturn(ORGANIZATION_AUD);
+        lenient().when(mockedApplicationManagementService.getAssociatedRolesOfApplication(PARENT_ORG_APP_ID,
+                PARENT_ORG_TENANT_DOMAIN)).thenReturn(roles);
+
+        RoleManagementService roleManagementService = mock(RoleManagementService.class);
+        OrganizationManagementHandlerDataHolder.getInstance().setRoleManagementServiceV2(roleManagementService);
+        lenient().when(roleManagementService.isExistingRoleName(roles.get(0).getName(), ORGANIZATION_AUD,
+                        SHARED_ORG_ID, SHARED_ORG_TENANT_DOMAIN)).thenReturn(true);
+        lenient().when(roleManagementService.getMainRoleToSharedRoleMappingsBySubOrg(
+                Collections.singletonList(role.getId()), SHARED_ORG_TENANT_DOMAIN)).thenReturn(new HashMap<>());
+
+        loggerUtils.when(LoggerUtils::isEnableV2AuditLogs).thenReturn(isV2AuditLogsEnabled);
+        identityUtil.when(() -> IdentityUtil.getInitiatorId(PARENT_ORG_USER_NAME, PARENT_ORG_TENANT_DOMAIN)).
+                thenReturn(PARENT_ORG_USER_ID);
+
+        SharedRoleMgtHandler sharedRoleMgtHandler = new SharedRoleMgtHandler();
+        sharedRoleMgtHandler.handleEvent(event);
+    }
+
+    @Test
+    public void testHandleEventForPreShareApplicationEventWithoutConflictingRoles() throws Exception {
+
+        Event event = createPreShareApplicationEvent();
+
+        OrganizationManager mockedOrganizationManager = mock(OrganizationManager.class);
+        OrganizationManagementHandlerDataHolder.getInstance().setOrganizationManager(mockedOrganizationManager);
+        lenient().when(mockedOrganizationManager.resolveTenantDomain(SHARED_ORG_ID)).
+                thenReturn(SHARED_ORG_TENANT_DOMAIN);
+        lenient().when(mockedOrganizationManager.resolveTenantDomain(PARENT_ORG_ID)).
+                thenReturn(PARENT_ORG_TENANT_DOMAIN);
+
+        List<RoleV2> roles = new ArrayList<>();
+        RoleV2 role = new RoleV2();
+        role.setId("role-id");
+        role.setName("role-name");
+        roles.add(role);
+
+        ApplicationManagementService mockedApplicationManagementService = mock(ApplicationManagementService.class);
+        OrganizationManagementHandlerDataHolder.getInstance()
+                .setApplicationManagementService(mockedApplicationManagementService);
+        lenient().when(mockedApplicationManagementService.getAllowedAudienceForRoleAssociation(PARENT_ORG_APP_ID,
+                PARENT_ORG_TENANT_DOMAIN)).thenReturn(ORGANIZATION_AUD);
+        lenient().when(mockedApplicationManagementService.getAssociatedRolesOfApplication(PARENT_ORG_APP_ID,
+                PARENT_ORG_TENANT_DOMAIN)).thenReturn(roles);
+
+        RoleManagementService roleManagementService = mock(RoleManagementService.class);
+        OrganizationManagementHandlerDataHolder.getInstance().setRoleManagementServiceV2(roleManagementService);
+        lenient().when(roleManagementService.isExistingRoleName(roles.get(0).getName(), ORGANIZATION_AUD,
+                SHARED_ORG_ID, SHARED_ORG_TENANT_DOMAIN)).thenReturn(true);
+        Map<String, String> mainRoleToSharedRoleMapping = new HashMap<>();
+        mainRoleToSharedRoleMapping.put(roles.get(0).getId(), "mapped-shared-role-id");
+        lenient().when(roleManagementService.getMainRoleToSharedRoleMappingsBySubOrg(
+                Collections.singletonList(role.getId()), SHARED_ORG_TENANT_DOMAIN)).
+                thenReturn(mainRoleToSharedRoleMapping);
+
+        SharedRoleMgtHandler sharedRoleMgtHandler = new SharedRoleMgtHandler();
+        sharedRoleMgtHandler.handleEvent(event);
+    }
+
+    @Test
+    public void testHandleEventForPreShareApplicationEventWithApplicationAud() throws Exception {
+
+        Event event = createPreShareApplicationEvent();
+
+        OrganizationManager mockedOrganizationManager = mock(OrganizationManager.class);
+        OrganizationManagementHandlerDataHolder.getInstance().setOrganizationManager(mockedOrganizationManager);
+        lenient().when(mockedOrganizationManager.resolveTenantDomain(SHARED_ORG_ID)).
+                thenReturn(SHARED_ORG_TENANT_DOMAIN);
+        lenient().when(mockedOrganizationManager.resolveTenantDomain(PARENT_ORG_ID)).
+                thenReturn(PARENT_ORG_TENANT_DOMAIN);
+
+        ApplicationManagementService mockedApplicationManagementService = mock(ApplicationManagementService.class);
+        OrganizationManagementHandlerDataHolder.getInstance()
+                .setApplicationManagementService(mockedApplicationManagementService);
+        lenient().when(mockedApplicationManagementService.getAllowedAudienceForRoleAssociation(PARENT_ORG_APP_ID,
+                PARENT_ORG_TENANT_DOMAIN)).thenReturn("application");
+
+        SharedRoleMgtHandler sharedRoleMgtHandler = new SharedRoleMgtHandler();
+        sharedRoleMgtHandler.handleEvent(event);
+    }
+
+    private void initPrivilegedCarbonContext() {
+
+        System.setProperty(
+                CarbonBaseConstants.CARBON_HOME,
+                Paths.get(System.getProperty("user.dir"), "src", "test", "resources").toString()
+        );
+        PrivilegedCarbonContext.startTenantFlow();
+    }
+
+    private static Event createPreShareApplicationEvent() {
+
+        Event event = new Event(OrgApplicationMgtConstants.EVENT_PRE_SHARE_APPLICATION);
+        event.addEventProperty(EVENT_PROP_PARENT_ORGANIZATION_ID, PARENT_ORG_ID);
+        event.addEventProperty(EVENT_PROP_PARENT_APPLICATION_ID, PARENT_ORG_APP_ID);
+        event.addEventProperty(EVENT_PROP_SHARED_ORGANIZATION_ID, SHARED_ORG_ID);
+        event.addEventProperty(EVENT_PROP_SHARED_APPLICATION_ID, SHARED_ORG_APP_ID);
+        return event;
+    }
+}

--- a/components/org.wso2.carbon.identity.organization.management.handler/src/test/resources/repository.conf/carbon.xml
+++ b/components/org.wso2.carbon.identity.organization.management.handler/src/test/resources/repository.conf/carbon.xml
@@ -1,0 +1,684 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+  ~ Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!--
+    This is the main server configuration file
+
+    ${carbon.home} represents the carbon.home system property.
+    Other system properties can be specified in a similar manner.
+-->
+<Server xmlns="http://wso2.org/projects/carbon/carbon.xml">
+
+    <!--
+       Product Name
+    -->
+    <Name>WSO2 Identity Server</Name>
+
+    <!--
+       machine readable unique key to identify each product
+    -->
+    <ServerKey>IS</ServerKey>
+
+    <!--
+       Product Version
+    -->
+    <Version>5.3.0</Version>
+
+    <!--
+       Host name or IP address of the machine hosting this server
+       e.g. www.wso2.org, 192.168.1.10
+       This is will become part of the End Point Reference of the
+       services deployed on this server instance.
+    -->
+    <HostName>localhost</HostName>
+
+    <!--
+    Host name to be used for the Carbon management console
+    -->
+    <MgtHostName>localhost</MgtHostName>
+
+    <!--
+        The URL of the back end server. This is where the admin services are hosted and
+        will be used by the clients in the front end server.
+        This is required only for the Front-end server. This is used when seperating BE server from FE server
+       -->
+    <ServerURL>local:/${carbon.context}/services/</ServerURL>
+    <!--
+    <ServerURL>https://localhost:${carbon.management.port}${carbon.context}/services/</ServerURL>
+    -->
+     <!--
+     The URL of the index page. This is where the user will be redirected after signing in to the
+     carbon server.
+     -->
+    <!-- IndexPageURL>/carbon/admin/index.jsp</IndexPageURL-->
+
+    <!--
+    For cApp deployment, we have to identify the roles that can be acted by the current server.
+    The following property is used for that purpose. Any number of roles can be defined here.
+    Regular expressions can be used in the role.
+    Ex : <Role>.*</Role> means this server can act any role
+    -->
+    <ServerRoles>
+        <Role>IdentityServer</Role>
+    </ServerRoles>
+
+    <!-- uncommnet this line to subscribe to a bam instance automatically -->
+    <!--<BamServerURL>https://bamhost:bamport/services/</BamServerURL>-->
+
+    <!--
+       The fully qualified name of the server
+    -->
+    <Package>org.wso2.carbon</Package>
+
+    <!--
+       Webapp context root of WSO2 Carbon management console.
+    -->
+    <WebContextRoot>/</WebContextRoot>
+
+    <!--
+    	Proxy context path is a useful parameter to add a proxy path when a Carbon server is fronted by reverse proxy. In addtion
+        to the proxy host and proxy port this parameter allows you add a path component to external URLs. e.g.
+     		URL of the Carbon server -> https://10.100.1.1:9443/carbon
+   		URL of the reverse proxy -> https://prod.abc.com/appserver/carbon
+
+   	appserver - proxy context path. This specially required whenever you are generating URLs to displace in
+   	Carbon UI components.
+    -->
+    <!--
+    	<MgtProxyContextPath></MgtProxyContextPath>
+    	<ProxyContextPath></ProxyContextPath>
+    -->
+
+    <!-- In-order to  get the registry http Port from the back-end when the default http transport is not the same-->
+    <!--RegistryHttpPort>9763</RegistryHttpPort-->
+
+    <!--
+    Number of items to be displayed on a management console page. This is used at the
+    backend server for pagination of various items.
+    -->
+    <ItemsPerPage>15</ItemsPerPage>
+
+    <!-- The endpoint URL of the cloud instance management Web service -->
+    <!--<InstanceMgtWSEndpoint>https://ec2.amazonaws.com/</InstanceMgtWSEndpoint>-->
+
+    <!--
+       Ports used by this server
+    -->
+    <Ports>
+
+        <!-- Ports offset. This entry will set the value of the ports defined below to
+         the define value + Offset.
+         e.g. Offset=2 and HTTPS port=9443 will set the effective HTTPS port to 9445
+         -->
+        <Offset>0</Offset>
+
+        <!-- The JMX Ports -->
+        <JMX>
+            <!--The port RMI registry is exposed-->
+            <RMIRegistryPort>9999</RMIRegistryPort>
+            <!--The port RMI server should be exposed-->
+            <RMIServerPort>11111</RMIServerPort>
+        </JMX>
+
+        <!-- Embedded LDAP server specific ports -->
+        <EmbeddedLDAP>
+            <!-- Port which embedded LDAP server runs -->
+            <LDAPServerPort>10389</LDAPServerPort>
+            <!-- Port which KDC (Kerberos Key Distribution Center) server runs -->
+            <KDCServerPort>8000</KDCServerPort>
+        </EmbeddedLDAP>
+	
+	<!-- 
+             Override datasources JNDIproviderPort defined in bps.xml and datasources.properties files
+	-->
+	<!--<JNDIProviderPort>2199</JNDIProviderPort>-->
+	<!--Override receive port of thrift based entitlement service.-->
+	<ThriftEntitlementReceivePort>10500</ThriftEntitlementReceivePort>
+
+    <!--
+     This is the proxy port of the worker cluster. These need to be configured in a scenario where
+     manager node is not exposed through the load balancer through which the workers are exposed
+     therefore doesn't have a proxy port.
+    <WorkerHttpProxyPort>80</WorkerHttpProxyPort>
+    <WorkerHttpsProxyPort>443</WorkerHttpsProxyPort>
+    -->
+
+    </Ports>
+
+    <!--
+        JNDI Configuration
+    -->
+    <JNDI>
+        <!-- 
+             The fully qualified name of the default initial context factory
+        -->
+        <DefaultInitialContextFactory>org.wso2.carbon.tomcat.jndi.CarbonJavaURLContextFactory</DefaultInitialContextFactory>
+        <!-- 
+             The restrictions that are done to various JNDI Contexts in a Multi-tenant environment 
+        -->
+        <Restrictions>
+            <!--
+                Contexts that will be available only to the super-tenant
+            -->
+            <!-- <SuperTenantOnly>
+                <UrlContexts>
+                    <UrlContext>
+                        <Scheme>foo</Scheme>
+                    </UrlContext>
+                    <UrlContext>
+                        <Scheme>bar</Scheme>
+                    </UrlContext>
+                </UrlContexts>
+            </SuperTenantOnly> -->
+            <!-- 
+                Contexts that are common to all tenants
+            -->
+            <AllTenants>
+                <UrlContexts>
+                    <UrlContext>
+                        <Scheme>java</Scheme>
+                    </UrlContext>
+                    <!-- <UrlContext>
+                        <Scheme>foo</Scheme>
+                    </UrlContext> -->
+                </UrlContexts>
+            </AllTenants>
+            <!-- 
+                 All other contexts not mentioned above will be available on a per-tenant basis 
+                 (i.e. will not be shared among tenants)
+            -->
+        </Restrictions>
+    </JNDI>
+
+    <!--
+        Property to determine if the server is running an a cloud deployment environment.
+        This property should only be used to determine deployment specific details that are
+        applicable only in a cloud deployment, i.e when the server deployed *-as-a-service.
+    -->
+    <IsCloudDeployment>false</IsCloudDeployment>
+
+    <!--
+	Property to determine whether usage data should be collected for metering purposes
+    -->
+    <EnableMetering>false</EnableMetering>
+
+    <!-- The Max time a thread should take for execution in seconds -->
+    <MaxThreadExecutionTime>600</MaxThreadExecutionTime>
+
+    <!--
+        A flag to enable or disable Ghost Deployer. By default this is set to false. That is
+        because the Ghost Deployer works only with the HTTP/S transports. If you are using
+        other transports, don't enable Ghost Deployer.
+    -->
+    <GhostDeployment>
+        <Enabled>false</Enabled>
+    </GhostDeployment>
+
+
+    <!--
+        Eager loading or lazy loading is a design pattern commonly used in computer programming which
+        will initialize an object upon creation or load on-demand. In carbon, lazy loading is used to
+        load tenant when a request is received only. Similarly Eager loading is used to enable load
+        existing tenants after carbon server starts up. Using this feature, you will be able to include
+        or exclude tenants which are to be loaded when server startup.
+
+        We can enable only one LoadingPolicy at a given time.
+
+        1. Tenant Lazy Loading
+           This is the default behaviour and enabled by default. With this policy, tenants are not loaded at
+           server startup, but loaded based on-demand (i.e when a request is received for a tenant).
+           The default tenant idle time is 30 minutes.
+
+        2. Tenant Eager Loading
+           This is by default not enabled. It can be be enabled by un-commenting the <EagerLoading> section.
+           The eager loading configurations supported are as below. These configurations can be given as the
+           value for <Include> element with eager loading.
+                (i)Load all tenants when server startup             -   *
+                (ii)Load all tenants except foo.com & bar.com       -   *,!foo.com,!bar.com
+                (iii)Load only foo.com &  bar.com to be included    -   foo.com,bar.com
+    -->
+    <Tenant>
+        <LoadingPolicy>
+            <LazyLoading>
+                <IdleTime>30</IdleTime>
+            </LazyLoading>
+            <!-- <EagerLoading>
+                   <Include>*,!foo.com,!bar.com</Include>
+            </EagerLoading>-->
+        </LoadingPolicy>
+    </Tenant>
+
+    <!--
+     Caching related configurations
+    -->
+    <Cache>
+        <!-- Default cache timeout in minutes -->
+        <DefaultCacheTimeout>15</DefaultCacheTimeout>
+    </Cache>
+
+    <!--
+    Axis2 related configurations
+    -->
+    <Axis2Config>
+        <!--
+             Location of the Axis2 Services & Modules repository
+
+             This can be a directory in the local file system, or a URL.
+
+             e.g.
+             1. /home/wso2wsas/repository/ - An absolute path
+             2. repository - In this case, the path is relative to CARBON_HOME
+             3. file:///home/wso2wsas/repository/
+             4. http://wso2wsas/repository/
+        -->
+        <RepositoryLocation>${carbon.home}/repository/deployment/server/</RepositoryLocation>
+
+        <!--
+         Deployment update interval in seconds. This is the interval between repository listener
+         executions. 
+        -->
+        <DeploymentUpdateInterval>15</DeploymentUpdateInterval>
+
+        <!--
+            Location of the main Axis2 configuration descriptor file, a.k.a. axis2.xml file
+
+            This can be a file on the local file system, or a URL
+
+            e.g.
+            1. /home/repository/axis2.xml - An absolute path
+            2. repository.conf/axis2.xml - In this case, the path is relative to CARBON_HOME
+            3. file:///home/carbon/repository/axis2.xml
+            4. http://repository/conf/axis2.xml
+        -->
+        <ConfigurationFile>${carbon.home}/repository/conf/axis2/axis2.xml</ConfigurationFile>
+
+        <!--
+          ServiceGroupContextIdleTime, which will be set in ConfigurationContex
+          for multiple clients which are going to access the same ServiceGroupContext
+          Default Value is 30 Sec.
+        -->
+        <ServiceGroupContextIdleTime>30000</ServiceGroupContextIdleTime>
+
+        <!--
+          This repository location is used to crete the client side configuration
+          context used by the server when calling admin services.
+        -->
+        <ClientRepositoryLocation>${carbon.home}/repository/deployment/client/</ClientRepositoryLocation>
+        <!-- This axis2 xml is used in createing the configuration context by the FE server
+         calling to BE server -->
+        <clientAxis2XmlLocation>${carbon.home}/repository/conf/axis2/axis2_client.xml</clientAxis2XmlLocation>
+        <!-- If this parameter is set, the ?wsdl on an admin service will not give the admin service wsdl. -->
+        <HideAdminServiceWSDLs>true</HideAdminServiceWSDLs>
+	
+	<!--WARNING-Use With Care! Uncommenting bellow parameter would expose all AdminServices in HTTP transport.
+	With HTTP transport your credentials and data routed in public channels are vulnerable for sniffing attacks. 
+	Use bellow parameter ONLY if your communication channels are confirmed to be secured by other means -->
+        <!--HttpAdminServices>*</HttpAdminServices-->
+
+    </Axis2Config>
+
+    <!--
+       The default user roles which will be created when the server
+       is started up for the first time.
+    -->
+    <ServiceUserRoles>
+        <Role>
+            <Name>admin</Name>
+            <Description>Default Administrator Role</Description>
+        </Role>
+        <Role>
+            <Name>user</Name>
+            <Description>Default User Role</Description>
+        </Role>
+    </ServiceUserRoles>
+    
+    <!-- 
+      Enable following config to allow Emails as usernames. 	
+    -->	    	
+    <!--EnableEmailUserName>true</EnableEmailUserName-->	
+
+    <!--
+      Security configurations
+    -->
+    <Security>
+        <!--
+            KeyStore which will be used for encrypting/decrypting passwords
+            and other sensitive information.
+        -->
+        <KeyStore>
+            <!-- Keystore file location-->
+            <Location>${carbon.home}/repository/resources/security/wso2carbon.jks</Location>
+            <!-- Keystore type (JKS/PKCS12 etc.)-->
+            <Type>JKS</Type>
+            <!-- Keystore password-->
+            <Password>wso2carbon</Password>
+            <!-- Private Key alias-->
+            <KeyAlias>wso2carbon</KeyAlias>
+            <!-- Private Key password-->
+            <KeyPassword>wso2carbon</KeyPassword>
+        </KeyStore>
+
+        <!--
+            System wide trust-store which is used to maintain the certificates of all
+            the trusted parties.
+        -->
+        <TrustStore>
+            <!-- trust-store file location -->
+            <Location>${carbon.home}/repository/resources/security/client-truststore.jks</Location>
+            <!-- trust-store type (JKS/PKCS12 etc.) -->
+            <Type>JKS</Type>
+            <!-- trust-store password -->
+            <Password>wso2carbon</Password>
+        </TrustStore>
+
+        <!--
+            The Authenticator configuration to be used at the JVM level. We extend the
+            java.net.Authenticator to make it possible to authenticate to given servers and 
+            proxies.
+        -->
+        <NetworkAuthenticatorConfig>
+            <!-- 
+                Below is a sample configuration for a single authenticator. Please note that
+                all child elements are mandatory. Not having some child elements would lead to
+                exceptions at runtime.
+            -->
+            <!-- <Credential> -->
+                <!-- 
+                    the pattern that would match a subset of URLs for which this authenticator
+                    would be used
+                -->
+                <!-- <Pattern>regularExpression</Pattern> -->
+                <!-- 
+                    the type of this authenticator. Allowed values are:
+                    1. server
+                    2. proxy
+                -->
+                <!-- <Type>proxy</Type> -->
+                <!-- the username used to log in to server/proxy -->
+                <!-- <Username>username</Username> -->
+                <!-- the password used to log in to server/proxy -->
+                <!-- <Password>password</Password> -->
+            <!-- </Credential> -->
+        </NetworkAuthenticatorConfig>
+
+        <!--
+         The Tomcat realm to be used for hosted Web applications. Allowed values are;
+         1. UserManager
+         2. Memory
+
+         If this is set to 'UserManager', the realm will pick users & roles from the system's
+         WSO2 User Manager. If it is set to 'memory', the realm will pick users & roles from
+         CARBON_HOME/repository/repository.conf/tomcat/tomcat-users.xml
+        -->
+        <TomcatRealm>UserManager</TomcatRealm>
+
+	<!--Option to disable storing of tokens issued by STS-->
+	<DisableTokenStore>false</DisableTokenStore>
+
+ <STSCallBackHandlerName>org.wso2.carbon.identity.provider.AttributeCallbackHandler</STSCallBackHandlerName>
+
+	<!--
+	 Security token store class name. If this is not set, default class will be
+	 org.wso2.carbon.security.util.SecurityTokenStore
+	-->
+	<TokenStoreClassName>org.wso2.carbon.identity.sts.store.DBTokenStore</TokenStoreClassName>
+
+        <XSSPreventionConfig>
+            <Enabled>true</Enabled>
+            <Rule>allow</Rule>
+            <Patterns>
+                <!--Pattern></Pattern-->
+            </Patterns>
+        </XSSPreventionConfig>
+    </Security>
+<HideMenuItemIds>
+<HideMenuItemId>claim_mgt_menu</HideMenuItemId>
+<HideMenuItemId>identity_mgt_emailtemplate_menu</HideMenuItemId>
+<HideMenuItemId>identity_security_questions_menu</HideMenuItemId>
+</HideMenuItemIds>
+
+    <!--
+       The temporary work directory
+    -->
+    <WorkDirectory>${carbon.home}/tmp/work</WorkDirectory>
+
+    <!--
+       House-keeping configuration
+    -->
+    <HouseKeeping>
+
+        <!--
+           true  - Start House-keeping thread on server startup
+           false - Do not start House-keeping thread on server startup.
+                   The user will run it manually as and when he wishes.
+        -->
+        <AutoStart>true</AutoStart>
+
+        <!--
+           The interval in *minutes*, between house-keeping runs
+        -->
+        <Interval>10</Interval>
+
+        <!--
+          The maximum time in *minutes*, temp files are allowed to live
+          in the system. Files/directories which were modified more than
+          "MaxTempFileLifetime" minutes ago will be removed by the
+          house-keeping task
+        -->
+        <MaxTempFileLifetime>30</MaxTempFileLifetime>
+    </HouseKeeping>
+
+    <!--
+       Configuration for handling different types of file upload & other file uploading related
+       config parameters.
+       To map all actions to a particular FileUploadExecutor, use
+       <Action>*</Action>
+    -->
+    <FileUploadConfig>
+        <!--
+           The total file upload size limit in MB
+        -->
+        <TotalFileSizeLimit>100</TotalFileSizeLimit>
+
+        <Mapping>
+            <Actions>
+                <Action>keystore</Action>
+                <Action>certificate</Action>
+                <Action>*</Action>
+            </Actions>
+            <Class>org.wso2.carbon.ui.transports.fileupload.AnyFileUploadExecutor</Class>
+        </Mapping>
+
+        <Mapping>
+            <Actions>
+                <Action>jarZip</Action>
+            </Actions>
+            <Class>org.wso2.carbon.ui.transports.fileupload.JarZipUploadExecutor</Class>
+        </Mapping>
+        <Mapping>
+            <Actions>
+                <Action>dbs</Action>
+            </Actions>
+            <Class>org.wso2.carbon.ui.transports.fileupload.DBSFileUploadExecutor</Class>
+        </Mapping>
+        <Mapping>
+            <Actions>
+                <Action>tools</Action>
+            </Actions>
+            <Class>org.wso2.carbon.ui.transports.fileupload.ToolsFileUploadExecutor</Class>
+        </Mapping>
+        <Mapping>
+            <Actions>
+                <Action>toolsAny</Action>
+            </Actions>
+            <Class>org.wso2.carbon.ui.transports.fileupload.ToolsAnyFileUploadExecutor</Class>
+        </Mapping>
+    </FileUploadConfig>
+
+    <!-- FileNameRegEx is used to validate the file input/upload/write-out names.
+    e.g.
+     <FileNameRegEx>^(?!(?:CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(?:\.[^.])?$)[^&lt;&gt:"/\\|?*\x00-\x1F][^&lt;&gt:"/\\|?*\x00-\x1F\ .]$</FileNameRegEx>
+    -->
+    <!--<FileNameRegEx></FileNameRegEx>-->
+
+    <!--
+       Processors which process special HTTP GET requests such as ?wsdl, ?policy etc.
+
+       In order to plug in a processor to handle a special request, simply add an entry to this
+       section.
+
+       The value of the Item element is the first parameter in the query string(e.g. ?wsdl)
+       which needs special processing
+       
+       The value of the Class element is a class which implements
+       org.wso2.carbon.transport.HttpGetRequestProcessor
+    -->
+    <HttpGetRequestProcessors>
+        <Processor>
+            <Item>info</Item>
+            <Class>org.wso2.carbon.core.transports.util.InfoProcessor</Class>
+        </Processor>
+        <Processor>
+            <Item>wsdl</Item>
+            <Class>org.wso2.carbon.core.transports.util.Wsdl11Processor</Class>
+        </Processor>
+        <Processor>
+            <Item>wsdl2</Item>
+            <Class>org.wso2.carbon.core.transports.util.Wsdl20Processor</Class>
+        </Processor>
+        <Processor>
+            <Item>xsd</Item>
+            <Class>org.wso2.carbon.core.transports.util.XsdProcessor</Class>
+        </Processor>
+    </HttpGetRequestProcessors>
+
+    <!-- Deployment Synchronizer Configuration. Enable value to true when running with "svn based" dep sync.
+	In master nodes you need to set both AutoCommit and AutoCheckout to true
+	and in  worker nodes set only AutoCheckout to true.
+    -->
+    <DeploymentSynchronizer>
+        <Enabled>false</Enabled>
+        <AutoCommit>false</AutoCommit>
+        <AutoCheckout>true</AutoCheckout>
+        <RepositoryType>svn</RepositoryType>
+        <SvnUrl>http://svnrepo.example.com/repos/</SvnUrl>
+        <SvnUser>username</SvnUser>
+        <SvnPassword>password</SvnPassword>
+        <SvnUrlAppendTenantId>true</SvnUrlAppendTenantId>
+    </DeploymentSynchronizer>
+
+    <!-- Deployment Synchronizer Configuration. Uncomment the following section when running with "registry based" dep sync.
+        In master nodes you need to set both AutoCommit and AutoCheckout to true
+        and in  worker nodes set only AutoCheckout to true.
+    -->
+    <!--<DeploymentSynchronizer>
+        <Enabled>true</Enabled>
+        <AutoCommit>false</AutoCommit>
+        <AutoCheckout>true</AutoCheckout>
+    </DeploymentSynchronizer>-->
+
+    <!-- Mediation persistence configurations. Only valid if mediation features are available i.e. ESB -->
+    <!--<MediationConfig>
+        <LoadFromRegistry>false</LoadFromRegistry>
+        <SaveToFile>false</SaveToFile>
+        <Persistence>enabled</Persistence>
+        <RegistryPersistence>enabled</RegistryPersistence>
+    </MediationConfig>-->
+
+    <!--
+    Server intializing code, specified as implementation classes of org.wso2.carbon.core.ServerInitializer.
+    This code will be run when the Carbon server is initialized
+    -->
+    <ServerInitializers>
+        <!--<Initializer></Initializer>-->
+    </ServerInitializers>
+    
+    <!--
+    Indicates whether the Carbon Servlet is required by the system, and whether it should be
+    registered
+    -->
+    <RequireCarbonServlet>${require.carbon.servlet}</RequireCarbonServlet>
+
+    <!--
+    Carbon H2 OSGI Configuration
+    By default non of the servers start.
+        name="web" - Start the web server with the H2 Console
+        name="webPort" - The port (default: 8082)
+        name="webAllowOthers" - Allow other computers to connect
+        name="webSSL" - Use encrypted (HTTPS) connections
+        name="tcp" - Start the TCP server
+        name="tcpPort" - The port (default: 9092)
+        name="tcpAllowOthers" - Allow other computers to connect
+        name="tcpSSL" - Use encrypted (SSL) connections
+        name="pg" - Start the PG server
+        name="pgPort"  - The port (default: 5435)
+        name="pgAllowOthers"  - Allow other computers to connect
+        name="trace" - Print additional trace information; for all servers
+        name="baseDir" - The base directory for H2 databases; for all servers  
+    -->
+    <!--H2DatabaseConfiguration>
+        <property name="web" />
+        <property name="webPort">8082</property>
+        <property name="webAllowOthers" />
+        <property name="webSSL" />
+        <property name="tcp" />
+        <property name="tcpPort">9092</property>
+        <property name="tcpAllowOthers" />
+        <property name="tcpSSL" />
+        <property name="pg" />
+        <property name="pgPort">5435</property>
+        <property name="pgAllowOthers" />
+        <property name="trace" />
+        <property name="baseDir">${carbon.home}</property>
+    </H2DatabaseConfiguration-->
+    <!--Disabling statistics reporter by default-->
+    <StatisticsReporterDisabled>true</StatisticsReporterDisabled>
+
+    <!-- Enable accessing Admin Console via HTTP -->
+    <!-- EnableHTTPAdminConsole>true</EnableHTTPAdminConsole -->
+
+    <!--
+       Default Feature Repository of WSO2 Carbon.
+    -->
+    <FeatureRepository>
+	    <RepositoryName>default repository</RepositoryName>
+	    <RepositoryURL>http://product-dist.wso2.com/p2/carbon/releases/wilkes/</RepositoryURL>
+    </FeatureRepository>
+
+    <!--
+	Configure API Management
+   -->
+   <APIManagement>
+	
+	<!--Uses the embedded API Manager by default. If you want to use an external 
+	API Manager instance to manage APIs, configure below  externalAPIManager-->
+	
+	<Enabled>true</Enabled>
+	
+	<!--Uncomment and configure API Gateway and 
+	Publisher URLs to use external API Manager instance-->
+	
+	<!--ExternalAPIManager>
+
+		<APIGatewayURL>http://localhost:8281</APIGatewayURL>
+		<APIPublisherURL>http://localhost:8281/publisher</APIPublisherURL>
+
+	</ExternalAPIManager-->
+	
+	<LoadAPIContextsInServerStartup>true</LoadAPIContextsInServerStartup>
+   </APIManagement>
+</Server>

--- a/pom.xml
+++ b/pom.xml
@@ -268,6 +268,11 @@
                 <artifactId>commons-collections</artifactId>
                 <version>${apache.common.collection.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.central.log.mgt</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
 
             <!--Test Dependencies-->
             <dependency>
@@ -545,7 +550,7 @@
         <carbon.multitenancy.package.import.version.range>[4.7.0,5.0.0)
         </carbon.multitenancy.package.import.version.range>
 
-        <carbon.identity.framework.version>7.3.3</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.7.15</carbon.identity.framework.version>
         <carbon.identity.package.import.version.range>[5.20.0, 8.0.0)
         </carbon.identity.package.import.version.range>
 


### PR DESCRIPTION
## Purpose
- $subject
- From [1] role management will be enabled in the sub organization level as well. 
- With that, in the sub organization level, there will be two types of roles.
   - Shared roles from the root organization (through the application sharing)
   - Roles created inside the sub organization directly.
- There can be conflicts when the roles are created in the sub organization level.
- This PR contains the fixes for the following conflicting scenarios.
   - Sub organization has a role named `role01` and an organization audience application will be shared from the root organization and root organization contains a role named `role01`
      - App sharing will be restricted to that corresponding conflicting sub organization.
   - Sub organization has a role named `role01` and already an organization audienace app is shared. Now in the root organization a new organization role will be created with a name `role01`.
       - Root organization role will not be shared to the conflicting sub organization.
   -  Sub organization has a role named `role01` and already an organization audienace app is shared. Now in the root organization an existing role is renamed to `role01`.
       - Role name modification will not be propogated to the conflicting sub organization.

[1] https://github.com/wso2/product-is/issues/21208

## Goals
- Resolving role sharing conflicts.

## Approach
- Restricting the conflicting resource or the main resource that initiated the conflicting resource sharing to the conflicting sub organization