### PR TITLE
Fix issue in retrieving and setting the correct SharedType for user associations

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/dao/OrganizationUserSharingDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/dao/OrganizationUserSharingDAOImpl.java
@@ -173,7 +173,8 @@ public class OrganizationUserSharingDAOImpl implements OrganizationUserSharingDA
                         userAssociation.setAssociatedUserId(resultSet.getString(COLUMN_NAME_ASSOCIATED_USER_ID));
                         userAssociation.setUserResidentOrganizationId(
                                 resultSet.getString(COLUMN_NAME_ASSOCIATED_ORG_ID));
-                        userAssociation.setSharedType(SharedType.fromString(COLUMN_NAME_UM_SHARED_TYPE));
+                        userAssociation.setSharedType(
+                                SharedType.fromString(resultSet.getString(COLUMN_NAME_UM_SHARED_TYPE)));
                         return userAssociation;
                     },
                     namedPreparedStatement -> {


### PR DESCRIPTION
## Purpose
> The issue prevented the deletion of a user who had been shared with a sub-organization, resulting in a `500 Internal Server Error`. The root cause was an invalid SharedType value being passed during the deletion process.

## Goals
> Ensure the correct `SharedType` is retrieved and set when processing user associations to prevent errors during user deletion.

## Approach
> Updated the retrieval mechanism for the `SharedType` to ensure the correct value is fetched dynamically rather than relying on a static reference. This prevents invalid values from causing failures during user deletion operations.

---

Related Issue:
[Unable to delete users from origin if the user is shared #22760](https://github.com/wso2/product-is/issues/22760)