### PR TITLE
Restrict Deletion of Shared Users at the Sub-Organization Level

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/OrganizationUserSharingServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/OrganizationUserSharingServiceImpl.java
@@ -217,11 +217,13 @@ public class OrganizationUserSharingServiceImpl implements OrganizationUserShari
     }
 
     private void startTenantFlow(String tenantDomain) {
+
         PrivilegedCarbonContext.startTenantFlow();
         PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(tenantDomain, true);
     }
 
     private void endTenantFlow() {
+
         PrivilegedCarbonContext.endTenantFlow();
     }
 

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/OrganizationUserSharingServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/OrganizationUserSharingServiceImpl.java
@@ -205,6 +205,7 @@ public class OrganizationUserSharingServiceImpl implements OrganizationUserShari
 
     private void deleteUserInTenantFlow(AbstractUserStoreManager userStoreManager, String userId,
                                         String tenantDomain, String organizationId) throws UserStoreException {
+
         try {
             String requestInitiator = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
             startTenantFlow(tenantDomain);

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/constant/UserSharingConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/constant/UserSharingConstants.java
@@ -226,7 +226,7 @@ public class UserSharingConstants {
                 "Unable to retrieve the organizations shared with the user due to an internal error."),
         ERROR_CODE_UNAUTHORIZED_DELETION_OF_SHARED_USER("10049",
                 "Unauthorized deletion of shared user.",
-                "Shared users can only be deleted by that particular user's resident organization."),;
+                "Shared users can only be deleted by that particular user's resident organization.");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/constant/UserSharingConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/constant/UserSharingConstants.java
@@ -223,7 +223,10 @@ public class UserSharingConstants {
                 "Unable to retrieve the roles shared with the specified user due to an internal error."),
         ERROR_CODE_GET_SHARED_ORGANIZATIONS_OF_USER("10048",
                 "Error occurred while retrieving shared organizations of user.",
-                "Unable to retrieve the organizations shared with the user due to an internal error.");
+                "Unable to retrieve the organizations shared with the user due to an internal error."),
+        ERROR_CODE_UNAUTHORIZED_DELETION_OF_SHARED_USER("10049",
+                "Unauthorized deletion of shared user.",
+                "Shared users can only be deleted by that particular user's resident organization."),;
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/constant/UserSharingConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/constant/UserSharingConstants.java
@@ -226,7 +226,8 @@ public class UserSharingConstants {
                 "Unable to retrieve the organizations shared with the user due to an internal error."),
         ERROR_CODE_UNAUTHORIZED_DELETION_OF_SHARED_USER("10049",
                 "Unauthorized deletion of shared user.",
-                "Shared users can only be deleted by that particular user's resident organization.");
+                "Users shared by ancestor organization requests can only be deleted by that particular " +
+                        "user's resident organization.");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/SharedUserOperationEventListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/SharedUserOperationEventListener.java
@@ -69,6 +69,7 @@ import static org.wso2.carbon.identity.organization.management.organization.user
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_MANAGED_ORGANIZATION_CLAIM_UPDATE_NOT_ALLOWED;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_SHARED_USER_CLAIM_UPDATE_NOT_ALLOWED;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.getOrganizationId;
+import static org.wso2.carbon.identity.organization.management.service.util.Utils.getTenantDomain;
 
 /**
  * User operation event listener for shared user management.
@@ -99,6 +100,10 @@ public class SharedUserOperationEventListener extends AbstractIdentityUserOperat
             String associatedOrgId = OrganizationSharedUserUtil
                     .getUserManagedOrganizationClaim((AbstractUserStoreManager) userStoreManager, userID);
             String orgId = getOrganizationId();
+            if (orgId == null) {
+                orgId = OrganizationUserSharingDataHolder.getInstance().getOrganizationManager()
+                        .resolveOrganizationId(getTenantDomain());
+            }
 
             if (associatedOrgId != null) {
                 // Retrieve the user association details for the given user and organization.

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/SharedUserOperationEventListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/SharedUserOperationEventListener.java
@@ -110,11 +110,10 @@ public class SharedUserOperationEventListener extends AbstractIdentityUserOperat
                 String tenantDomain = getTenantDomain(loginTenantId);
                 String requestInitiatedOrg = OrganizationUserSharingDataHolder.getInstance().getOrganizationManager()
                         .resolveOrganizationId(tenantDomain);
-                boolean isSharedOrOwner = sharedType == SharedType.SHARED || sharedType == SharedType.OWNER;
-                boolean isUnauthorizedDeletion = !StringUtils.equals(requestInitiatedOrg, associatedOrgId);
+                boolean isSharedUserOrOwner = sharedType == SharedType.SHARED || sharedType == SharedType.OWNER;
 
                 // Prevent deletion if the request originates from a sub-org and the user has a restricted shared type.
-                if (isSharedOrOwner && isUnauthorizedDeletion) {
+                if (isSharedUserOrOwner && !StringUtils.equals(requestInitiatedOrg, associatedOrgId)) {
                     throw new UserStoreClientException(
                             ERROR_CODE_UNAUTHORIZED_DELETION_OF_SHARED_USER.getDescription(),
                             ERROR_CODE_UNAUTHORIZED_DELETION_OF_SHARED_USER.getCode());

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/SharedUserOperationEventListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/SharedUserOperationEventListener.java
@@ -58,7 +58,6 @@ import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 
 import static org.wso2.carbon.identity.claim.metadata.mgt.util.ClaimConstants.SHARED_PROFILE_VALUE_RESOLVING_METHOD;
@@ -107,7 +106,7 @@ public class SharedUserOperationEventListener extends AbstractIdentityUserOperat
                 String sharedType = userAssociation.getSharedType();
 
                 // Restrict deletion if the shared type is not "INVITED".
-                if (!Objects.equals(sharedType, SharedType.INVITED.name())) {
+                if (SharedType.valueOf(sharedType) != SharedType.INVITED) {
                     throw new UserStoreClientException(
                             ERROR_CODE_UNAUTHORIZED_DELETION_OF_SHARED_USER.getDescription(),
                             ERROR_CODE_UNAUTHORIZED_DELETION_OF_SHARED_USER.getCode());


### PR DESCRIPTION
## Purpose
> Currently, users who have been shared from a parent organization to a sub-organization can be deleted at the sub-organization level. This behavior is incorrect as shared users should only be removed (unshared) by the parent organization. This PR introduces a restriction to prevent unauthorized deletion of shared users.

## Goals
> - Ensure that shared users cannot be deleted from the sub-organization level.
> - Restrict deletion unless the user's shared type is explicitly marked as "INVITED".
> - Enforce proper access control and validation in user sharing scenarios.

## Approach
> Introduced a validation check to determine the user's sharing type before allowing deletion. If the user was shared through a method other than an invitation, deletion is restricted at the sub-organization level, ensuring only the parent organization can unshare the user.

---

## Related Issue
[Restrict Deletion of Shared Users at the Sub-Organization Level #22577](https://github.com/wso2/product-is/issues/22577)