### PR TITLE
Handle the Cleanup of Resource Sharing Policies and Attributes During Resource, Attribute, and Organization Deletion.

### DIFF
--- a/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/ResourceSharingPolicyHandlerService.java
+++ b/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/ResourceSharingPolicyHandlerService.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.organization.resource.sharing.policy.management;
 
+import org.apache.commons.lang.NotImplementedException;
 import org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.ResourceType;
 import org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.SharedAttributeType;
 import org.wso2.carbon.identity.organization.resource.sharing.policy.management.exception.ResourceSharingPolicyMgtException;
@@ -253,8 +254,11 @@ public interface ResourceSharingPolicyHandlerService {
      * @param resourceId   The unique identifier of the resource whose sharing policy is to be deleted.
      * @throws ResourceSharingPolicyMgtException If an error occurs while deleting the resource sharing policy.
      */
-    void deleteResourceSharingPolicyByResourceTypeAndId(ResourceType resourceType, String resourceId)
-            throws ResourceSharingPolicyMgtException;
+    default void deleteResourceSharingPolicyByResourceTypeAndId(ResourceType resourceType, String resourceId)
+            throws ResourceSharingPolicyMgtException {
+
+        throw new NotImplementedException("aggregate method is not implemented in " + this.getClass());
+    }
 
     /**
      * Deletes a shared resource attribute based on its attribute type and unique identifier.
@@ -266,8 +270,12 @@ public interface ResourceSharingPolicyHandlerService {
      * @param attributeId   The unique identifier of the attribute to be deleted.
      * @throws ResourceSharingPolicyMgtException If an error occurs while deleting the shared resource attribute.
      */
-    void deleteSharedResourceAttributeByAttributeTypeAndId(SharedAttributeType attributeType, String attributeId)
-            throws ResourceSharingPolicyMgtException;
+    default void deleteSharedResourceAttributeByAttributeTypeAndId(SharedAttributeType attributeType,
+                                                                   String attributeId)
+            throws ResourceSharingPolicyMgtException {
+
+        throw new NotImplementedException("aggregate method is not implemented in " + this.getClass());
+    }
 
     /**
      * Deletes all resource sharing policies and shared resource attributes associated with a given organization.
@@ -279,6 +287,9 @@ public interface ResourceSharingPolicyHandlerService {
      * @throws ResourceSharingPolicyMgtException If an error occurs while deleting the resource sharing policies or
      *                                           attributes.
      */
-    void deleteResourceSharingPoliciesAndAttributesByOrganizationId(String organizationId)
-            throws ResourceSharingPolicyMgtException;
+    default void deleteResourceSharingPoliciesAndAttributesByOrganizationId(String organizationId)
+            throws ResourceSharingPolicyMgtException {
+
+        throw new NotImplementedException("aggregate method is not implemented in " + this.getClass());
+    }
 }

