### PR TITLE
Refactor unshare organization users logic to support specific user unsharing for shared organizations

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/OrganizationUserSharingService.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/OrganizationUserSharingService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023-2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -19,6 +19,7 @@
 package org.wso2.carbon.identity.organization.management.organization.user.sharing;
 
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.models.UserAssociation;
+import org.wso2.carbon.identity.organization.management.service.exception.NotImplementedException;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 
 import java.util.List;
@@ -49,6 +50,21 @@ public interface OrganizationUserSharingService {
      */
     boolean unshareOrganizationUsers(String associatedUserId, String associatedOrgId)
             throws OrganizationManagementException;
+
+    /**
+     * Unshare the specified user in the given shared organization.
+     *
+     * @param associatedUserId  The ID of the associated user.
+     * @param sharedOrgId       The ID of the shared organization from which the user will be unshared.
+     * @return True if the user is unshared successfully.
+     * @throws OrganizationManagementException If an error occurs while unsharing the user in the shared organization.
+     */
+    default boolean unshareOrganizationUserInSharedOrganization(String associatedUserId, String sharedOrgId)
+            throws OrganizationManagementException {
+
+        throw new NotImplementedException("unshareOrganizationUserInSharedOrganization method is not implemented in " +
+                this.getClass().getName());
+    }
 
     /**
      * Delete the organization user association of the shared user.

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/constant/UserSharingConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/constant/UserSharingConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023-2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -52,6 +52,8 @@ public class UserSharingConstants {
     public static final String PRIMARY_DOMAIN = "PRIMARY";
     public static final String AUTHENTICATION_TYPE = "authenticationType";
     public static final String APPLICATION_AUTHENTICATION_TYPE = "APPLICATION";
+
+    public static final String USER_UNSHARING_RESTRICTION = "RESTRICTED";
 
     /*
     Minimum permissions required for org creator to logged in to the console and view user, groups, roles, SP,

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/models/UserAssociation.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/models/UserAssociation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023-2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -23,10 +23,23 @@ package org.wso2.carbon.identity.organization.management.organization.user.shari
  */
 public class UserAssociation {
 
+    private int id;
     private String userId;
     private String organizationId;
     private String associatedUserId;
     private String userResidentOrganizationId;
+    private String sharedType;
+    private String editRestriction;
+
+    public int getId() {
+
+        return id;
+    }
+
+    public void setId(int id) {
+
+        this.id = id;
+    }
 
     public String getUserId() {
 
@@ -66,5 +79,25 @@ public class UserAssociation {
     public void setUserResidentOrganizationId(String userResidentOrganizationId) {
 
         this.userResidentOrganizationId = userResidentOrganizationId;
+    }
+
+    public String getSharedType() {
+
+        return sharedType;
+    }
+
+    public void setSharedType(String sharedType) {
+
+        this.sharedType = sharedType;
+    }
+
+    public String getEditRestriction() {
+
+        return editRestriction;
+    }
+
+    public void setEditRestriction(String editRestriction) {
+
+        this.editRestriction = editRestriction;
     }
 }


### PR DESCRIPTION
## Purpose
> Enhance the user unsharing logic to provide specific unsharing capabilities for shared organizations.

## Goals
> - Introduce a new method to unshare a specific user from a shared organization.
> - Refactor the existing unsharing logic to be more modular and reusable.
> - Improve code clarity and maintainability by introducing a dedicated `removeSharedUsers` method.

## Approach

> - Added a new default method `unshareOrganizationUserInSharedOrganization` in the interface to handle specific user unsharing.
> - Updated the `unshareOrganizationUsers` method to use the modular `removeSharedUsers` utility method.
> - Introduced logic to handle user unsharing restrictions based on `editRestriction` and `userResidentOrganizationId`.
> - Ensured proper exception handling for user store operations.
> - Maintained backward compatibility with existing unshare operations.

---

### Related Issue

Solution to a part of [Parent organization admin gives sub org level access to users in his/her organization #29](https://github.com/wso2-enterprise/iam-product-management/issues/29)
