### PR TITLE
Add Batch Insert for Adding Shared Resource Attributes

### DIFF
--- a/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/dao/ResourceSharingPolicyHandlerDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/main/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/dao/ResourceSharingPolicyHandlerDAOImpl.java
@@ -231,6 +231,7 @@ public class ResourceSharingPolicyHandlerDAOImpl implements ResourceSharingPolic
                 template.executeBatchInsert(CREATE_SHARED_RESOURCE_ATTRIBUTE, (namedPreparedStatement -> {
                     for (SharedResourceAttribute sharedResourceAttribute : sharedResourceAttributes) {
                         setSharedResourceAttributeParameters(namedPreparedStatement, sharedResourceAttribute);
+                        namedPreparedStatement.addBatch();
                     }
                 }), null);
                 return true;


### PR DESCRIPTION
## Purpose
> The current implementation for adding shared resource attributes lacked explicit batch queuing, leading to potential data inconsistencies during insert operations. This fix introduces proper batch insertion to ensure all attributes are processed correctly.

## Goals

> - Ensure all shared resource attributes are queued for batch processing and insertion.
> - Maintain transactional integrity and improve reliability of the operation.
> - Prevent partial or incomplete batch execution scenarios.

## Approach
> Introduced addBatch() within the batch processing logic to ensure each shared resource attribute is properly queued for insertion.

--

## Related Issues

[Improve Batch Processing Logic for Adding Shared Resource Attributes #22430](https://github.com/wso2/product-is/issues/22430)
