### PR TITLE
Add an event handler to share users to newly created organizations. 

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/pom.xml
@@ -53,6 +53,10 @@
             <artifactId>org.wso2.carbon.identity.organization.management.role.management.service</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.resource.sharing.policy.management</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.core</artifactId>
         </dependency>
@@ -151,6 +155,8 @@
                             org.wso2.carbon.identity.organization.management.role.management.service;version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
                             org.wso2.carbon.identity.organization.management.role.management.service.models;version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
                             org.wso2.carbon.identity.organization.management.ext;version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.resource.sharing.policy.management;version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.resource.sharing.policy.management.exception;version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
                             org.wso2.carbon.user.api;version="${carbon.user.api.imp.pkg.version.range}",
                             org.wso2.carbon.user.core;version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.user.core.common;version="${carbon.kernel.package.import.version.range}",

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/internal/OrganizationUserSharingDataHolder.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/internal/OrganizationUserSharingDataHolder.java
@@ -24,6 +24,7 @@ import org.wso2.carbon.identity.organization.management.organization.user.sharin
 import org.wso2.carbon.identity.organization.management.role.management.service.RoleManager;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.OrgResourceResolverService;
+import org.wso2.carbon.identity.organization.resource.sharing.policy.management.ResourceSharingPolicyHandlerService;
 import org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService;
 import org.wso2.carbon.user.core.service.RealmService;
 