--- a/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/ResourceSharingPolicyHandlerService.java
+++ b/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/ResourceSharingPolicyHandlerService.java
@@ -57,7 +57,7 @@ public interface ResourceSharingPolicyHandlerService {
      * @param resourceSharingPolicyId The unique identifier of the resource sharing policy to be retrieved.
      *                                Must be a valid ID greater than zero.
      * @return An {@link Optional} containing the {@link ResourceSharingPolicy} if found,
-     *         or an empty {@link Optional} if no matching resource sharing policy exists.
+     * or an empty {@link Optional} if no matching resource sharing policy exists.
      * @throws ResourceSharingPolicyMgtException If an error occurs while retrieving the resource sharing policy.
      */
     Optional<ResourceSharingPolicy> getResourceSharingPolicyById(int resourceSharingPolicyId)
@@ -121,7 +121,7 @@ public interface ResourceSharingPolicyHandlerService {
      * @throws ResourceSharingPolicyMgtException If an error occurs while deleting the resource sharing policy.
      */
     void deleteResourceSharingPolicyByResourceTypeAndId(ResourceType resourceType, String resourceId,
-                                                           String sharingPolicyInitiatedOrgId)
+                                                        String sharingPolicyInitiatedOrgId)
             throws ResourceSharingPolicyMgtException;
 
     /**
@@ -205,8 +205,8 @@ public interface ResourceSharingPolicyHandlerService {
      * @throws ResourceSharingPolicyMgtException If an error occurs while deleting the shared resource attributes.
      */
     void deleteSharedResourceAttributesByResourceSharingPolicyId(int resourceSharingPolicyId,
-                                                                    SharedAttributeType sharedAttributeType,
-                                                                    String sharingPolicyInitiatedOrgId)
+                                                                 SharedAttributeType sharedAttributeType,
+                                                                 String sharingPolicyInitiatedOrgId)
             throws ResourceSharingPolicyMgtException;
 
     /**
@@ -221,17 +221,17 @@ public interface ResourceSharingPolicyHandlerService {
      * @throws ResourceSharingPolicyMgtException If an error occurs while deleting the shared resource attribute.
      */
     void deleteSharedResourceAttributeByAttributeTypeAndId(SharedAttributeType attributeType, String attributeId,
-                                                              String sharingPolicyInitiatedOrgId)
+                                                           String sharingPolicyInitiatedOrgId)
             throws ResourceSharingPolicyMgtException;
 
     /**
      * Adds a resource sharing policy along with its associated shared resource attributes in a single transaction.
      *
-     * @param resourceSharingPolicy       The {@link ResourceSharingPolicy} containing details such as resource type,
-     *                                    initiating organization, policy holding organization, and sharing policy.
-     *                                    Must not be {@code null}.
-     * @param sharedResourceAttributes    A list of {@link SharedResourceAttribute} objects associated with the resource
-     *                                    sharing policy. Must not be {@code null} or empty.
+     * @param resourceSharingPolicy    The {@link ResourceSharingPolicy} containing details such as resource type,
+     *                                 initiating organization, policy holding organization, and sharing policy.
+     *                                 Must not be {@code null}.
+     * @param sharedResourceAttributes A list of {@link SharedResourceAttribute} objects associated with the resource
+     *                                 sharing policy. Must not be {@code null} or empty.
      * @return {@code true} if both the resource sharing policy and the shared resource attributes were added
      * successfully.
      * @throws ResourceSharingPolicyMgtException If an error occurs while adding the resource sharing policy or the
@@ -273,7 +273,8 @@ public interface ResourceSharingPolicyHandlerService {
     default void deleteResourceSharingPolicyByResourceTypeAndId(ResourceType resourceType, String resourceId)
             throws ResourceSharingPolicyMgtException {
 
-        throw new NotImplementedException("deleteResourceSharingPolicyByResourceTypeAndId method is not implemented in " + this.getClass());
+        throw new NotImplementedException(
+                "deleteResourceSharingPolicyByResourceTypeAndId method is not implemented in " + this.getClass());
     }
 
     /**
@@ -290,7 +291,8 @@ public interface ResourceSharingPolicyHandlerService {
                                                                    String attributeId)
             throws ResourceSharingPolicyMgtException {
 
-        throw new NotImplementedException("deleteSharedResourceAttributeByAttributeTypeAndId method is not implemented in " + this.getClass());
+        throw new NotImplementedException(
+                "deleteSharedResourceAttributeByAttributeTypeAndId method is not implemented in " + this.getClass());
     }
 
     /**
@@ -306,6 +308,8 @@ public interface ResourceSharingPolicyHandlerService {
     default void deleteResourceSharingPoliciesAndAttributesByOrganizationId(String organizationId)
             throws ResourceSharingPolicyMgtException {
 
-        throw new NotImplementedException("deleteResourceSharingPoliciesAndAttributesByOrganizationId method is not implemented in " + this.getClass());
+        throw new NotImplementedException(
+                "deleteResourceSharingPoliciesAndAttributesByOrganizationId method is not implemented in " +
+                        this.getClass());
     }
 }

--- a/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/ResourceSharingPolicyHandlerService.java
+++ b/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/ResourceSharingPolicyHandlerService.java
@@ -245,11 +245,9 @@ public interface ResourceSharingPolicyHandlerService {
 
     /**
      * Deletes a resource sharing policy based on its resource type and resource ID.
-     * <p>
-     * This method should only be used when a resource (e.g., user) is being deleted independently of the policies.
+     * This method should only be used when a resource (e.g. user) is being deleted independently of the policies.
      * It ensures that all related resource sharing policies associated with the given resource are also deleted
      * as part of the resource deletion process.
-     * </p>
      *
      * @param resourceType The {@link ResourceType} of the resource.
      * @param resourceId   The unique identifier of the resource whose sharing policy is to be deleted.
@@ -260,11 +258,9 @@ public interface ResourceSharingPolicyHandlerService {
 
     /**
      * Deletes a shared resource attribute based on its attribute type and unique identifier.
-     * <p>
-     * This method should only be used when a resource (e.g., roles) is being deleted independently of the policies.
+     * This method should only be used when a resource (e.g. roles) is being deleted independently of the policies.
      * It ensures that all corresponding shared resource attributes associated with the given attribute are also
      * deleted as part of the attribute deletion process.
-     * </p>
      *
      * @param attributeType The {@link SharedAttributeType} of the attribute to be deleted.
      * @param attributeId   The unique identifier of the attribute to be deleted.
@@ -275,11 +271,9 @@ public interface ResourceSharingPolicyHandlerService {
 
     /**
      * Deletes all resource sharing policies and shared resource attributes associated with a given organization.
-     * <p>
      * This method should be called when an organization is being deleted. It ensures that all resource sharing
      * policies and corresponding shared resource attributes related to the specified organization are also deleted
      * as part of the organization's deletion process.
-     * </p>
      *
      * @param organizationId The unique identifier of the organization being deleted.
      * @throws ResourceSharingPolicyMgtException If an error occurs while deleting the resource sharing policies or

--- a/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/ResourceSharingPolicyHandlerService.java
+++ b/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/ResourceSharingPolicyHandlerService.java
@@ -273,7 +273,7 @@ public interface ResourceSharingPolicyHandlerService {
     default void deleteResourceSharingPolicyByResourceTypeAndId(ResourceType resourceType, String resourceId)
             throws ResourceSharingPolicyMgtException {
 
-        throw new NotImplementedException("aggregate method is not implemented in " + this.getClass());
+        throw new NotImplementedException("deleteResourceSharingPolicyByResourceTypeAndId method is not implemented in " + this.getClass());
     }
 
     /**
@@ -290,7 +290,7 @@ public interface ResourceSharingPolicyHandlerService {
                                                                    String attributeId)
             throws ResourceSharingPolicyMgtException {
 
-        throw new NotImplementedException("aggregate method is not implemented in " + this.getClass());
+        throw new NotImplementedException("deleteSharedResourceAttributeByAttributeTypeAndId method is not implemented in " + this.getClass());
     }
 
     /**
@@ -306,6 +306,6 @@ public interface ResourceSharingPolicyHandlerService {
     default void deleteResourceSharingPoliciesAndAttributesByOrganizationId(String organizationId)
             throws ResourceSharingPolicyMgtException {
 
-        throw new NotImplementedException("aggregate method is not implemented in " + this.getClass());
+        throw new NotImplementedException("deleteResourceSharingPoliciesAndAttributesByOrganizationId method is not implemented in " + this.getClass());
     }
 }

--- a/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/ResourceSharingPolicyHandlerService.java
+++ b/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/ResourceSharingPolicyHandlerService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -18,9 +18,9 @@
 
 package org.wso2.carbon.identity.organization.resource.sharing.policy.management;
 
-import org.apache.commons.lang.NotImplementedException;
 import org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.ResourceType;
 import org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.SharedAttributeType;
+import org.wso2.carbon.identity.organization.resource.sharing.policy.management.exception.NotImplementedException;
 import org.wso2.carbon.identity.organization.resource.sharing.policy.management.exception.ResourceSharingPolicyMgtException;
 import org.wso2.carbon.identity.organization.resource.sharing.policy.management.model.ResourceSharingPolicy;
 import org.wso2.carbon.identity.organization.resource.sharing.policy.management.model.SharedResourceAttribute;

--- a/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/ResourceSharingPolicyHandlerService.java
+++ b/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/ResourceSharingPolicyHandlerService.java
@@ -242,4 +242,49 @@ public interface ResourceSharingPolicyHandlerService {
     Map<String, Map<ResourceSharingPolicy, List<SharedResourceAttribute>>>
     getResourceSharingPoliciesWithSharedAttributes(List<String> policyHoldingOrganizationIds)
             throws ResourceSharingPolicyMgtException;
+
+    /**
+     * Deletes a resource sharing policy based on its resource type and resource ID.
+     * <p>
+     * This method should only be used when a resource (e.g., user) is being deleted independently of the policies.
+     * It ensures that all related resource sharing policies associated with the given resource are also deleted
+     * as part of the resource deletion process.
+     * </p>
+     *
+     * @param resourceType The {@link ResourceType} of the resource.
+     * @param resourceId   The unique identifier of the resource whose sharing policy is to be deleted.
+     * @throws ResourceSharingPolicyMgtException If an error occurs while deleting the resource sharing policy.
+     */
+    void deleteResourceSharingPolicyByResourceTypeAndId(ResourceType resourceType, String resourceId)
+            throws ResourceSharingPolicyMgtException;
+
+    /**
+     * Deletes a shared resource attribute based on its attribute type and unique identifier.
+     * <p>
+     * This method should only be used when a resource (e.g., roles) is being deleted independently of the policies.
+     * It ensures that all corresponding shared resource attributes associated with the given attribute are also
+     * deleted as part of the attribute deletion process.
+     * </p>
+     *
+     * @param attributeType The {@link SharedAttributeType} of the attribute to be deleted.
+     * @param attributeId   The unique identifier of the attribute to be deleted.
+     * @throws ResourceSharingPolicyMgtException If an error occurs while deleting the shared resource attribute.
+     */
+    void deleteSharedResourceAttributeByAttributeTypeAndId(SharedAttributeType attributeType, String attributeId)
+            throws ResourceSharingPolicyMgtException;
+
+    /**
+     * Deletes all resource sharing policies and shared resource attributes associated with a given organization.
+     * <p>
+     * This method should be called when an organization is being deleted. It ensures that all resource sharing
+     * policies and corresponding shared resource attributes related to the specified organization are also deleted
+     * as part of the organization's deletion process.
+     * </p>
+     *
+     * @param organizationId The unique identifier of the organization being deleted.
+     * @throws ResourceSharingPolicyMgtException If an error occurs while deleting the resource sharing policies or
+     *                                           attributes.
+     */
+    void deleteResourceSharingPoliciesAndAttributesByOrganizationId(String organizationId)
+            throws ResourceSharingPolicyMgtException;
 }

