### PR TITLE
Fix Incorrect User Association and Role Deletion Issues in Post-Organization Creation Event Handler When Sharing Users Under a Policy

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/OrganizationUserSharingHandler.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/OrganizationUserSharingHandler.java
@@ -27,26 +27,36 @@ import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
 import org.wso2.carbon.identity.organization.management.ext.Constants;
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.OrganizationUserSharingService;
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.OrganizationUserSharingServiceImpl;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.EditOperation;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.SharedType;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.exception.UserSharingMgtException;
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.internal.OrganizationUserSharingDataHolder;
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.models.UserAssociation;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementServerException;
 import org.wso2.carbon.identity.organization.management.service.model.Organization;
 import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
 import org.wso2.carbon.identity.organization.management.service.util.Utils;
+import org.wso2.carbon.identity.organization.resource.sharing.policy.management.ResourceSharingPolicyHandlerService;
 import org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.PolicyEnum;
 import org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.ResourceType;
 import org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.SharedAttributeType;
 import org.wso2.carbon.identity.organization.resource.sharing.policy.management.exception.ResourceSharingPolicyMgtException;
 import org.wso2.carbon.identity.organization.resource.sharing.policy.management.model.ResourceSharingPolicy;
 import org.wso2.carbon.identity.organization.resource.sharing.policy.management.model.SharedResourceAttribute;
+import org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService;
 import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementException;
