### PR TITLE
Introduce Dependency and Bundle Definition for Resource Sharing Policy Management

### DIFF
--- a/features/org.wso2.carbon.identity.organization.management.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.organization.management.server.feature/pom.xml
@@ -73,6 +73,10 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.identity.organization.management</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.resource.sharing.policy.management</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management</groupId>
             <artifactId>org.wso2.carbon.identity.organization.user.invitation.management</artifactId>
         </dependency>
         <dependency>
@@ -121,6 +125,7 @@
                                 <bundleDef>org.wso2.carbon.identity.organization.management:org.wso2.carbon.identity.organization.management.claim.provider</bundleDef>
                                 <bundleDef>org.wso2.carbon.identity.organization.management:org.wso2.carbon.identity.organization.management.governance.connector</bundleDef>
                                 <bundleDef>org.wso2.carbon.identity.organization.management:org.wso2.carbon.identity.organization.management.organization.user.sharing</bundleDef>
+                                <bundleDef>org.wso2.carbon.identity.organization.management:org.wso2.carbon.identity.organization.resource.sharing.policy.management</bundleDef>
                                 <bundleDef>org.wso2.carbon.identity.organization.management:org.wso2.carbon.identity.organization.user.invitation.management</bundleDef>
                                 <bundleDef>org.wso2.carbon.identity.organization.management:org.wso2.carbon.identity.organization.config.service</bundleDef>
                                 <bundleDef>org.wso2.carbon.identity.organization.management:org.wso2.carbon.identity.organization.discovery.service</bundleDef>


### PR DESCRIPTION
This PR updates the `organization management server feature` module to include the newly introduced `Resource Sharing Policy Management` component. This enhancement ensures the required dependency and bundle definition are added for seamless integration and functionality.

## Purpose
> This update ensures that the Resource Sharing Policy Management component is included in the server feature, enabling the system to manage resource-sharing policies effectively.

## Goals
> - Add the necessary dependency for the Resource Sharing Policy Management component.
> - Define the bundle required for the component to function as part of the server feature.

## Release note
> Added the dependency and bundle definition for the Resource Sharing Policy Management component in the Organization Management Server feature module.

---

### Related Issue

[Introduce a Centralized Resource Sharing Policy Management Service #21815](https://github.com/wso2/product-is/issues/21815)