@@ -41,6 +42,7 @@ public class OrganizationUserSharingDataHolder {
     private RoleManager roleManager;
     private ClaimMetadataManagementService claimManagementService;
     private OrgResourceResolverService orgResourceResolverService;
+    private ResourceSharingPolicyHandlerService resourceSharingPolicyHandlerService;
 
     public static OrganizationUserSharingDataHolder getInstance() {
 
@@ -205,5 +207,27 @@ public class OrganizationUserSharingDataHolder {
     public void setOrgResourceResolverService(OrgResourceResolverService orgResourceResolverService) {
 
         this.orgResourceResolverService = orgResourceResolverService;
+    }
+
+    /**
+     * Get the resource sharing policy handler service.
+     *
+     * @return ResourceSharingPolicyHandlerService resource sharing policy handler service.
+     */
+    public ResourceSharingPolicyHandlerService getResourceSharingPolicyHandlerService() {
+
+        return resourceSharingPolicyHandlerService;
+    }
+
+    /**
+     * Set the resource sharing policy handler service.
+     *
+     * @param resourceSharingPolicyHandlerService ResourceSharingPolicyHandlerService resource
+     *                                            sharing policy handler service.
+     */
+    public void setResourceSharingPolicyHandlerService(
+            ResourceSharingPolicyHandlerService resourceSharingPolicyHandlerService) {
+
+        this.resourceSharingPolicyHandlerService = resourceSharingPolicyHandlerService;
     }
 }

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/internal/OrganizationUserSharingServiceComponent.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/internal/OrganizationUserSharingServiceComponent.java
@@ -32,12 +32,14 @@ import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementServic
 import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.OrganizationUserSharingService;
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.OrganizationUserSharingServiceImpl;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.listener.OrganizationUserSharingHandler;
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.listener.SharedUserOperationEventListener;
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.listener.SharedUserProfileUpdateGovernanceEventListener;
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.listener.SharingOrganizationCreatorUserEventHandler;
 import org.wso2.carbon.identity.organization.management.role.management.service.RoleManager;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.OrgResourceResolverService;
+import org.wso2.carbon.identity.organization.resource.sharing.policy.management.ResourceSharingPolicyHandlerService;
 import org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService;
 import org.wso2.carbon.user.core.listener.UserOperationEventListener;
 import org.wso2.carbon.user.core.service.RealmService;
@@ -68,6 +70,8 @@ public class OrganizationUserSharingServiceComponent {
                 new SharedUserProfileUpdateGovernanceEventListener(), null);
         bundleContext.registerService(AbstractEventHandler.class.getName(),
                 new SharingOrganizationCreatorUserEventHandler(), null);
+        bundleContext.registerService(AbstractEventHandler.class.getName(),
+                new OrganizationUserSharingHandler(), null);
         LOG.info("OrganizationUserSharingServiceComponent activated successfully.");
     }
 
@@ -189,5 +193,27 @@ public class OrganizationUserSharingServiceComponent {
 
         OrganizationUserSharingDataHolder.getInstance().setOrgResourceResolverService(null);
         LOG.debug("Unset Org Resource Resolver Service.");
+    }
+
+    @Reference(
+            name = "resource.sharing.policy.handler.service",
+            service = ResourceSharingPolicyHandlerService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetResourceSharingPolicyHandlerService"
+    )
+    protected void setResourceSharingPolicyHandlerService(
+            ResourceSharingPolicyHandlerService resourceSharingPolicyHandlerService) {
+
+        OrganizationUserSharingDataHolder.getInstance()
+                .setResourceSharingPolicyHandlerService(resourceSharingPolicyHandlerService);
+        LOG.debug("Set Resource Sharing Policy Handler Service.");
+    }
+
+    protected void unsetResourceSharingPolicyHandlerService(
+            ResourceSharingPolicyHandlerService resourceSharingPolicyHandlerService) {
+
+        OrganizationUserSharingDataHolder.getInstance().setResourceSharingPolicyHandlerService(null);
+        LOG.debug("Unset Resource Sharing Policy Handler Service.");
     }
 }

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/OrganizationUserSharingHandler.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/OrganizationUserSharingHandler.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.management.organization.user.sharing.listener;
+
+import org.wso2.carbon.identity.core.bean.context.MessageContext;
+import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.event.event.Event;
+import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
+import org.wso2.carbon.identity.organization.management.ext.Constants;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.OrganizationUserSharingService;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.OrganizationUserSharingServiceImpl;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.internal.OrganizationUserSharingDataHolder;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.identity.organization.management.service.model.Organization;
+import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
+import org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.PolicyEnum;
+import org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.ResourceType;
+import org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.SharedAttributeType;
+import org.wso2.carbon.identity.organization.resource.sharing.policy.management.exception.ResourceSharingPolicyMgtException;
+import org.wso2.carbon.identity.organization.resource.sharing.policy.management.model.ResourceSharingPolicy;
+import org.wso2.carbon.identity.organization.resource.sharing.policy.management.model.SharedResourceAttribute;
+import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementException;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * The event handler for sharing users to the newly created organization.
+ */
+public class OrganizationUserSharingHandler extends AbstractEventHandler {
+
+    private final OrganizationUserSharingService userSharingService = new OrganizationUserSharingServiceImpl();
+
+    /**
+     * Handles the user sharing for the newly created organization.
+     *
+     * @param event The event to be handled.
+     * @throws IdentityEventException If an error occurs while handling the event.
+     */
+    @Override
+    public void handleEvent(Event event) throws IdentityEventException {
+
+        String eventName = event.getEventName();
+        Map<String, Object> eventProperties = event.getEventProperties();
+        Organization createdOrganization = (Organization) eventProperties.get(Constants.EVENT_PROP_ORGANIZATION);
+
+        try {
+            if (OrganizationManagementUtil.isOrganization(createdOrganization.getId())) {
+                shareUsers(createdOrganization.getId());
+            }
+        } catch (OrganizationManagementException e) {
+            throw new IdentityEventException("Error while handling user sharing for event: " + eventName, e);
+        } catch (ResourceSharingPolicyMgtException e) {
+            throw new IdentityEventException("Error while retrieving resource sharing policies for event: " + eventName,
+                    e);
+        } catch (IdentityRoleManagementException e) {
+            throw new IdentityEventException("Error while handling role sharing for event: " + eventName, e);
+        }
+    }
+
+    @Override
+    public int getPriority(MessageContext messageContext) {
+
+        /*
+         * This handler should run after OrganizationCreationHandler to make sure shared application roles are created
+         * in the newly created organization before sharing users.
+         */
+        int priority = super.getPriority(messageContext);
+        if (priority == -1) {
+            priority = 15;
+        }
+        return priority;
+    }
+
+    private void shareUsers(String createdOrgId)
+            throws OrganizationManagementException, ResourceSharingPolicyMgtException, IdentityRoleManagementException {
+
+        // Get ancestor organizations of the current organization.
+        List<String> allAncestorOrgs = getOrganizationManager().getAncestorOrganizationIds(createdOrgId);
+        allAncestorOrgs.removeIf(orgId -> orgId.equals(createdOrgId));
+
+        // Get all resources of each ancestor organization.
+        Map<String, List<ResourceSharingPolicy>> resourcesGroupedByOrganization =
+                OrganizationUserSharingDataHolder.getInstance().getResourceSharingPolicyHandlerService()
+                        .getResourceSharingPoliciesGroupedByPolicyHoldingOrgId(allAncestorOrgs);
+
+        for (Map.Entry<String, List<ResourceSharingPolicy>> ancestorOrg : resourcesGroupedByOrganization.entrySet()) {
+            List<ResourceSharingPolicy> resourcesList = ancestorOrg.getValue();
+            for (ResourceSharingPolicy resource : resourcesList) {
+                if (!ResourceType.USER.equals(resource.getResourceType())) {
+                    continue;
+                }
+
+                if (PolicyEnum.ALL_EXISTING_AND_FUTURE_ORGS.equals(resource.getSharingPolicy()) ||
+                        PolicyEnum.SELECTED_ORG_WITH_ALL_EXISTING_AND_FUTURE_CHILDREN.equals(
+                                resource.getSharingPolicy())) {
+                    shareUser(resource.getResourceSharingPolicyId(), resource.getResourceId(),
+                            resource.getInitiatingOrgId(), createdOrgId);
+                } else if (getOrganizationManager().getRelativeDepthBetweenOrganizationsInSameBranch(
+                        ancestorOrg.getKey(), createdOrgId) == 1 &&
+                        (PolicyEnum.IMMEDIATE_EXISTING_AND_FUTURE_ORGS.equals(resource.getSharingPolicy()) ||
+                                PolicyEnum.SELECTED_ORG_WITH_EXISTING_IMMEDIATE_AND_FUTURE_CHILDREN.equals(
+                                        resource.getSharingPolicy()))) {
+                    shareUser(resource.getResourceSharingPolicyId(), resource.getResourceId(),
+                            resource.getInitiatingOrgId(), createdOrgId);
+                }
+            }
+        }
+    }
+
+    private void shareUser(int resourceSharingPolicyId, String userId, String residentOrgId, String createdOrgId)
+            throws OrganizationManagementException, ResourceSharingPolicyMgtException, IdentityRoleManagementException {
+
+        List<SharedResourceAttribute> userAttributes =
+                OrganizationUserSharingDataHolder.getInstance().getResourceSharingPolicyHandlerService()
+                        .getSharedResourceAttributesBySharingPolicyId(resourceSharingPolicyId);
+
+        // Extract the role IDs from the user attributes.
+        List<String> roleIds = userAttributes.stream().filter(attribute -> SharedAttributeType.ROLE.equals(
+                        attribute.getSharedAttributeType())).map(SharedResourceAttribute::getSharedAttributeId)
+                .collect(Collectors.toList());
+
+        userSharingService.shareOrganizationUser(createdOrgId, userId, residentOrgId);
+        if (roleIds.isEmpty()) {
+            // No roles to share.
+            return;
+        }
+
+        // Get the corresponding shared role IDs in the created organization.
+        List<String> sharedRoleIds = getSharedRoleIds(roleIds, createdOrgId);
+        String sharedUserId = userSharingService.getUserAssociationOfAssociatedUserByOrgId(userId, createdOrgId)
+                .getUserId();
+
+        for (String sharedRoleId : sharedRoleIds) {
+            // Assign the shared roles to the shared user.
+            OrganizationUserSharingDataHolder.getInstance().getRoleManagementService()
+                    .updateUserListOfRole(sharedRoleId, Collections.singletonList(sharedUserId),
+                            Collections.emptyList(), getOrganizationManager().resolveTenantDomain(createdOrgId));
+        }
+    }
+
+    private OrganizationManager getOrganizationManager() {
+
+        return OrganizationUserSharingDataHolder.getInstance().getOrganizationManager();
+    }
+
+    private List<String> getSharedRoleIds(List<String> roleIds, String createdOrgId)
+            throws OrganizationManagementException, IdentityRoleManagementException {
+
+        return new ArrayList<>(OrganizationUserSharingDataHolder.getInstance().getRoleManagementService()
+                .getMainRoleToSharedRoleMappingsBySubOrg(roleIds,
+                        getOrganizationManager().resolveTenantDomain(createdOrgId)).values());
+    }
+}


### PR DESCRIPTION
## Purpose
$subject.

this handler is responsible for sharing users to a newly created sub-organization based on the user sharing policies of it's ancestor organizations. 

### Related issue
- https://github.com/wso2/product-is/issues/22433