+import org.wso2.carbon.identity.role.v2.mgt.core.util.UserIDResolver;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import static org.wso2.carbon.identity.organization.management.service.util.Utils.getOrganizationId;
 
 /**
  * The event handler for sharing users to the newly created organization.
@@ -55,6 +65,7 @@ public class OrganizationUserSharingHandler extends AbstractEventHandler {
 
     private static final Log LOG = LogFactory.getLog(OrganizationUserSharingHandler.class);
     private final OrganizationUserSharingService userSharingService = new OrganizationUserSharingServiceImpl();
+    private final UserIDResolver userIDResolver = new UserIDResolver();
 
     /**
      * Handles the user sharing for the newly created organization.
@@ -100,18 +111,15 @@ public class OrganizationUserSharingHandler extends AbstractEventHandler {
     private void shareUsers(String createdOrgId)
             throws OrganizationManagementException, ResourceSharingPolicyMgtException, IdentityRoleManagementException {
 
-        // Get ancestor organizations of the current organization.
         List<String> allAncestorOrgs = getOrganizationManager().getAncestorOrganizationIds(createdOrgId);
-        // Level of the primary organizations.
         int topHierarchyLevel = Utils.getSubOrgStartLevel() >= 1 ? Utils.getSubOrgStartLevel() - 1 : 0;
-        // Get ancestor organizations starting from the immediate parent to the top level.
         List<String> relevantAncestorOrgs =
                 new ArrayList<>(allAncestorOrgs.subList(1, allAncestorOrgs.size() - topHierarchyLevel));
 
         // Get all resources of each ancestor organization.
         Map<String, List<ResourceSharingPolicy>> resourcesGroupedByOrganization =
-                OrganizationUserSharingDataHolder.getInstance().getResourceSharingPolicyHandlerService()
-                        .getResourceSharingPoliciesGroupedByPolicyHoldingOrgId(relevantAncestorOrgs);
+                getResourceSharingPolicyHandlerService().getResourceSharingPoliciesGroupedByPolicyHoldingOrgId(
+                        relevantAncestorOrgs);
 
         for (Map.Entry<String, List<ResourceSharingPolicy>> ancestorOrg : resourcesGroupedByOrganization.entrySet()) {
             List<ResourceSharingPolicy> resourcesList = ancestorOrg.getValue();
@@ -120,21 +128,20 @@ public class OrganizationUserSharingHandler extends AbstractEventHandler {
                     continue;
                 }
 
-                if (PolicyEnum.ALL_EXISTING_AND_FUTURE_ORGS.equals(resource.getSharingPolicy()) ||
-                        PolicyEnum.SELECTED_ORG_WITH_ALL_EXISTING_AND_FUTURE_CHILDREN.equals(
-                                resource.getSharingPolicy())) {
-                    shareUser(resource.getResourceSharingPolicyId(), resource.getResourceId(),
-                            resource.getInitiatingOrgId(), createdOrgId);
-                } else if (getOrganizationManager().getRelativeDepthBetweenOrganizationsInSameBranch(
-                        ancestorOrg.getKey(), createdOrgId) == 1 &&
-                        (PolicyEnum.IMMEDIATE_EXISTING_AND_FUTURE_ORGS.equals(resource.getSharingPolicy()) ||
-                                PolicyEnum.SELECTED_ORG_WITH_EXISTING_IMMEDIATE_AND_FUTURE_CHILDREN.equals(
-                                        resource.getSharingPolicy()))) {
+                if (shouldShareUser(resource.getSharingPolicy(), createdOrgId, ancestorOrg)) {
                     shareUser(resource.getResourceSharingPolicyId(), resource.getResourceId(),
                             resource.getInitiatingOrgId(), createdOrgId);
                 }
             }
         }
+    }
+
+    private boolean shouldShareUser(PolicyEnum policy, String createdOrgId,
+                                    Map.Entry<String, List<ResourceSharingPolicy>> ancestorOrgId)
+            throws OrganizationManagementServerException {
+
+        return isAllExistingAndFutureOrgs(policy) ||
+                (isImmediateLevelOrganization(createdOrgId, ancestorOrgId) && isImmediateExistingAndFutureOrgs(policy));
     }
 
     private void shareUser(int resourceSharingPolicyId, String userId, String residentOrgId, String createdOrgId)
@@ -145,46 +152,54 @@ public class OrganizationUserSharingHandler extends AbstractEventHandler {
                         .getSharedResourceAttributesBySharingPolicyId(resourceSharingPolicyId);
 
         // Extract the role IDs from the user attributes.
-        List<String> roleIds = userAttributes.stream().filter(attribute -> SharedAttributeType.ROLE.equals(
-                        attribute.getSharedAttributeType())).map(SharedResourceAttribute::getSharedAttributeId)
-                .collect(Collectors.toList());
+        List<String> roleIds = userAttributes.stream()
+                .filter(attribute -> SharedAttributeType.ROLE.equals(attribute.getSharedAttributeType()))
+                .map(SharedResourceAttribute::getSharedAttributeId).collect(Collectors.toList());
 
         UserAssociation existingUserAssociation =
                 userSharingService.getUserAssociationOfAssociatedUserByOrgId(userId, createdOrgId);
         if (existingUserAssociation == null) {
-            userSharingService.shareOrganizationUser(createdOrgId, userId, residentOrgId);
+            userSharingService.shareOrganizationUser(createdOrgId, userId, residentOrgId, SharedType.SHARED);
         } else if (LOG.isDebugEnabled()) {
             LOG.debug("User: " + userId + " is already shared with the organization: " + createdOrgId);
         }
 
         if (roleIds.isEmpty()) {
-            // No roles assigned to the user.
             return;
         }
 
         // Get the corresponding shared role IDs in the created organization.
         List<String> sharedRoleIds = getSharedRoleIds(roleIds, createdOrgId);
-        String sharedUserId = userSharingService.getUserAssociationOfAssociatedUserByOrgId(userId, createdOrgId)
-                .getUserId();
-
+        String tenantDomain = getOrganizationManager().resolveTenantDomain(createdOrgId);
+        String sharedUserId =
+                userSharingService.getUserAssociationOfAssociatedUserByOrgId(userId, createdOrgId).getUserId();
         List<String> sharedUserExistingRoles =
-                OrganizationUserSharingDataHolder.getInstance().getRoleManagementService()
-                        .getRoleIdListOfUser(sharedUserId, getOrganizationManager().resolveTenantDomain(createdOrgId));
+                getRoleManagementService().getRoleIdListOfUser(sharedUserId, tenantDomain);
 
         // Remove the shared roles that are already assigned to the shared user.
-        sharedRoleIds.removeIf(sharedUserExistingRoles::contains);
+        sharedRoleIds.removeIf(sharedUserExistingRoles::contains);//TODO: WHAT?
 
         for (String sharedRoleId : sharedRoleIds) {
             // Assign the shared roles to the shared user.
-            OrganizationUserSharingDataHolder.getInstance().getRoleManagementService()
-                    .updateUserListOfRole(sharedRoleId, Collections.singletonList(sharedUserId),
-                            Collections.emptyList(), getOrganizationManager().resolveTenantDomain(createdOrgId));
+            getRoleManagementService().updateUserListOfRole(sharedRoleId, Collections.singletonList(sharedUserId), Collections.emptyList(), tenantDomain);
+            restrictUserRoleDeletion(sharedRoleId, userId, tenantDomain, createdOrgId);
         }
     }
 
-    private OrganizationManager getOrganizationManager() {
+    private void restrictUserRoleDeletion(String rolId, String userId, String tenantDomain, String createdOrgId) {
 
-        return OrganizationUserSharingDataHolder.getInstance().getOrganizationManager();
+        try {
+            UserAssociation userAssociation =
+                    getOrganizationUserSharingService().getUserAssociationOfAssociatedUserByOrgId(userId, createdOrgId);
+            String usernameWithDomain = userIDResolver.getNameByID(userAssociation.getUserId(), tenantDomain);
+            String username = UserCoreUtil.removeDomainFromName(usernameWithDomain);
+            String domainName = UserCoreUtil.extractDomainFromName(usernameWithDomain);
+
+            getOrganizationUserSharingService().addEditRestrictionsForSharedUserRole(rolId, username,
+                    tenantDomain, domainName, EditOperation.DELETE, getOrganizationId());
+        } catch (IdentityRoleManagementException | UserSharingMgtException | OrganizationManagementException e) {
+            LOG.error("Error while adding edit restrictions for shared user role deletion.", e);
+        }
     }
 
     private List<String> getSharedRoleIds(List<String> roleIds, String createdOrgId)
@@ -203,5 +218,45 @@ public class OrganizationUserSharingHandler extends AbstractEventHandler {
                     rolesWithoutSharedRoles);
         }
         return new ArrayList<>(mainRoleToSharedRoleMappings.values());
+    }
+
+    private boolean isAllExistingAndFutureOrgs(PolicyEnum policy) {
+
+        return PolicyEnum.ALL_EXISTING_AND_FUTURE_ORGS.equals(policy) ||
+                PolicyEnum.SELECTED_ORG_WITH_ALL_EXISTING_AND_FUTURE_CHILDREN.equals(policy);
+    }
+
+    private boolean isImmediateExistingAndFutureOrgs(PolicyEnum policy) {
+
+        return PolicyEnum.IMMEDIATE_EXISTING_AND_FUTURE_ORGS.equals(policy) ||
+                PolicyEnum.SELECTED_ORG_WITH_EXISTING_IMMEDIATE_AND_FUTURE_CHILDREN.equals(policy);
+    }
+
+    private boolean isImmediateLevelOrganization(String createdOrgId,
+                                                 Map.Entry<String, List<ResourceSharingPolicy>> ancestorOrg)
+            throws OrganizationManagementServerException {
+
+        return getOrganizationManager().getRelativeDepthBetweenOrganizationsInSameBranch(ancestorOrg.getKey(),
+                createdOrgId) == 1;
+    }
+
+    private OrganizationUserSharingService getOrganizationUserSharingService() {
+
+        return OrganizationUserSharingDataHolder.getInstance().getOrganizationUserSharingService();
+    }
+
+    private OrganizationManager getOrganizationManager() {
+
+        return OrganizationUserSharingDataHolder.getInstance().getOrganizationManager();
+    }
+
+    private ResourceSharingPolicyHandlerService getResourceSharingPolicyHandlerService() {
+
+        return OrganizationUserSharingDataHolder.getInstance().getResourceSharingPolicyHandlerService();
+    }
+
+    private RoleManagementService getRoleManagementService() {
+
+        return OrganizationUserSharingDataHolder.getInstance().getRoleManagementService();
     }
 }


### PR DESCRIPTION
## Purpose
 This PR addresses two critical issues observed in the OrganizationUserSharingHandler, the post-organization creation event handler, when a user is shared under a policy that mandates sharing with newly created organizations.
 1. Incorrect User Association in Newly Created Organizations and police change.
 2. Shared user-role deletion is possible within the sub-org.

## Goals
 - Ensure correct user association when a user is shared under a policy that mandates sharing with newly created organizations and when the policy changes.
 - Prevent shared user roles from being deleted within sub-organizations by enforcing proper restrictions.

## Approach
1. Fix Incorrect User Association in Newly Created Organizations and Policy Changes
    - Ensure that the user association is correctly linked to the original resident organization instead of the sharing-initiating organization.
    - Update the OrganizationUserSharingHandler to correctly handle policy changes and maintain expected user sharing behavior.

2. Fix Shared User-Role Deletion Issue
    - Insert the shared user-roles into `UM_SHARED_USER_RESTRICTED_EDIT_PERMISSIONS` table.