### PR TITLE
Fix Root Org Template Resolving Edge Case

### DIFF
--- a/components/org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service/src/main/java/org/wso2/carbon/identity/organization/resource/hierarchy/traverse/service/strategy/FirstFoundAggregationStrategy.java
+++ b/components/org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service/src/main/java/org/wso2/carbon/identity/organization/resource/hierarchy/traverse/service/strategy/FirstFoundAggregationStrategy.java
@@ -46,7 +46,8 @@ public class FirstFoundAggregationStrategy<T> implements AggregationStrategy<T> 
         }
 
         for (String orgId : organizationHierarchy) {
-            if (OrgResourceHierarchyTraverseUtil.isMinOrgHierarchyDepthReached(orgId)) {
+            if (organizationHierarchy.size() != 1 &&
+                    OrgResourceHierarchyTraverseUtil.isMinOrgHierarchyDepthReached(orgId)) {
                 break;
             }
 
@@ -68,7 +69,8 @@ public class FirstFoundAggregationStrategy<T> implements AggregationStrategy<T> 
         }
 
         for (String orgId : organizationHierarchy) {
-            if (OrgResourceHierarchyTraverseUtil.isMinOrgHierarchyDepthReached(orgId)) {
+            if (organizationHierarchy.size() != 1 &&
+                    OrgResourceHierarchyTraverseUtil.isMinOrgHierarchyDepthReached(orgId)) {
                 break;
             }
 

--- a/components/org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service/src/main/java/org/wso2/carbon/identity/organization/resource/hierarchy/traverse/service/strategy/MergeAllAggregationStrategy.java
+++ b/components/org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service/src/main/java/org/wso2/carbon/identity/organization/resource/hierarchy/traverse/service/strategy/MergeAllAggregationStrategy.java
@@ -63,7 +63,8 @@ public class MergeAllAggregationStrategy<T> implements AggregationStrategy<T> {
         }
 
         for (String orgId : organizationHierarchy) {
-            if (OrgResourceHierarchyTraverseUtil.isMinOrgHierarchyDepthReached(orgId)) {
+            if (organizationHierarchy.size() != 1 &&
+                    OrgResourceHierarchyTraverseUtil.isMinOrgHierarchyDepthReached(orgId)) {
                 break;
             }
 
@@ -90,7 +91,8 @@ public class MergeAllAggregationStrategy<T> implements AggregationStrategy<T> {
         }
 
         for (String orgId : organizationHierarchy) {
-            if (OrgResourceHierarchyTraverseUtil.isMinOrgHierarchyDepthReached(orgId)) {
+            if (organizationHierarchy.size() != 1 &&
+                    OrgResourceHierarchyTraverseUtil.isMinOrgHierarchyDepthReached(orgId)) {
                 break;
             }
 

--- a/components/org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service/src/test/java/org/wso2/carbon/identity/organization/resource/hierarchy/traverse/service/OrgResourceResolverServiceTest.java
+++ b/components/org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service/src/test/java/org/wso2/carbon/identity/organization/resource/hierarchy/traverse/service/OrgResourceResolverServiceTest.java
@@ -492,8 +492,6 @@ public class OrgResourceResolverServiceTest {
         when(organizationManager.getOrganizationDepthInHierarchy(anyString()))
                 .thenThrow(OrganizationManagementServerException.class);
         assertThrows(OrgResourceHierarchyTraverseServerException.class,
-                () -> invokeOrgLevelResourceResolver(aggregationStrategy, ROOT_ORG_ID));
-        assertThrows(OrgResourceHierarchyTraverseServerException.class,
                 () -> invokeOrgLevelResourceResolver(aggregationStrategy, L1_ORG_ID));
         assertThrows(OrgResourceHierarchyTraverseServerException.class,
                 () -> invokeOrgLevelResourceResolver(aggregationStrategy, L2_ORG_ID));


### PR DESCRIPTION
### Purpose
- When minimum org hierarchy depth is 1, resource traversal aggregation strategies do not check if a resource is available in the root organization even for a resource requested for the root organization. This PR fixes this issue.

### Related Issues
- https://github.com/wso2/product-is/issues/21214