--- a/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/ResourceSharingPolicyHandlerServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/ResourceSharingPolicyHandlerServiceImpl.java
@@ -234,6 +234,28 @@ public class ResourceSharingPolicyHandlerServiceImpl implements ResourceSharingP
                 policyHoldingOrganizationIds);
     }
 
+    @Override
+    public void deleteResourceSharingPolicyByResourceTypeAndId(ResourceType resourceType, String resourceId)
+            throws ResourceSharingPolicyMgtException {
+
+        RESOURCE_SHARING_POLICY_HANDLER_DAO.deleteResourceSharingPolicyByResourceTypeAndId(resourceType, resourceId);
+    }
+
+    @Override
+    public void deleteSharedResourceAttributeByAttributeTypeAndId(SharedAttributeType attributeType, String attributeId)
+            throws ResourceSharingPolicyMgtException {
+
+        RESOURCE_SHARING_POLICY_HANDLER_DAO.deleteSharedResourceAttributeByAttributeTypeAndId(attributeType,
+                attributeId);
+    }
+
+    @Override
+    public void deleteResourceSharingPoliciesAndAttributesByOrganizationId(String organizationId)
+            throws ResourceSharingPolicyMgtException {
+
+        RESOURCE_SHARING_POLICY_HANDLER_DAO.deleteResourceSharingPoliciesAndAttributesByOrganizationId(organizationId);
+    }
+
     private boolean isValidAttributeForTheResource(ResourceSharingPolicy resourceSharingPolicy,
                                                    SharedResourceAttribute sharedResourceAttribute) {
 

--- a/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/constant/ResourceSharingSQLConstants.java
+++ b/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/constant/ResourceSharingSQLConstants.java
@@ -134,6 +134,28 @@ public class ResourceSharingSQLConstants {
                     "UM_INITIATING_ORG_ID = :" +
                     SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_INITIATING_ORG_ID + ";)";
 
+    // SQL for deleting resource sharing policy by resource type and ID at Resource deletion.
+    public static final String DELETE_RESOURCE_SHARING_POLICY_BY_RESOURCE_TYPE_AND_ID_AT_RESOURCE_DELETION =
+            "DELETE FROM UM_RESOURCE_SHARING_POLICY WHERE " +
+                    "UM_RESOURCE_TYPE = :" +
+                    SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_RESOURCE_TYPE + "; AND " +
+                    "UM_RESOURCE_ID = :" +
+                    SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_RESOURCE_ID + ";";
+
+    // SQL for deleting shared resource attribute by attribute type and ID at Attribute deletion.
+    public static final String DELETE_SHARED_RESOURCE_ATTRIBUTE_BY_ATTRIBUTE_TYPE_AND_ID_AT_ATTRIBUTE_DELETION =
+            "DELETE FROM UM_SHARED_RESOURCE_ATTRIBUTES WHERE " +
+                    "UM_SHARED_ATTRIBUTE_TYPE = :" +
+                    SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_SHARED_ATTRIBUTE_TYPE + "; AND " +
+                    "UM_SHARED_ATTRIBUTE_ID = :" +
+                    SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_SHARED_ATTRIBUTE_ID + ";";
+
+    // SQL for deleting resource sharing policy by org ID.
+    public static final String DELETE_RESOURCE_SHARING_POLICY_BY_ORG_ID_AT_ATTRIBUTE_DELETION =
+            "DELETE FROM UM_RESOURCE_SHARING_POLICY WHERE " +
+                    "UM_INITIATING_ORG_ID = :" + SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_INITIATING_ORG_ID + "; OR " +
+                    "UM_POLICY_HOLDING_ORG_ID = :" + SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_POLICY_HOLDING_ORG_ID + ";";
+
     private ResourceSharingSQLConstants() {
 
     }

--- a/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/dao/ResourceSharingPolicyHandlerDAO.java
+++ b/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/dao/ResourceSharingPolicyHandlerDAO.java
@@ -255,11 +255,9 @@ public interface ResourceSharingPolicyHandlerDAO {
 
     /**
      * Deletes a resource sharing policy based on its resource type and resource ID.
-     * <p>
-     * This method is intended to be used when a resource (e.g., user) is being deleted independently of the policies.
+     * This method is intended to be used when a resource (e.g. user) is being deleted independently of the policies.
      * It ensures that all related resource sharing policies associated with the specified resource are deleted
      * as part of the resource deletion process.
-     * </p>
      *
      * @param resourceType The {@link ResourceType} of the resource whose policy needs to be deleted.
      *                     Must not be {@code null}.
@@ -272,11 +270,9 @@ public interface ResourceSharingPolicyHandlerDAO {
 
     /**
      * Deletes a shared resource attribute based on its attribute type and unique identifier.
-     * <p>
-     * This method is intended to be used when a resource (e.g., roles) is being deleted independently of the policies.
+     * This method is intended to be used when a resource (e.g. roles) is being deleted independently of the policies.
      * It ensures that all corresponding shared resource attributes associated with the specified attribute are deleted
      * as part of the attribute deletion process.
-     * </p>
      *
      * @param attributeType The {@link SharedAttributeType} of the attribute to be deleted.
      *                      Must not be {@code null}.
@@ -289,11 +285,9 @@ public interface ResourceSharingPolicyHandlerDAO {
 
     /**
      * Deletes all resource sharing policies and shared resource attributes associated with a given organization.
-     * <p>
      * This method is intended to be used when an organization is being deleted. It ensures that all resource sharing
      * policies and corresponding shared resource attributes related to the specified organization are also deleted
      * as part of the organization's deletion process.
-     * </p>
      *
      * @param organizationId The unique identifier of the organization whose policies and attributes need to be deleted.
      *                       Must not be {@code null} or empty.

--- a/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/dao/ResourceSharingPolicyHandlerDAO.java
+++ b/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/dao/ResourceSharingPolicyHandlerDAO.java
@@ -285,7 +285,7 @@ public interface ResourceSharingPolicyHandlerDAO {
     default void deleteResourceSharingPolicyByResourceTypeAndId(ResourceType resourceType, String resourceId)
             throws ResourceSharingPolicyMgtServerException {
 
-        throw new NotImplementedException("aggregate method is not implemented in " + this.getClass());
+        throw new NotImplementedException("deleteResourceSharingPolicyByResourceTypeAndId method is not implemented in " + this.getClass());
     }
 
     /**
@@ -304,7 +304,7 @@ public interface ResourceSharingPolicyHandlerDAO {
                                                                    String attributeId)
             throws ResourceSharingPolicyMgtServerException {
 
-        throw new NotImplementedException("aggregate method is not implemented in " + this.getClass());
+        throw new NotImplementedException("deleteSharedResourceAttributeByAttributeTypeAndId method is not implemented in " + this.getClass());
     }
 
     /**
@@ -321,6 +321,6 @@ public interface ResourceSharingPolicyHandlerDAO {
     default void deleteResourceSharingPoliciesAndAttributesByOrganizationId(String organizationId)
             throws ResourceSharingPolicyMgtServerException {
 
-        throw new NotImplementedException("aggregate method is not implemented in " + this.getClass());
+        throw new NotImplementedException("deleteResourceSharingPoliciesAndAttributesByOrganizationId method is not implemented in " + this.getClass());
     }
 }

--- a/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/dao/ResourceSharingPolicyHandlerDAO.java
+++ b/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/dao/ResourceSharingPolicyHandlerDAO.java
@@ -18,9 +18,9 @@
 
 package org.wso2.carbon.identity.organization.resource.sharing.policy.management.dao;
 
-import org.apache.commons.lang.NotImplementedException;
 import org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.ResourceType;
 import org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.SharedAttributeType;
+import org.wso2.carbon.identity.organization.resource.sharing.policy.management.exception.NotImplementedException;
 import org.wso2.carbon.identity.organization.resource.sharing.policy.management.exception.ResourceSharingPolicyMgtServerException;
 import org.wso2.carbon.identity.organization.resource.sharing.policy.management.model.ResourceSharingPolicy;
 import org.wso2.carbon.identity.organization.resource.sharing.policy.management.model.SharedResourceAttribute;

--- a/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/dao/ResourceSharingPolicyHandlerDAO.java
+++ b/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/dao/ResourceSharingPolicyHandlerDAO.java
@@ -252,4 +252,54 @@ public interface ResourceSharingPolicyHandlerDAO {
     Map<String, Map<ResourceSharingPolicy, List<SharedResourceAttribute>>>
     getResourceSharingPoliciesWithSharedAttributes(List<String> policyHoldingOrganizationIds)
             throws ResourceSharingPolicyMgtServerException;
+
+    /**
+     * Deletes a resource sharing policy based on its resource type and resource ID.
+     * <p>
+     * This method is intended to be used when a resource (e.g., user) is being deleted independently of the policies.
+     * It ensures that all related resource sharing policies associated with the specified resource are deleted
+     * as part of the resource deletion process.
+     * </p>
+     *
+     * @param resourceType The {@link ResourceType} of the resource whose policy needs to be deleted.
+     *                     Must not be {@code null}.
+     * @param resourceId   The unique identifier of the resource whose sharing policy is to be deleted.
+     *                     Must not be {@code null} or empty.
+     * @throws ResourceSharingPolicyMgtServerException If an error occurs while deleting the resource sharing policy.
+     */
+    void deleteResourceSharingPolicyByResourceTypeAndId(ResourceType resourceType, String resourceId)
+            throws ResourceSharingPolicyMgtServerException;
+
+    /**
+     * Deletes a shared resource attribute based on its attribute type and unique identifier.
+     * <p>
+     * This method is intended to be used when a resource (e.g., roles) is being deleted independently of the policies.
+     * It ensures that all corresponding shared resource attributes associated with the specified attribute are deleted
+     * as part of the attribute deletion process.
+     * </p>
+     *
+     * @param attributeType The {@link SharedAttributeType} of the attribute to be deleted.
+     *                      Must not be {@code null}.
+     * @param attributeId   The unique identifier of the attribute to be deleted.
+     *                      Must not be {@code null} or empty.
+     * @throws ResourceSharingPolicyMgtServerException If an error occurs while deleting the shared resource attribute.
+     */
+    void deleteSharedResourceAttributeByAttributeTypeAndId(SharedAttributeType attributeType, String attributeId)
+            throws ResourceSharingPolicyMgtServerException;
+
+    /**
+     * Deletes all resource sharing policies and shared resource attributes associated with a given organization.
+     * <p>
+     * This method is intended to be used when an organization is being deleted. It ensures that all resource sharing
+     * policies and corresponding shared resource attributes related to the specified organization are also deleted
+     * as part of the organization's deletion process.
+     * </p>
+     *
+     * @param organizationId The unique identifier of the organization whose policies and attributes need to be deleted.
+     *                       Must not be {@code null} or empty.
+     * @throws ResourceSharingPolicyMgtServerException If an error occurs while deleting the resource sharing policies
+     *                                                 or attributes.
+     */
+    void deleteResourceSharingPoliciesAndAttributesByOrganizationId(String organizationId)
+            throws ResourceSharingPolicyMgtServerException;
 }

--- a/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/dao/ResourceSharingPolicyHandlerDAO.java
+++ b/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/dao/ResourceSharingPolicyHandlerDAO.java
@@ -57,12 +57,11 @@ public interface ResourceSharingPolicyHandlerDAO {
      * @param resourceSharingPolicyId The unique identifier of the resource sharing policy to be retrieved.
      *                                Must be a valid ID greater than zero.
      * @return An {@link Optional} containing the {@link ResourceSharingPolicy} if found,
-     *         or an empty {@link Optional} if no matching resource sharing policy exists.
+     * or an empty {@link Optional} if no matching resource sharing policy exists.
      * @throws ResourceSharingPolicyMgtServerException If an error occurs while retrieving the resource sharing policy.
      */
     Optional<ResourceSharingPolicy> getResourceSharingPolicyById(int resourceSharingPolicyId)
             throws ResourceSharingPolicyMgtServerException;
-
 
     /**
      * Retrieves a list of resource sharing policies associated with the given policy holding organization IDs.
@@ -71,7 +70,7 @@ public interface ResourceSharingPolicyHandlerDAO {
      *                                     Must not be {@code null} or empty.
      * @return A list of {@link ResourceSharingPolicy} objects for the specified organization IDs.
      * @throws ResourceSharingPolicyMgtServerException If an error occurs while retrieving the resource sharing
-     * policies.
+     *                                                 policies.
      */
     List<ResourceSharingPolicy> getResourceSharingPolicies(List<String> policyHoldingOrganizationIds)
             throws ResourceSharingPolicyMgtServerException;
@@ -85,7 +84,7 @@ public interface ResourceSharingPolicyHandlerDAO {
      * @return A map where each key is a {@link ResourceType} and the corresponding value is a list of
      * {@link ResourceSharingPolicy}.
      * @throws ResourceSharingPolicyMgtServerException If an error occurs while retrieving the resource sharing
-     * policies.
+     *                                                 policies.
      */
     Map<ResourceType, List<ResourceSharingPolicy>> getResourceSharingPoliciesGroupedByResourceType(
             List<String> policyHoldingOrganizationIds) throws ResourceSharingPolicyMgtServerException;
@@ -98,7 +97,7 @@ public interface ResourceSharingPolicyHandlerDAO {
      *                                     Must not be {@code null} or empty.
      * @return A map where each key is an organization ID, and the value is a list of {@link ResourceSharingPolicy}.
      * @throws ResourceSharingPolicyMgtServerException If an error occurs while retrieving the resource sharing
-     * policies.
+     *                                                 policies.
      */
     Map<String, List<ResourceSharingPolicy>> getResourceSharingPoliciesGroupedByPolicyHoldingOrgId(
             List<String> policyHoldingOrganizationIds) throws ResourceSharingPolicyMgtServerException;
@@ -127,7 +126,7 @@ public interface ResourceSharingPolicyHandlerDAO {
      * @throws ResourceSharingPolicyMgtServerException If an error occurs while deleting the resource sharing policy.
      */
     void deleteResourceSharingPolicyByResourceTypeAndId(ResourceType resourceType, String resourceId,
-                                                           String sharingPolicyInitiatedOrgId)
+                                                        String sharingPolicyInitiatedOrgId)
             throws ResourceSharingPolicyMgtServerException;
 
     /**
@@ -163,7 +162,7 @@ public interface ResourceSharingPolicyHandlerDAO {
      * @param resourceSharingPolicyId The unique identifier of the resource sharing policy.
      * @return A list of {@link SharedResourceAttribute} associated with the given policy.
      * @throws ResourceSharingPolicyMgtServerException If an error occurs while retrieving the shared resource
-     * attributes.
+     *                                                 attributes.
      */
     List<SharedResourceAttribute> getSharedResourceAttributesBySharingPolicyId(int resourceSharingPolicyId)
             throws ResourceSharingPolicyMgtServerException;
@@ -174,7 +173,7 @@ public interface ResourceSharingPolicyHandlerDAO {
      * @param attributeType The {@link SharedAttributeType} of the resource attribute to be retrieved.
      * @return A list of {@link SharedResourceAttribute} objects for the specified type.
      * @throws ResourceSharingPolicyMgtServerException If an error occurs while retrieving the shared resource
-     * attributes.
+     *                                                 attributes.
      */
     List<SharedResourceAttribute> getSharedResourceAttributesByType(SharedAttributeType attributeType)
             throws ResourceSharingPolicyMgtServerException;
@@ -185,7 +184,7 @@ public interface ResourceSharingPolicyHandlerDAO {
      * @param attributeId The unique identifier of the resource attribute to be retrieved.
      * @return A list of {@link SharedResourceAttribute} objects for the specified attribute ID.
      * @throws ResourceSharingPolicyMgtServerException If an error occurs while retrieving the shared resource
-     * attributes.
+     *                                                 attributes.
      */
     List<SharedResourceAttribute> getSharedResourceAttributesById(String attributeId)
             throws ResourceSharingPolicyMgtServerException;
@@ -197,7 +196,7 @@ public interface ResourceSharingPolicyHandlerDAO {
      * @param attributeId   The unique identifier of the attribute to be retrieved.
      * @return A list of {@link SharedResourceAttribute} objects for the specified type and ID.
      * @throws ResourceSharingPolicyMgtServerException If an error occurs while retrieving the shared resource
-     * attributes.
+     *                                                 attributes.
      */
     List<SharedResourceAttribute> getSharedResourceAttributesByTypeAndId(SharedAttributeType attributeType,
                                                                          String attributeId)
@@ -215,8 +214,8 @@ public interface ResourceSharingPolicyHandlerDAO {
      * @throws ResourceSharingPolicyMgtServerException If an error occurs while deleting the shared resource attributes.
      */
     void deleteSharedResourceAttributesByResourceSharingPolicyId(int resourceSharingPolicyId,
-                                                                    SharedAttributeType sharedAttributeType,
-                                                                    String sharingPolicyInitiatedOrgId)
+                                                                 SharedAttributeType sharedAttributeType,
+                                                                 String sharingPolicyInitiatedOrgId)
             throws ResourceSharingPolicyMgtServerException;
 
     /**
@@ -231,17 +230,17 @@ public interface ResourceSharingPolicyHandlerDAO {
      * @throws ResourceSharingPolicyMgtServerException If an error occurs while deleting the shared resource attribute.
      */
     void deleteSharedResourceAttributeByAttributeTypeAndId(SharedAttributeType attributeType, String attributeId,
-                                                              String sharingPolicyInitiatedOrgId)
+                                                           String sharingPolicyInitiatedOrgId)
             throws ResourceSharingPolicyMgtServerException;
 
     /**
      * Adds a resource sharing policy along with its associated shared resource attributes in a single transaction.
      *
-     * @param resourceSharingPolicy       The {@link ResourceSharingPolicy} containing details such as resource type,
-     *                                    initiating organization, policy holding organization, and sharing policy.
-     *                                    Must not be {@code null}.
-     * @param sharedResourceAttributes    A list of {@link SharedResourceAttribute} objects associated with the resource
-     *                                    sharing policy. Must not be {@code null} or empty.
+     * @param resourceSharingPolicy    The {@link ResourceSharingPolicy} containing details such as resource type,
+     *                                 initiating organization, policy holding organization, and sharing policy.
+     *                                 Must not be {@code null}.
+     * @param sharedResourceAttributes A list of {@link SharedResourceAttribute} objects associated with the resource
+     *                                 sharing policy. Must not be {@code null} or empty.
      * @return {@code true} if both the resource sharing policy and the shared resource attributes were added
      * successfully.
      * @throws ResourceSharingPolicyMgtServerException If an error occurs while adding the resource sharing policy or
@@ -264,7 +263,7 @@ public interface ResourceSharingPolicyHandlerDAO {
      * - The value is a list of {@link SharedResourceAttribute} associated with the policy.
      * If no matching policies or attributes are found, an empty map will be returned.
      * @throws ResourceSharingPolicyMgtServerException If an error occurs while retrieving the resource sharing
-     *                                           policies or shared attributes.
+     *                                                 policies or shared attributes.
      */
     Map<String, Map<ResourceSharingPolicy, List<SharedResourceAttribute>>>
     getResourceSharingPoliciesWithSharedAttributes(List<String> policyHoldingOrganizationIds)
@@ -285,7 +284,8 @@ public interface ResourceSharingPolicyHandlerDAO {
     default void deleteResourceSharingPolicyByResourceTypeAndId(ResourceType resourceType, String resourceId)
             throws ResourceSharingPolicyMgtServerException {
 
-        throw new NotImplementedException("deleteResourceSharingPolicyByResourceTypeAndId method is not implemented in " + this.getClass());
+        throw new NotImplementedException(
+                "deleteResourceSharingPolicyByResourceTypeAndId method is not implemented in " + this.getClass());
     }
 
     /**
@@ -304,7 +304,8 @@ public interface ResourceSharingPolicyHandlerDAO {
                                                                    String attributeId)
             throws ResourceSharingPolicyMgtServerException {
 
-        throw new NotImplementedException("deleteSharedResourceAttributeByAttributeTypeAndId method is not implemented in " + this.getClass());
+        throw new NotImplementedException(
+                "deleteSharedResourceAttributeByAttributeTypeAndId method is not implemented in " + this.getClass());
     }
 
     /**
@@ -321,6 +322,8 @@ public interface ResourceSharingPolicyHandlerDAO {
     default void deleteResourceSharingPoliciesAndAttributesByOrganizationId(String organizationId)
             throws ResourceSharingPolicyMgtServerException {
 
-        throw new NotImplementedException("deleteResourceSharingPoliciesAndAttributesByOrganizationId method is not implemented in " + this.getClass());
+        throw new NotImplementedException(
+                "deleteResourceSharingPoliciesAndAttributesByOrganizationId method is not implemented in " +
+                        this.getClass());
     }
 }

--- a/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/dao/ResourceSharingPolicyHandlerDAO.java
+++ b/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/dao/ResourceSharingPolicyHandlerDAO.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.organization.resource.sharing.policy.management.dao;
 
+import org.apache.commons.lang.NotImplementedException;
 import org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.ResourceType;
 import org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.SharedAttributeType;
 import org.wso2.carbon.identity.organization.resource.sharing.policy.management.exception.ResourceSharingPolicyMgtServerException;
@@ -265,8 +266,11 @@ public interface ResourceSharingPolicyHandlerDAO {
      *                     Must not be {@code null} or empty.
      * @throws ResourceSharingPolicyMgtServerException If an error occurs while deleting the resource sharing policy.
      */
-    void deleteResourceSharingPolicyByResourceTypeAndId(ResourceType resourceType, String resourceId)
-            throws ResourceSharingPolicyMgtServerException;
+    default void deleteResourceSharingPolicyByResourceTypeAndId(ResourceType resourceType, String resourceId)
+            throws ResourceSharingPolicyMgtServerException {
+
+        throw new NotImplementedException("aggregate method is not implemented in " + this.getClass());
+    }
 
     /**
      * Deletes a shared resource attribute based on its attribute type and unique identifier.
@@ -280,8 +284,12 @@ public interface ResourceSharingPolicyHandlerDAO {
      *                      Must not be {@code null} or empty.
      * @throws ResourceSharingPolicyMgtServerException If an error occurs while deleting the shared resource attribute.
      */
-    void deleteSharedResourceAttributeByAttributeTypeAndId(SharedAttributeType attributeType, String attributeId)
-            throws ResourceSharingPolicyMgtServerException;
+    default void deleteSharedResourceAttributeByAttributeTypeAndId(SharedAttributeType attributeType,
+                                                                   String attributeId)
+            throws ResourceSharingPolicyMgtServerException {
+
+        throw new NotImplementedException("aggregate method is not implemented in " + this.getClass());
+    }
 
     /**
      * Deletes all resource sharing policies and shared resource attributes associated with a given organization.
@@ -294,6 +302,9 @@ public interface ResourceSharingPolicyHandlerDAO {
      * @throws ResourceSharingPolicyMgtServerException If an error occurs while deleting the resource sharing policies
      *                                                 or attributes.
      */
-    void deleteResourceSharingPoliciesAndAttributesByOrganizationId(String organizationId)
-            throws ResourceSharingPolicyMgtServerException;
+    default void deleteResourceSharingPoliciesAndAttributesByOrganizationId(String organizationId)
+            throws ResourceSharingPolicyMgtServerException {
+
+        throw new NotImplementedException("aggregate method is not implemented in " + this.getClass());
+    }
 }

--- a/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/dao/ResourceSharingPolicyHandlerDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/dao/ResourceSharingPolicyHandlerDAOImpl.java
@@ -52,9 +52,12 @@ import static org.wso2.carbon.identity.organization.resource.sharing.policy.mana
 import static org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.ResourceSharingSQLConstants.CREATE_RESOURCE_SHARING_POLICY;
 import static org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.ResourceSharingSQLConstants.CREATE_SHARED_RESOURCE_ATTRIBUTE;
 import static org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.ResourceSharingSQLConstants.DELETE_RESOURCE_SHARING_POLICY;
+import static org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.ResourceSharingSQLConstants.DELETE_RESOURCE_SHARING_POLICY_BY_ORG_ID_AT_ATTRIBUTE_DELETION;
 import static org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.ResourceSharingSQLConstants.DELETE_RESOURCE_SHARING_POLICY_BY_RESOURCE_TYPE_AND_ID;
+import static org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.ResourceSharingSQLConstants.DELETE_RESOURCE_SHARING_POLICY_BY_RESOURCE_TYPE_AND_ID_AT_RESOURCE_DELETION;
 import static org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.ResourceSharingSQLConstants.DELETE_SHARED_RESOURCE_ATTRIBUTE;
 import static org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.ResourceSharingSQLConstants.DELETE_SHARED_RESOURCE_ATTRIBUTE_BY_ATTRIBUTE_TYPE_AND_ID;
+import static org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.ResourceSharingSQLConstants.DELETE_SHARED_RESOURCE_ATTRIBUTE_BY_ATTRIBUTE_TYPE_AND_ID_AT_ATTRIBUTE_DELETION;
 import static org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.ResourceSharingSQLConstants.GET_RESOURCE_SHARING_POLICIES_BY_ORG_IDS_HEAD;
 import static org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.ResourceSharingSQLConstants.GET_RESOURCE_SHARING_POLICIES_WITH_SHARED_ATTRIBUTES_BY_POLICY_HOLDING_ORGS_HEAD;
 import static org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.ResourceSharingSQLConstants.GET_RESOURCE_SHARING_POLICY_BY_ID;
@@ -358,6 +361,60 @@ public class ResourceSharingPolicyHandlerDAOImpl implements ResourceSharingPolic
                                                           ));
         } catch (DataAccessException e) {
             throw handleServerException(ERROR_CODE_RETRIEVING_RESOURCE_SHARING_POLICY_FAILED);
+        }
+    }
+
+    @Override
+    public void deleteResourceSharingPolicyByResourceTypeAndId(ResourceType resourceType, String resourceId)
+            throws ResourceSharingPolicyMgtServerException {
+
+        NamedJdbcTemplate namedJdbcTemplate = getNewTemplate();
+        try {
+            namedJdbcTemplate.executeUpdate(DELETE_RESOURCE_SHARING_POLICY_BY_RESOURCE_TYPE_AND_ID_AT_RESOURCE_DELETION,
+                    namedPreparedStatement -> {
+                        namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_RESOURCE_TYPE,
+                                resourceType.name());
+                        namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_RESOURCE_ID,
+                                resourceId);
+                    });
+        } catch (DataAccessException e) {
+            throw handleServerException(ERROR_CODE_RESOURCE_SHARING_POLICY_DELETION_BY_RESOURCE_TYPE_AND_ID_FAILED);
+        }
+    }
+
+    @Override
+    public void deleteSharedResourceAttributeByAttributeTypeAndId(SharedAttributeType attributeType, String attributeId)
+            throws ResourceSharingPolicyMgtServerException {
+
+        NamedJdbcTemplate namedJdbcTemplate = getNewTemplate();
+        try {
+            namedJdbcTemplate.executeUpdate(
+                    DELETE_SHARED_RESOURCE_ATTRIBUTE_BY_ATTRIBUTE_TYPE_AND_ID_AT_ATTRIBUTE_DELETION,
+                    namedPreparedStatement -> {
+                        namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_SHARED_ATTRIBUTE_TYPE,
+                                attributeType.name());
+                        namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_SHARED_ATTRIBUTE_ID,
+                                attributeId);
+                    });
+        } catch (DataAccessException e) {
+            throw handleServerException(ERROR_CODE_SHARED_RESOURCE_ATTRIBUTE_DELETION_BY_ATTRIBUTE_TYPE_AND_ID_FAILED);
+        }
+    }
+
+    @Override
+    public void deleteResourceSharingPoliciesAndAttributesByOrganizationId(String organizationId)
+            throws ResourceSharingPolicyMgtServerException {
+
+        NamedJdbcTemplate namedJdbcTemplate = getNewTemplate();
+        try {
+            namedJdbcTemplate.executeUpdate(
+                    DELETE_RESOURCE_SHARING_POLICY_BY_ORG_ID_AT_ATTRIBUTE_DELETION,
+                    namedPreparedStatement -> {
+                        namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_INITIATING_ORG_ID, organizationId);
+                        namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_POLICY_HOLDING_ORG_ID, organizationId);
+                    });
+        } catch (DataAccessException e) {
+            throw handleServerException(ERROR_CODE_RESOURCE_SHARING_POLICY_DELETION_FAILED);
         }
     }
 

