### PR TITLE
Skip user sharing for users who are not managed by the sharing-initiated organization

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImpl.java
@@ -1018,14 +1018,14 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
         }
     }
 
-    private boolean isResidentUserInOrg(String userID, String orgId) {
+    private boolean isResidentUserInOrg(String userId, String orgId) {
 
         try {
             String tenantDomain = getOrganizationManager().resolveTenantDomain(orgId);
             int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
             AbstractUserStoreManager userStoreManager = getAbstractUserStoreManager(tenantId);
             String associatedOrgId =
-                    OrganizationSharedUserUtil.getUserManagedOrganizationClaim(userStoreManager, userID);
+                    OrganizationSharedUserUtil.getUserManagedOrganizationClaim(userStoreManager, userId);
             return associatedOrgId == null;
         } catch (UserStoreException | OrganizationManagementException e) {
             LOG.error("Error occurred while checking if the user is a resident user in the organization.", e);

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImpl.java
@@ -490,7 +490,7 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
 
         for (String associatedUserId : userIds.getIds()) {
             try {
-                if (!isResidentUserInOrg(associatedUserId, sharingInitiatedOrgId)) {
+                if (isNotResidentUserInOrg(associatedUserId, sharingInitiatedOrgId)) {
                     LOG.warn(String.format(LOG_WARN_NON_RESIDENT_USER, associatedUserId, sharingInitiatedOrgId));
                     continue;
                 }
@@ -606,7 +606,7 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
 
         for (String associatedUserId : userIds.getIds()) {
             try {
-                if (!isResidentUserInOrg(associatedUserId, sharingInitiatedOrgId)) {
+                if (isNotResidentUserInOrg(associatedUserId, sharingInitiatedOrgId)) {
                     LOG.warn(String.format(LOG_WARN_NON_RESIDENT_USER, associatedUserId, sharingInitiatedOrgId));
                     continue;
                 }
@@ -1018,7 +1018,7 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
         }
     }
 
-    private boolean isResidentUserInOrg(String userId, String orgId) {
+    private boolean isNotResidentUserInOrg(String userId, String orgId) {
 
         try {
             String tenantDomain = getOrganizationManager().resolveTenantDomain(orgId);
@@ -1026,10 +1026,10 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
             AbstractUserStoreManager userStoreManager = getAbstractUserStoreManager(tenantId);
             String associatedOrgId =
                     OrganizationSharedUserUtil.getUserManagedOrganizationClaim(userStoreManager, userId);
-            return associatedOrgId == null;
+            return associatedOrgId != null;
         } catch (UserStoreException | OrganizationManagementException e) {
             LOG.error("Error occurred while checking if the user is a resident user in the organization.", e);
-            return false;
+            return true;
         }
     }
 

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/constant/UserSharingConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/constant/UserSharingConstants.java
@@ -61,6 +61,8 @@ public class UserSharingConstants {
 
     public static final String LOG_WARN_SKIP_ORG_SHARE_MESSAGE =
             "Skipping user share for organizations that are not immediate children: %s";
+    public static final String LOG_WARN_NON_RESIDENT_USER =
+            "Skipping user share for user: %s since the user is not managed by the sharing initiated org: %s";
 
     public static final String DEFAULT_PROFILE = "default";
     public static final String CLAIM_MANAGED_ORGANIZATION = "http://wso2.org/claims/identity/managedOrg";


### PR DESCRIPTION
## Purpose
User sharing is only supported for users who are managed by the sharing-initiated organization. Previously, attempts to share users not managed by the initiating organization caused failures, especially during new organization creation. This fix ensures that only eligible users are considered for sharing, preventing unnecessary errors.

## Goals
- Enforce the rule that only users managed by the sharing-initiated organization can be shared.
- Prevent failures caused by attempting to share users outside the initiating organization.
- Improve system stability by skipping unsupported user-sharing scenarios.

## Approach
- Added a validation to allow sharing only for users managed by the sharing-initiated organization.
- Skipped sharing for users outside the initiating organization.
- Logged a warning when a non-managed user is encountered.

---

## Related Issue

[Sharing a shared user (resharing) is not properly handled #22884](https://github.com/wso2/product-is/issues/22884)