### PR TITLE
Add Method to Delete Resource Sharing Policy in a Given Organization by Resource Type and ID

### DIFF
--- a/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/ResourceSharingPolicyHandlerService.java
+++ b/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/ResourceSharingPolicyHandlerService.java
@@ -124,6 +124,22 @@ public interface ResourceSharingPolicyHandlerService {
             throws ResourceSharingPolicyMgtException;
 
     /**
+     * Deletes a resource sharing policy in the specified policy holding organization, based on its resource type
+     * and resource ID, if permitted.
+     *
+     * @param policyHoldingOrgId          The ID of the organization holding the policy for the resource.
+     * @param resourceType                The {@link ResourceType} of the resource.
+     * @param resourceId                  The unique identifier of the resource whose sharing policy is to be deleted.
+     * @param sharingPolicyInitiatedOrgId The ID of the organization initiating the share request.
+     *                                    The deletion will only be successful if the initiating organization
+     *                                    has permission to delete sharing policies.
+     * @throws ResourceSharingPolicyMgtException If an error occurs while deleting the resource sharing policy.
+     */
+    void deleteResourceSharingPolicyInOrgByResourceTypeAndId(String policyHoldingOrgId, ResourceType resourceType,
+                                                             String resourceId, String sharingPolicyInitiatedOrgId)
+            throws ResourceSharingPolicyMgtException;
+
+    /**
      * Adds shared resource attributes to an existing resource sharing policy.
      *
      * @param sharedResourceAttributes A list of {@link SharedResourceAttribute} objects to be added.

--- a/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/ResourceSharingPolicyHandlerServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/ResourceSharingPolicyHandlerServiceImpl.java
@@ -121,6 +121,19 @@ public class ResourceSharingPolicyHandlerServiceImpl implements ResourceSharingP
     }
 
     @Override
+    public void deleteResourceSharingPolicyInOrgByResourceTypeAndId(String policyHoldingOrgId,
+                                                                    ResourceType resourceType, String resourceId,
+                                                                    String sharingPolicyInitiatedOrgId)
+            throws ResourceSharingPolicyMgtException {
+
+        validateIdFormat(Arrays.asList(policyHoldingOrgId, resourceId, sharingPolicyInitiatedOrgId));
+
+        RESOURCE_SHARING_POLICY_HANDLER_DAO.deleteResourceSharingPolicyInOrgByResourceTypeAndId(policyHoldingOrgId,
+                resourceType, resourceId, sharingPolicyInitiatedOrgId);
+
+    }
+
+    @Override
     public boolean addSharedResourceAttributes(List<SharedResourceAttribute> sharedResourceAttributes)
             throws ResourceSharingPolicyMgtException {
 

--- a/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/ResourceSharingPolicyHandlerServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/ResourceSharingPolicyHandlerServiceImpl.java
@@ -130,7 +130,6 @@ public class ResourceSharingPolicyHandlerServiceImpl implements ResourceSharingP
 
         RESOURCE_SHARING_POLICY_HANDLER_DAO.deleteResourceSharingPolicyInOrgByResourceTypeAndId(policyHoldingOrgId,
                 resourceType, resourceId, sharingPolicyInitiatedOrgId);
-
     }
 
     @Override

--- a/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/constant/ResourceSharingSQLConstants.java
+++ b/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/constant/ResourceSharingSQLConstants.java
@@ -75,6 +75,18 @@ public class ResourceSharingSQLConstants {
                     "UM_INITIATING_ORG_ID = :" +
                     SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_INITIATING_ORG_ID + ";";
 
+    // SQL for deleting resource sharing policy in an organization by resource type and ID.
+    public static final String DELETE_RESOURCE_SHARING_POLICY_IN_ORG_BY_RESOURCE_TYPE_AND_ID =
+            "DELETE FROM UM_RESOURCE_SHARING_POLICY WHERE " +
+                    "UM_POLICY_HOLDING_ORG_ID = :" +
+                    SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_POLICY_HOLDING_ORG_ID + "; AND " +
+                    "UM_RESOURCE_TYPE = :" +
+                    SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_RESOURCE_TYPE + "; AND " +
+                    "UM_RESOURCE_ID = :" +
+                    SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_RESOURCE_ID + "; AND " +
+                    "UM_INITIATING_ORG_ID = :" +
+                    SQLPlaceholders.DB_SCHEMA_COLUMN_NAME_INITIATING_ORG_ID + ";";
+
     // SQL constant for inserting a shared resource attribute.
     public static final String CREATE_SHARED_RESOURCE_ATTRIBUTE =
             "INSERT INTO UM_SHARED_RESOURCE_ATTRIBUTES " +

--- a/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/dao/ResourceSharingPolicyHandlerDAO.java
+++ b/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/dao/ResourceSharingPolicyHandlerDAO.java
@@ -130,6 +130,22 @@ public interface ResourceSharingPolicyHandlerDAO {
             throws ResourceSharingPolicyMgtServerException;
 
     /**
+     * Deletes a resource sharing policy in the specified policy holding organization, based on its resource type
+     * and resource ID, if permitted.
+     *
+     * @param policyHoldingOrgId          The ID of the organization holding the policy for the resource.
+     * @param resourceType                The {@link ResourceType} of the resource.
+     * @param resourceId                  The unique identifier of the resource whose sharing policy is to be deleted.
+     * @param sharingPolicyInitiatedOrgId The ID of the organization initiating the share request.
+     *                                    The deletion will only be successful if the initiating organization
+     *                                    has permission to delete sharing policies.
+     * @throws ResourceSharingPolicyMgtServerException If an error occurs while deleting the resource sharing policy.
+     */
+    void deleteResourceSharingPolicyInOrgByResourceTypeAndId(String policyHoldingOrgId, ResourceType resourceType,
+                                                             String resourceId, String sharingPolicyInitiatedOrgId)
+            throws ResourceSharingPolicyMgtServerException;
+
+    /**
      * Adds shared resource attributes to an existing resource sharing policy.
      *
      * @param sharedResourceAttributes A list of {@link SharedResourceAttribute} objects to be added.

--- a/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/dao/ResourceSharingPolicyHandlerDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/dao/ResourceSharingPolicyHandlerDAOImpl.java
@@ -53,6 +53,7 @@ import static org.wso2.carbon.identity.organization.resource.sharing.policy.mana
 import static org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.ResourceSharingSQLConstants.CREATE_SHARED_RESOURCE_ATTRIBUTE;
 import static org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.ResourceSharingSQLConstants.DELETE_RESOURCE_SHARING_POLICY;
 import static org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.ResourceSharingSQLConstants.DELETE_RESOURCE_SHARING_POLICY_BY_RESOURCE_TYPE_AND_ID;
+import static org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.ResourceSharingSQLConstants.DELETE_RESOURCE_SHARING_POLICY_IN_ORG_BY_RESOURCE_TYPE_AND_ID;
 import static org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.ResourceSharingSQLConstants.DELETE_SHARED_RESOURCE_ATTRIBUTE;
 import static org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.ResourceSharingSQLConstants.DELETE_SHARED_RESOURCE_ATTRIBUTE_BY_ATTRIBUTE_TYPE_AND_ID;
 import static org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.ResourceSharingSQLConstants.GET_RESOURCE_SHARING_POLICIES_BY_ORG_IDS_HEAD;
@@ -180,6 +181,30 @@ public class ResourceSharingPolicyHandlerDAOImpl implements ResourceSharingPolic
         try {
             namedJdbcTemplate.executeUpdate(DELETE_RESOURCE_SHARING_POLICY_BY_RESOURCE_TYPE_AND_ID,
                     namedPreparedStatement -> {
+                        namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_RESOURCE_TYPE,
+                                resourceType.name());
+                        namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_RESOURCE_ID,
+                                resourceId);
+                        namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_INITIATING_ORG_ID,
+                                sharingPolicyInitiatedOrgId);
+                    });
+        } catch (DataAccessException e) {
+            throw handleServerException(ERROR_CODE_RESOURCE_SHARING_POLICY_DELETION_BY_RESOURCE_TYPE_AND_ID_FAILED);
+        }
+    }
+
+    @Override
+    public void deleteResourceSharingPolicyInOrgByResourceTypeAndId(String policyHoldingOrgId,
+                                                                    ResourceType resourceType, String resourceId,
+                                                                    String sharingPolicyInitiatedOrgId)
+            throws ResourceSharingPolicyMgtServerException {
+
+        NamedJdbcTemplate namedJdbcTemplate = getNewTemplate();
+        try {
+            namedJdbcTemplate.executeUpdate(DELETE_RESOURCE_SHARING_POLICY_IN_ORG_BY_RESOURCE_TYPE_AND_ID,
+                    namedPreparedStatement -> {
+                        namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_POLICY_HOLDING_ORG_ID,
+                                policyHoldingOrgId);
                         namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_RESOURCE_TYPE,
                                 resourceType.name());
                         namedPreparedStatement.setString(DB_SCHEMA_COLUMN_NAME_RESOURCE_ID,

--- a/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/test/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/ResourceSharingPolicyHandlerServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/test/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/ResourceSharingPolicyHandlerServiceImplTest.java
@@ -292,7 +292,7 @@ public class ResourceSharingPolicyHandlerServiceImplTest {
         Assert.assertTrue(actualPolicies.isEmpty());
     }
 
-    @Test(expectedExceptions = ResourceSharingPolicyMgtClientException.class, priority = 9)
+    @Test(expectedExceptions = ResourceSharingPolicyMgtClientException.class, priority = 10)
     public void testGetResourceSharingPoliciesFailureForEmptyOrgIdInList() throws Exception {
 
         List<ResourceSharingPolicy> actualPolicies =
@@ -301,7 +301,7 @@ public class ResourceSharingPolicyHandlerServiceImplTest {
         Assert.assertTrue(actualPolicies.isEmpty());
     }
 
-    @Test(expectedExceptions = ResourceSharingPolicyMgtServerException.class, priority = 10)
+    @Test(expectedExceptions = ResourceSharingPolicyMgtServerException.class, priority = 11)
     public void testGetResourceSharingPoliciesFailureForInvalidOrgId() throws Exception {
 
         NamedJdbcTemplate mockJdbcTemplate = mock(NamedJdbcTemplate.class);
@@ -320,7 +320,7 @@ public class ResourceSharingPolicyHandlerServiceImplTest {
         }
     }
 
-    @Test(expectedExceptions = ResourceSharingPolicyMgtClientException.class, priority = 11)
+    @Test(expectedExceptions = ResourceSharingPolicyMgtClientException.class, priority = 12)
     public void testGetResourceSharingPoliciesFailureForNullOrgs() throws Exception {
 
         List<String> policyHoldingOrgIds = new ArrayList<>();
@@ -334,7 +334,7 @@ public class ResourceSharingPolicyHandlerServiceImplTest {
     }
 
     // Tests: DELETE Resource Sharing Policy Records.
-    @Test(dataProvider = "organizationIdsProvider", priority = 12)
+    @Test(dataProvider = "organizationIdsProvider", priority = 13)
     public void testDeleteResourceSharingPolicyRecordByIdSuccess(List<String> organizationIds) throws Exception {
 
         List<Integer> addedResourceSharingPolyIds =
@@ -349,7 +349,7 @@ public class ResourceSharingPolicyHandlerServiceImplTest {
         }
     }
 
-    @Test(expectedExceptions = ResourceSharingPolicyMgtServerException.class, priority = 13)
+    @Test(expectedExceptions = ResourceSharingPolicyMgtServerException.class, priority = 14)
     public void testDeleteResourceSharingPolicyRecordByIdFailure()
             throws ResourceSharingPolicyMgtException {
 
@@ -368,29 +368,14 @@ public class ResourceSharingPolicyHandlerServiceImplTest {
         }
     }
 
-    @Test(expectedExceptions = ResourceSharingPolicyMgtClientException.class, priority = 21)
+    @Test(expectedExceptions = ResourceSharingPolicyMgtClientException.class, priority = 15)
     public void testDeleteResourceSharingPolicyRecordByIdAndEmptySharingInitiatedOrgIdFailure()
             throws ResourceSharingPolicyMgtException {
 
         resourceSharingPolicyHandlerService.deleteResourceSharingPolicyRecordById(1, "");
     }
 
-    @DataProvider(name = "organizationsAndResourceTypesAndIdsProvider")
-    public Object[][] organizationsAndResourceTypesAndIdsProvider() {
-
-        return new Object[][]{
-                {Arrays.asList(UM_ID_ORGANIZATION_SUPER, UM_ID_ORGANIZATION_ORG_ALL),
-                        RESOURCE_TYPE_RESOURCE_1, UM_ID_RESOURCE_1},
-                {Arrays.asList(UM_ID_ORGANIZATION_ORG_IMMEDIATE, UM_ID_ORGANIZATION_ORG_IMMEDIATE_CHILD1),
-                        RESOURCE_TYPE_RESOURCE_1, UM_ID_RESOURCE_2},
-                {Arrays.asList(UM_ID_ORGANIZATION_ORG_ALL, UM_ID_ORGANIZATION_ORG_ALL_CHILD1),
-                        RESOURCE_TYPE_RESOURCE_1, UM_ID_RESOURCE_3},
-                {Arrays.asList(UM_ID_ORGANIZATION_SUPER, UM_ID_ORGANIZATION_SUPER),
-                        RESOURCE_TYPE_RESOURCE_1, UM_ID_RESOURCE_4},
-        };
-    }
-
-    @Test(priority = 14)
+    @Test(priority = 16)
     public void testDeleteResourceSharingPolicyByResourceTypeAndIdSuccess() throws Exception {
 
         ResourceSharingPolicy resourceSharingPolicy = new ResourceSharingPolicy.Builder()
@@ -413,7 +398,7 @@ public class ResourceSharingPolicyHandlerServiceImplTest {
         Assert.assertFalse(deletedPolicy.isPresent());
     }
 
-    @Test(expectedExceptions = ResourceSharingPolicyMgtServerException.class, priority = 15)
+    @Test(expectedExceptions = ResourceSharingPolicyMgtServerException.class, priority = 17)
     public void testDeleteResourceSharingPolicyByResourceTypeAndIdFailure() throws ResourceSharingPolicyMgtException {
 
         NamedJdbcTemplate mockJdbcTemplate = mock(NamedJdbcTemplate.class);
@@ -432,7 +417,7 @@ public class ResourceSharingPolicyHandlerServiceImplTest {
         }
     }
 
-    @Test(priority = 14)
+    @Test(priority = 18)
     public void testDeleteResourceSharingPolicyInOrgByResourceTypeAndIdSuccess() throws Exception {
 
         ResourceSharingPolicy resourceSharingPolicy = new ResourceSharingPolicy.Builder()
@@ -455,7 +440,7 @@ public class ResourceSharingPolicyHandlerServiceImplTest {
         Assert.assertFalse(deletedPolicy.isPresent());
     }
 
-    @Test(expectedExceptions = ResourceSharingPolicyMgtServerException.class, priority = 15)
+    @Test(expectedExceptions = ResourceSharingPolicyMgtServerException.class, priority = 19)
     public void testDeleteResourceSharingPolicyInOrgByResourceTypeAndIdFailure()
             throws ResourceSharingPolicyMgtException {
 
@@ -476,7 +461,7 @@ public class ResourceSharingPolicyHandlerServiceImplTest {
     }
 
     // Tests: CREATE Shared Resource Attributes Records.
-    @Test(priority = 16)
+    @Test(priority = 20)
     public void testAddSharedResourceAttributesSuccess() throws Exception {
 
         List<SharedResourceAttribute> sharedResourceAttributes = Arrays.asList(
@@ -496,7 +481,7 @@ public class ResourceSharingPolicyHandlerServiceImplTest {
 
     }
 
-    @Test(priority = 17)
+    @Test(priority = 21)
     public void testAddSharedResourceAttributesSuccessWithIgnoringInvalidAttributes() throws Exception {
 
         List<SharedResourceAttribute> sharedResourceAttributes = Arrays.asList(
@@ -516,7 +501,7 @@ public class ResourceSharingPolicyHandlerServiceImplTest {
 
     }
 
-    @Test(priority = 18)
+    @Test(priority = 22)
     public void testAddSharedResourceAttributesSuccessWithInapplicableAttribute() throws Exception {
 
         ResourceSharingPolicy resourceSharingPolicyMock = mock(ResourceSharingPolicy.class);
@@ -560,7 +545,7 @@ public class ResourceSharingPolicyHandlerServiceImplTest {
                 .getResourceSharingPolicyById(invalidSharedResourceAttribute.getResourceSharingPolicyId());
     }
 
-    @Test(expectedExceptions = ResourceSharingPolicyMgtServerException.class, priority = 19)
+    @Test(expectedExceptions = ResourceSharingPolicyMgtServerException.class, priority = 23)
     public void testAddSharedResourceAttributesFailure() throws ResourceSharingPolicyMgtException {
 
         NamedJdbcTemplate mockJdbcTemplate = mock(NamedJdbcTemplate.class);
@@ -580,7 +565,7 @@ public class ResourceSharingPolicyHandlerServiceImplTest {
     }
 
     // Tests: GET Shared Resource Attributes Records.
-    @Test(priority = 20)
+    @Test(priority = 24)
     public void testGetSharedResourceAttributesBySharingPolicyIdSuccess() throws Exception {
 
         addAndAssertSharedResourceAttributes();
@@ -592,7 +577,7 @@ public class ResourceSharingPolicyHandlerServiceImplTest {
                 "Expected non-empty list of shared resource attributes.");
     }
 
-    @Test(expectedExceptions = ResourceSharingPolicyMgtServerException.class, priority = 21)
+    @Test(expectedExceptions = ResourceSharingPolicyMgtServerException.class, priority = 25)
     public void testGetSharedResourceAttributesBySharingPolicyIdFailure() throws ResourceSharingPolicyMgtException {
 
         NamedJdbcTemplate mockJdbcTemplate = mock(NamedJdbcTemplate.class);
@@ -610,7 +595,7 @@ public class ResourceSharingPolicyHandlerServiceImplTest {
         }
     }
 
-    @Test(priority = 22)
+    @Test(priority = 26)
     public void testGetSharedResourceAttributesByTypeSuccess() throws Exception {
 
         List<SharedResourceAttribute> sharedResourceAttributes =
@@ -622,7 +607,7 @@ public class ResourceSharingPolicyHandlerServiceImplTest {
                 "Expected non-empty list of shared resource attributes by type.");
     }
 
-    @Test(priority = 24)
+    @Test(priority = 27)
     public void testGetSharedResourceAttributesByIdSuccess() throws Exception {
 
         addAndAssertSharedResourceAttributes();
@@ -634,13 +619,13 @@ public class ResourceSharingPolicyHandlerServiceImplTest {
                 "Expected non-empty list of shared resource attributes by ID.");
     }
 
-    @Test(expectedExceptions = ResourceSharingPolicyMgtClientException.class, priority = 25)
+    @Test(expectedExceptions = ResourceSharingPolicyMgtClientException.class, priority = 28)
     public void testGetSharedResourceAttributesByIdFailureForNull() throws Exception {
 
         resourceSharingPolicyHandlerService.getSharedResourceAttributesById(null);
     }
 
-    @Test(priority = 26)
+    @Test(priority = 29)
     public void testGetSharedResourceAttributesByTypeAndIdSuccess() throws Exception {
 
         addAndAssertSharedResourceAttributes();
@@ -653,13 +638,13 @@ public class ResourceSharingPolicyHandlerServiceImplTest {
                 "Expected non-empty list of shared resource attributes by type and ID.");
     }
 
-    @Test(expectedExceptions = ResourceSharingPolicyMgtClientException.class, priority = 27)
+    @Test(expectedExceptions = ResourceSharingPolicyMgtClientException.class, priority = 30)
     public void testGetSharedResourceAttributesByTypeAndIdFailureForNull() throws Exception {
 
         resourceSharingPolicyHandlerService.getSharedResourceAttributesByTypeAndId(null, null);
     }
 
-    @Test(expectedExceptions = ResourceSharingPolicyMgtServerException.class, priority = 28)
+    @Test(expectedExceptions = ResourceSharingPolicyMgtServerException.class, priority = 31)
     public void testGetSharedResourceAttributesByTypeAndIdFailure()
             throws ResourceSharingPolicyMgtException {
 
@@ -680,7 +665,7 @@ public class ResourceSharingPolicyHandlerServiceImplTest {
     }
 
     // Tests: DELETE Shared Resource Attributes Records.
-    @Test(priority = 29)
+    @Test(priority = 32)
     public void testDeleteSharedResourceAttributesByResourceSharingPolicyIdSuccess() throws Exception {
 
         resourceSharingPolicyHandlerService.deleteSharedResourceAttributesByResourceSharingPolicyId
@@ -690,7 +675,7 @@ public class ResourceSharingPolicyHandlerServiceImplTest {
         Assert.assertEquals(sharedResourceAttributes.size(), 0);
     }
 
-    @Test(expectedExceptions = ResourceSharingPolicyMgtServerException.class, priority = 30)
+    @Test(expectedExceptions = ResourceSharingPolicyMgtServerException.class, priority = 33)
     public void testDeleteSharedResourceAttributesByResourceSharingPolicyIdFailure()
             throws ResourceSharingPolicyMgtException {
 
@@ -710,7 +695,7 @@ public class ResourceSharingPolicyHandlerServiceImplTest {
         }
     }
 
-    @Test(priority = 31)
+    @Test(priority = 34)
     public void testDeleteSharedResourceAttributeByAttributeTypeAndIdSuccess() throws Exception {
 
         resourceSharingPolicyHandlerService.deleteSharedResourceAttributeByAttributeTypeAndId(
@@ -721,7 +706,7 @@ public class ResourceSharingPolicyHandlerServiceImplTest {
         Assert.assertEquals(sharedResourceAttributes.size(), 0);
     }
 
-    @Test(expectedExceptions = ResourceSharingPolicyMgtServerException.class, priority = 32)
+    @Test(expectedExceptions = ResourceSharingPolicyMgtServerException.class, priority = 35)
     public void testDeleteSharedResourceAttributeByAttributeTypeAndIdFailure()
             throws ResourceSharingPolicyMgtException {
 
@@ -741,7 +726,7 @@ public class ResourceSharingPolicyHandlerServiceImplTest {
         }
     }
 
-    @Test(priority = 33)
+    @Test(priority = 36)
     public void testAddResourceSharingPolicyWithAttributesSuccess() throws ResourceSharingPolicyMgtException {
 
         ResourceSharingPolicy resourceSharingPolicy = new ResourceSharingPolicy.Builder()
@@ -769,7 +754,7 @@ public class ResourceSharingPolicyHandlerServiceImplTest {
         Assert.assertTrue(result, "Expected the method to successfully add valid attributes.");
     }
 
-    @Test(expectedExceptions = ResourceSharingPolicyMgtServerException.class, priority = 34)
+    @Test(expectedExceptions = ResourceSharingPolicyMgtServerException.class, priority = 37)
     public void testAddResourceSharingPolicyWithAttributesFailure() throws ResourceSharingPolicyMgtException {
 
         ResourceSharingPolicy resourceSharingPolicy = new ResourceSharingPolicy.Builder()
@@ -796,7 +781,7 @@ public class ResourceSharingPolicyHandlerServiceImplTest {
         }
     }
 
-    @Test(priority = 35)
+    @Test(priority = 38)
     public void testGetResourceSharingPoliciesWithSharedAttributesSuccess() throws Exception {
         // Prepare mock data
         List<String> policyHoldingOrganizationIds = Arrays.asList(
@@ -842,7 +827,7 @@ public class ResourceSharingPolicyHandlerServiceImplTest {
         }
     }
 
-    @Test(priority = 36)
+    @Test(priority = 39)
     public void testGetResourceSharingPoliciesWithSharedAttributesEmptyResult() throws Exception {
 
         List<String> policyHoldingOrganizationIds = Collections.singletonList(UM_ID_ORGANIZATION_INVALID);
@@ -854,7 +839,7 @@ public class ResourceSharingPolicyHandlerServiceImplTest {
         Assert.assertEquals(result.size(), 0);
     }
 
-    @Test(expectedExceptions = ResourceSharingPolicyMgtServerException.class, priority = 37)
+    @Test(expectedExceptions = ResourceSharingPolicyMgtServerException.class, priority = 40)
     public void testGetResourceSharingPoliciesWithSharedAttributesFailure() throws ResourceSharingPolicyMgtException {
 
         NamedJdbcTemplate mockJdbcTemplate = mock(NamedJdbcTemplate.class);


### PR DESCRIPTION
This PR introduces a new method to the `ResourceSharingPolicyHandlerService` interface for deleting resource-sharing policies of a specified resource type and ID within a given policy-holding organization. The method ensures proper permission checks for the initiating organization before deletion as well.

## Purpose
> TThis addition addresses the need to delete specific resource sharing policies within a specified policy-holding organization while validating permissions of the initiating organization. It resolves the following issues:
> - [Introduce a Centralized Resource Sharing Policy Management Service #21815](https://github.com/wso2/product-is/issues/21815)

## Goals

> - Enable deletion of resource-sharing policies within a specified policy-holding organization.
> - Provide precise control by targeting resource type and ID.
> - Validate the initiating organization’s permissions before proceeding with the deletion.

## Approach

> - Introduced the deleteResourceSharingPolicyInOrgByResourceTypeAndId method in the service interface.
> - Implemented the method using a parameterized SQL query in the DAO layer.
> - Validated the policy-holding organization and initiating organization IDs for proper permission checks.
> - Added exception handling to manage database access issues gracefully.

## Release note
> Added a new method to delete resource-sharing policies within a specified policy-holding organization based on resource type and ID, with validation for initiating organization permissions.

## Documentation
> N/A (Documentation updates will be tracked separately.)

## Test environment
> - JDK 11
> - macOS 15.1.1 (24B91)
> - H2 Database

---

### Related Issue

[Add Method to Delete Resource Sharing Policy in a Given Organization by Resource Type and ID #22250](https://github.com/wso2/product-is/issues/22250)