### PR TITLE
Inherit main application isDiscoverable property and access url to shared applications. 

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
@@ -185,8 +185,7 @@ public class FragmentApplicationMgtListener extends AbstractApplicationMgtListen
         /* If the application is a fragment application, only certain configurations are allowed to be updated since
         the organization login authenticator needs some configurations unchanged. Hence, the listener will override
         any configs changes that are required for organization login. */
-        if (existingApplication != null && Arrays.stream(existingApplication.getSpProperties())
-                .anyMatch(p -> IS_FRAGMENT_APP.equalsIgnoreCase(p.getName()) && Boolean.parseBoolean(p.getValue()))) {
+        if (isFragmentApp(existingApplication)) {
             serviceProvider.setSpProperties(existingApplication.getSpProperties());
             serviceProvider.setInboundAuthenticationConfig(existingApplication.getInboundAuthenticationConfig());
             LocalAndOutboundAuthenticationConfig localAndOutBoundAuthenticationConfig =
@@ -262,8 +261,7 @@ public class FragmentApplicationMgtListener extends AbstractApplicationMgtListen
                                             String tenantDomain) throws IdentityApplicationManagementException {
 
         // If the application is a shared application, updates to the application are allowed
-        if (serviceProvider != null && Arrays.stream(serviceProvider.getSpProperties())
-                .anyMatch(p -> IS_FRAGMENT_APP.equalsIgnoreCase(p.getName()) && Boolean.parseBoolean(p.getValue()))) {
+        if (isFragmentApp(serviceProvider)) {
             Optional<MainApplicationDO> mainApplicationDO;
             try {
                 String sharedOrgId = getOrganizationManager().resolveOrganizationId(tenantDomain);
@@ -337,31 +335,36 @@ public class FragmentApplicationMgtListener extends AbstractApplicationMgtListen
     public boolean doPostGetApplicationWithRequiredAttributes(ServiceProvider serviceProvider, String tenantDomain)
             throws IdentityApplicationManagementException {
 
-        if (serviceProvider != null && Arrays.stream(serviceProvider.getSpProperties()).anyMatch(
-                property -> IS_FRAGMENT_APP.equalsIgnoreCase(property.getName()) &&
-                        Boolean.parseBoolean(property.getValue()))) {
-            try {
-                Optional<MainApplicationDO> mainApplicationDO;
-                String sharedOrgId = getOrganizationManager().resolveOrganizationId(tenantDomain);
-                mainApplicationDO = getOrgApplicationMgtDAO()
-                        .getMainApplication(serviceProvider.getApplicationResourceId(), sharedOrgId);
-                if (mainApplicationDO.isPresent()) {
-                    String mainApplicationTenantDomain = getOrganizationManager().resolveTenantDomain(
-                            mainApplicationDO.get().getOrganizationId());
-                    ServiceProvider mainApplication = getApplicationByResourceId(
-                            mainApplicationDO.get().getMainApplicationId(), mainApplicationTenantDomain);
-                    inheritDiscoverabilityProperty(mainApplication, serviceProvider);
-                    if (StringUtils.isBlank(serviceProvider.getAccessUrl())) {
-                        serviceProvider.setAccessUrl(mainApplication.getAccessUrl());
-                    }
-                }
-            } catch (OrganizationManagementException e) {
-                throw new IdentityApplicationManagementException(
-                        "Error while retrieving the fragment application details.", e);
+        try {
+            if (!OrganizationManagementUtil.isOrganization(tenantDomain) || !isFragmentApp(serviceProvider)) {
+                return true;
             }
+            Optional<MainApplicationDO> mainApplicationDO;
+            String sharedOrgId = getOrganizationManager().resolveOrganizationId(tenantDomain);
+            mainApplicationDO = getOrgApplicationMgtDAO()
+                    .getMainApplication(serviceProvider.getApplicationResourceId(), sharedOrgId);
+            if (mainApplicationDO.isPresent()) {
+                String mainApplicationTenantDomain = getOrganizationManager().resolveTenantDomain(
+                        mainApplicationDO.get().getOrganizationId());
+                ServiceProvider mainApplication = getApplicationByResourceId(
+                        mainApplicationDO.get().getMainApplicationId(), mainApplicationTenantDomain);
+                inheritDiscoverabilityProperty(mainApplication, serviceProvider);
+                if (StringUtils.isBlank(serviceProvider.getAccessUrl())) {
+                    serviceProvider.setAccessUrl(mainApplication.getAccessUrl());
+                }
+            }
+        } catch (OrganizationManagementException e) {
+            throw new IdentityApplicationManagementException(
+                    "Error while retrieving the fragment application details.", e);
         }
-
         return true;
+    }
+
+    private boolean isFragmentApp(ServiceProvider serviceProvider) {
+
+        return serviceProvider != null && Arrays.stream(serviceProvider.getSpProperties()).anyMatch(
+                property -> IS_FRAGMENT_APP.equalsIgnoreCase(property.getName()) &&
+                        Boolean.parseBoolean(property.getValue()));
     }
 
     private void inheritDiscoverabilityProperty(ServiceProvider mainApplication, ServiceProvider sharedApplication) {

--- a/pom.xml
+++ b/pom.xml
@@ -570,7 +570,7 @@
         <carbon.multitenancy.package.import.version.range>[4.7.0,5.0.0)
         </carbon.multitenancy.package.import.version.range>
 
-        <carbon.identity.framework.version>7.7.95</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.7.213</carbon.identity.framework.version>
         <carbon.identity.package.import.version.range>[5.20.0, 8.0.0)
         </carbon.identity.package.import.version.range>
 


### PR DESCRIPTION
## Purpose
This PR implements the `doPostGetApplicationWithRequiredAttributes` method in the `FragmentApplicationMgtListener`. If the retrieving application is a shared app and if the main application is a discoverable application, inherit that to the shared application.

Dependent on
- https://github.com/wso2/carbon-identity-framework/pull/6462

### Related issue
- https://github.com/wso2/product-is/issues/22556