--- a/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/exception/NotImplementedException.java
+++ b/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/exception/NotImplementedException.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.resource.sharing.policy.management.exception;
+
+/**
+ * A custom runtime exception to indicate that a method or functionality is not yet implemented.
+ */
+public class NotImplementedException extends RuntimeException {
+
+    private static final long serialVersionUID = 5117918786934518376L;
+
+    /**
+     * Constructs a new NotImplementedException with no detail message or cause.
+     * <p>
+     * This constructor is typically used when no additional information is required
+     * to explain why the exception is thrown.
+     */
+    public NotImplementedException() {
+
+        super();
+    }
+
+    /**
+     * Constructs a new NotImplementedException with a detailed message and the root cause.
+     *
+     * @param message A descriptive message explaining why this exception is thrown.
+     * @param cause   The underlying cause of this exception.
+     */
+    public NotImplementedException(String message, Throwable cause) {
+
+        super(message, cause);
+    }
+
+    /**
+     * Constructs a new NotImplementedException with a detailed message.
+     *
+     * @param message A descriptive message explaining why this exception is thrown.
+     */
+    public NotImplementedException(String message) {
+
+        super(message);
+    }
+
+    /**
+     * Constructs a new NotImplementedException with the root cause.
+     *
+     * @param cause The underlying cause of this exception.
+     */
+    public NotImplementedException(Throwable cause) {
+
+        super(cause);
+    }
+}

