### PR TITLE
Replace String with SharedType Enum in UserAssociation and ResponseOrgDetailsDO

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/constant/SharedType.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/constant/SharedType.java
@@ -21,8 +21,40 @@ package org.wso2.carbon.identity.organization.management.organization.user.shari
  * Enum representing the types of user associations.
  */
 public enum SharedType {
-    SHARED,
-    INVITED,
-    OWNER,
-    NOT_SPECIFIED,
+    SHARED("SHARED"),
+    INVITED("INVITED"),
+    OWNER("OWNER"),
+    NOT_SPECIFIED("NOT SPECIFIED");
+
+    private final String value;
+
+    SharedType(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Returns the exact value as stored in the database.
+     *
+     * @return The database value of the enum.
+     */
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    /**
+     * Custom method to get the enum from a string value, handling spaces.
+     *
+     * @param dbValue The database value.
+     * @return The corresponding SharedType enum.
+     * @throws IllegalArgumentException if the value does not match any enum.
+     */
+    public static SharedType fromString(String dbValue) {
+        for (SharedType type : SharedType.values()) {
+            if (type.value.equalsIgnoreCase(dbValue)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("Invalid SharedType value: " + dbValue);
+    }
 }

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/constant/SharedType.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/constant/SharedType.java
@@ -29,6 +29,7 @@ public enum SharedType {
     private final String value;
 
     SharedType(String value) {
+
         this.value = value;
     }
 
@@ -39,22 +40,24 @@ public enum SharedType {
      */
     @Override
     public String toString() {
+
         return value;
     }
 
     /**
      * Custom method to get the enum from a string value, handling spaces.
      *
-     * @param dbValue The database value.
+     * @param stringValueOfSharedType The string value of SharedType.
      * @return The corresponding SharedType enum.
      * @throws IllegalArgumentException if the value does not match any enum.
      */
-    public static SharedType fromString(String dbValue) {
+    public static SharedType fromString(String stringValueOfSharedType) {
+
         for (SharedType type : SharedType.values()) {
-            if (type.value.equalsIgnoreCase(dbValue)) {
+            if (type.value.equalsIgnoreCase(stringValueOfSharedType)) {
                 return type;
             }
         }
-        throw new IllegalArgumentException("Invalid SharedType value: " + dbValue);
+        throw new IllegalArgumentException("Invalid SharedType value: " + stringValueOfSharedType);
     }
 }

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/dao/OrganizationUserSharingDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/dao/OrganizationUserSharingDAOImpl.java
@@ -173,7 +173,7 @@ public class OrganizationUserSharingDAOImpl implements OrganizationUserSharingDA
                         userAssociation.setAssociatedUserId(resultSet.getString(COLUMN_NAME_ASSOCIATED_USER_ID));
                         userAssociation.setUserResidentOrganizationId(
                                 resultSet.getString(COLUMN_NAME_ASSOCIATED_ORG_ID));
-                        userAssociation.setSharedType(COLUMN_NAME_UM_SHARED_TYPE);
+                        userAssociation.setSharedType(SharedType.fromString(COLUMN_NAME_UM_SHARED_TYPE));
                         return userAssociation;
                     },
                     namedPreparedStatement -> {
@@ -201,7 +201,8 @@ public class OrganizationUserSharingDAOImpl implements OrganizationUserSharingDA
                         userAssociation.setAssociatedUserId(resultSet.getString(COLUMN_NAME_ASSOCIATED_USER_ID));
                         userAssociation.setUserResidentOrganizationId(
                                 resultSet.getString(COLUMN_NAME_ASSOCIATED_ORG_ID));
-                        userAssociation.setSharedType(resultSet.getString(COLUMN_NAME_UM_SHARED_TYPE));
+                        userAssociation.setSharedType(
+                                SharedType.fromString(resultSet.getString(COLUMN_NAME_UM_SHARED_TYPE)));
                         return userAssociation;
                     },
                     namedPreparedStatement -> {
@@ -229,7 +230,8 @@ public class OrganizationUserSharingDAOImpl implements OrganizationUserSharingDA
                         userAssociation.setAssociatedUserId(resultSet.getString(COLUMN_NAME_ASSOCIATED_USER_ID));
                         userAssociation.setUserResidentOrganizationId(
                                 resultSet.getString(COLUMN_NAME_ASSOCIATED_ORG_ID));
-                        userAssociation.setSharedType(resultSet.getString(COLUMN_NAME_UM_SHARED_TYPE));
+                        userAssociation.setSharedType(
+                                SharedType.fromString(resultSet.getString(COLUMN_NAME_UM_SHARED_TYPE)));
                         return userAssociation;
                     },
                     namedPreparedStatement -> {
@@ -257,7 +259,8 @@ public class OrganizationUserSharingDAOImpl implements OrganizationUserSharingDA
                         userAssociation.setAssociatedUserId(resultSet.getString(COLUMN_NAME_ASSOCIATED_USER_ID));
                         userAssociation.setUserResidentOrganizationId(
                                 resultSet.getString(COLUMN_NAME_ASSOCIATED_ORG_ID));
-                        userAssociation.setSharedType(resultSet.getString(COLUMN_NAME_UM_SHARED_TYPE));
+                        userAssociation.setSharedType(
+                                SharedType.fromString(resultSet.getString(COLUMN_NAME_UM_SHARED_TYPE)));
                         return userAssociation;
                     },
                     namedPreparedStatement -> {

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/SharedUserOperationEventListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/SharedUserOperationEventListener.java
@@ -104,7 +104,7 @@ public class SharedUserOperationEventListener extends AbstractIdentityUserOperat
             if (associatedOrgId != null) {
                 // Retrieve the user association details for the given user and organization.
                 UserAssociation userAssociation = getUserAssociation(userID, orgId);
-                SharedType sharedType = SharedType.valueOf(userAssociation.getSharedType());
+                SharedType sharedType = userAssociation.getSharedType();
 
                 int loginTenantId = IdentityTenantUtil.getLoginTenantId();
                 String tenantDomain = getTenantDomain(loginTenantId);

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/models/UserAssociation.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/models/UserAssociation.java
@@ -87,8 +87,7 @@ public class UserAssociation {
         return sharedType;
     }
 
-    public void setSharedType(
-            SharedType sharedType) {
+    public void setSharedType(SharedType sharedType) {
 
         this.sharedType = sharedType;
     }

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/models/UserAssociation.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/models/UserAssociation.java
@@ -18,6 +18,8 @@
 
 package org.wso2.carbon.identity.organization.management.organization.user.sharing.models;
 
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.SharedType;
+
 /**
  * Model class to represent the user associations created for the shared users.
  */
@@ -28,7 +30,7 @@ public class UserAssociation {
     private String organizationId;
     private String associatedUserId;
     private String userResidentOrganizationId;
-    private String sharedType;
+    private SharedType sharedType;
 
     public int getId() {
 
@@ -80,12 +82,13 @@ public class UserAssociation {
         this.userResidentOrganizationId = userResidentOrganizationId;
     }
 
-    public String getSharedType() {
+    public SharedType getSharedType() {
 
         return sharedType;
     }
 
-    public void setSharedType(String sharedType) {
+    public void setSharedType(
+            SharedType sharedType) {
 
         this.sharedType = sharedType;
     }

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/models/dos/ResponseOrgDetailsDO.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/models/dos/ResponseOrgDetailsDO.java
@@ -18,6 +18,8 @@
 
 package org.wso2.carbon.identity.organization.management.organization.user.sharing.models.dos;
 
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.SharedType;
+
 /**
  * Model that contains the shared organizations details of a user in the response object.
  */
@@ -26,7 +28,7 @@ public class ResponseOrgDetailsDO {
     private String organizationId;
     private String organizationName;
     private String sharedUserId;
-    private String sharedType;
+    private SharedType sharedType;
     private String rolesRef;
 
     public String getOrganizationId() {
@@ -59,12 +61,13 @@ public class ResponseOrgDetailsDO {
         this.sharedUserId = sharedUserId;
     }
 
-    public String getSharedType() {
+    public SharedType getSharedType() {
 
         return sharedType;
     }
 
-    public void setSharedType(String sharedType) {
+    public void setSharedType(
+            SharedType sharedType) {
 
         this.sharedType = sharedType;
     }

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/models/dos/ResponseOrgDetailsDO.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/models/dos/ResponseOrgDetailsDO.java
@@ -66,8 +66,7 @@ public class ResponseOrgDetailsDO {
         return sharedType;
     }
 
-    public void setSharedType(
-            SharedType sharedType) {
+    public void setSharedType(SharedType sharedType) {
 
         this.sharedType = sharedType;
     }


### PR DESCRIPTION
## Purpose
> Enhance type safety by replacing String with the `SharedType` enum for sharedType in `UserAssociation` and `ResponseOrgDetailsDO`.

## Goals
> - Ensure consistency in handling sharedType values.
> - Prevent invalid values by enforcing strict enum usage.
> - Facilitate safe conversions between database values and enums.

## Approach
Modified `SharedType` to store explicit string values and provide `toString()` and `fromString()` methods.
Replaced `String sharedType` with `SharedType sharedType` in `UserAssociation` and `ResponseOrgDetailsDO`.
Ensured compatibility by handling case-insensitive mappings in `fromString()`.
Verified that database interactions correctly process the updated enum type.