--- a/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/test/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/ResourceSharingPolicyHandlerServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/test/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/ResourceSharingPolicyHandlerServiceImplTest.java
@@ -45,6 +45,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -830,6 +831,142 @@ public class ResourceSharingPolicyHandlerServiceImplTest {
         }
     }
 
+    @Test(priority = 38)
+    public void testDeleteResourceSharingPolicyByResourceTypeAndIdForResourceDeletionSuccess() throws Exception {
+
+        ResourceSharingPolicy resourceSharingPolicy = new ResourceSharingPolicy.Builder()
+                .withResourceId(UM_ID_RESOURCE_1)
+                .withResourceType(RESOURCE_TYPE_RESOURCE_1)
+                .withInitiatingOrgId(UM_ID_ORGANIZATION_SUPER)
+                .withPolicyHoldingOrgId(UM_ID_ORGANIZATION_SUPER)
+                .withSharingPolicy(PolicyEnum.SELECTED_ORG_WITH_EXISTING_IMMEDIATE_AND_FUTURE_CHILDREN)
+                .build();
+
+        int addedPolicyId = resourceSharingPolicyHandlerService.addResourceSharingPolicy(resourceSharingPolicy);
+
+        // Deleting the added policy
+        resourceSharingPolicyHandlerService.deleteResourceSharingPolicyByResourceTypeAndId(
+                RESOURCE_TYPE_RESOURCE_1, UM_ID_RESOURCE_1);
+
+        // Verifying that the policy is deleted
+        Optional<ResourceSharingPolicy> deletedPolicy =
+                resourceSharingPolicyHandlerService.getResourceSharingPolicyById(addedPolicyId);
+        Assert.assertFalse(deletedPolicy.isPresent());
+    }
+
+    @Test(expectedExceptions = ResourceSharingPolicyMgtServerException.class, priority = 39)
+    public void testDeleteResourceSharingPolicyByResourceTypeAndIdForResourceDeletionFailure()
+            throws ResourceSharingPolicyMgtException {
+
+        NamedJdbcTemplate mockJdbcTemplate = mock(NamedJdbcTemplate.class);
+
+        try (MockedStatic<Utils> mockedStatic = mockStatic(Utils.class)) {
+            mockedStatic.when(Utils::getNewTemplate).thenReturn(mockJdbcTemplate);
+            doThrow(new DataAccessException(MOCKED_DATA_ACCESS_EXCEPTION)).when(mockJdbcTemplate)
+                    .executeUpdate(anyString(), any());
+
+            resourceSharingPolicyHandlerService.deleteResourceSharingPolicyByResourceTypeAndId(RESOURCE_TYPE_RESOURCE_1,
+                    UM_ID_RESOURCE_1);
+
+            mockedStatic.verify(Utils::getNewTemplate, times(1));
+        } catch (DataAccessException e) {
+            throw new TestException(e);
+        }
+    }
+
+    @Test(priority = 40)
+    public void testDeleteSharedResourceAttributeByAttributeTypeAndIdForAttributeDeletionSuccess() throws Exception {
+
+        resourceSharingPolicyHandlerService.deleteSharedResourceAttributeByAttributeTypeAndId(
+                SHARED_ATTRIBUTE_TYPE_RESOURCE_ATTRIBUTE_1, UM_ID_RESOURCE_ATTRIBUTE_1);
+        List<SharedResourceAttribute> sharedResourceAttributes =
+                resourceSharingPolicyHandlerService.getSharedResourceAttributesByTypeAndId(
+                        SHARED_ATTRIBUTE_TYPE_RESOURCE_ATTRIBUTE_1, UM_ID_RESOURCE_ATTRIBUTE_1);
+        Assert.assertEquals(sharedResourceAttributes.size(), 0);
+    }
+
+    @Test(expectedExceptions = ResourceSharingPolicyMgtServerException.class, priority = 41)
+    public void testDeleteSharedResourceAttributeByAttributeTypeAndIdForAttributeDeletionFailure()
+            throws ResourceSharingPolicyMgtException {
+
+        NamedJdbcTemplate mockJdbcTemplate = mock(NamedJdbcTemplate.class);
+
+        try (MockedStatic<Utils> mockedStatic = mockStatic(Utils.class)) {
+            mockedStatic.when(Utils::getNewTemplate).thenReturn(mockJdbcTemplate);
+            doThrow(new DataAccessException(MOCKED_DATA_ACCESS_EXCEPTION)).when(mockJdbcTemplate)
+                    .executeUpdate(anyString(), any());
+
+            resourceSharingPolicyHandlerService.deleteSharedResourceAttributeByAttributeTypeAndId(
+                    SHARED_ATTRIBUTE_TYPE_RESOURCE_ATTRIBUTE_1, UM_ID_RESOURCE_1);
+
+            mockedStatic.verify(Utils::getNewTemplate, times(1));
+        } catch (DataAccessException e) {
+            throw new TestException(e);
+        }
+    }
+
+    @Test(priority = 42)
+    public void testDeleteResourceSharingPoliciesAndAttributesByOrganizationIdSuccess() throws Exception {
+
+        // Fetch the policies before deletion and collect their IDs.
+        List<ResourceSharingPolicy> resourceSharingPoliciesBeforeDelete =
+                resourceSharingPolicyHandlerService.getResourceSharingPolicies(
+                        Collections.singletonList(UM_ID_ORGANIZATION_ORG_ALL));
+        List<Integer> resourceSharingPolicyIdsBeforeDelete = resourceSharingPoliciesBeforeDelete.stream()
+                .map(ResourceSharingPolicy::getResourceSharingPolicyId)
+                .collect(Collectors.toList());
+
+        // Call the method to delete policies and attributes for the given orgId.
+        resourceSharingPolicyHandlerService.deleteResourceSharingPoliciesAndAttributesByOrganizationId(
+                UM_ID_ORGANIZATION_ORG_ALL);
+
+        // Verify that all policies for the orgId are deleted using getResourceSharingPolicyById().
+        resourceSharingPolicyIdsBeforeDelete.forEach(policyId -> {
+            Optional<ResourceSharingPolicy> resourceSharingPolicy;
+            try {
+                resourceSharingPolicy = resourceSharingPolicyHandlerService.getResourceSharingPolicyById(policyId);
+            } catch (ResourceSharingPolicyMgtException e) {
+                throw new RuntimeException(e);
+            }
+            Assert.assertFalse(resourceSharingPolicy.isPresent(),
+                    "Resource sharing policy was not deleted successfully for policy ID: " + policyId);
+        });
+
+        // Verify that all attributes related to the deleted policies are also deleted.
+        resourceSharingPolicyIdsBeforeDelete.forEach(policyId -> {
+            List<SharedResourceAttribute> sharedResourceAttributes;
+            try {
+                sharedResourceAttributes =
+                        resourceSharingPolicyHandlerService.getSharedResourceAttributesBySharingPolicyId(policyId);
+            } catch (ResourceSharingPolicyMgtException e) {
+                throw new TestException(e);
+            }
+            Assert.assertTrue(sharedResourceAttributes.isEmpty(),
+                    "Shared resource attributes were not deleted successfully for policy ID: " + policyId);
+        });
+    }
+
+    @Test(expectedExceptions = ResourceSharingPolicyMgtServerException.class, priority = 43)
+    public void testDeleteResourceSharingPoliciesAndAttributesByOrganizationIdFailure()
+            throws ResourceSharingPolicyMgtException {
+
+        NamedJdbcTemplate mockJdbcTemplate = mock(NamedJdbcTemplate.class);
+
+        try (MockedStatic<Utils> mockedStatic = mockStatic(Utils.class)) {
+            mockedStatic.when(Utils::getNewTemplate).thenReturn(mockJdbcTemplate);
+
+            doThrow(new DataAccessException(MOCKED_DATA_ACCESS_EXCEPTION)).when(mockJdbcTemplate)
+                    .executeUpdate(anyString(), any());
+
+            resourceSharingPolicyHandlerService.deleteResourceSharingPoliciesAndAttributesByOrganizationId(
+                    UM_ID_ORGANIZATION_ORG_ALL);
+
+            mockedStatic.verify(Utils::getNewTemplate, times(1));
+        } catch (DataAccessException e) {
+            throw new TestException(e);
+        }
+    }
+
     // Helpers: Private helper methods for tests.
     private List<Integer> addAndAssertResourceSharingPolicy(List<String> policyHoldingOrgIds)
             throws ResourceSharingPolicyMgtException {
@@ -885,5 +1022,4 @@ public class ResourceSharingPolicyHandlerServiceImplTest {
         Assert.assertTrue(isAdded, "Added shared resource attributes.");
 
     }
-
 }


### PR DESCRIPTION
This PR introduces mechanisms to clean up resource-sharing policies and shared attributes in the database when resources, attributes, or organizations are deleted. It ensures proper data integrity and consistency by removing orphaned entries.

## Purpose
> This feature resolves the need for proper cleanup mechanisms to remove resource-sharing policies and shared attributes when resources, attributes, or organizations are deleted. It resolves the following issues:
> - [Handle the Cleanup of Resource Sharing Policies and Attributes During Resource, Attribute, and Organization Deletion #22199](https://github.com/wso2/product-is/issues/22199)

## Goals

> - Introduce SQL queries and methods for deleting resource-sharing policies and shared attributes by resource type, attribute type, or organization ID.
> - Ensure data integrity by removing orphaned entries during deletion processes.
> - Maintain a consistent and clean database state.

## Approach

> - Added SQL queries for deleting:
>   - Resource-sharing policies by resource type and ID.
>   - Shared attributes by attribute type and ID.
>   - Resource-sharing policies by organization ID.
> - Implemented DAO and service methods to execute these queries.
> - Added unit tests to validate the correctness of the implemented methods.

## Release note
> Introduced mechanisms to clean up resource-sharing policies and shared attributes during the deletion of related resources, attributes, and organizations.

## Documentation
> N/A (Documentation updates will be tracked separately.)

## Test environment
> - JDK 11
> - macOS 15.1.1 (24B91)
> - H2 Database

---

### Related Issue

[Handle the Cleanup of Resource Sharing Policies and Attributes During Resource, Attribute, and Organization Deletion #22199](https://github.com/wso2/product-is/issues/22199)