### PR TITLE
Handle org session termination when root session is terminated

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.handler/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.handler/pom.xml
@@ -41,6 +41,15 @@
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.orbit.com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.wso2.carbon</groupId>
             <artifactId>org.wso2.carbon.user.core</artifactId>
         </dependency>
@@ -85,8 +94,20 @@
             <artifactId>org.wso2.carbon.identity.central.log.mgt</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.identity.organization.management</groupId>
             <artifactId>org.wso2.carbon.identity.organization.resource.sharing.policy.management</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
+            <artifactId>org.wso2.carbon.identity.oauth</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.outbound.auth.oidc</groupId>
+            <artifactId>org.wso2.carbon.identity.application.authenticator.oidc</artifactId>
         </dependency>
         <!--Test Dependencies-->
         <dependency>
@@ -165,6 +186,15 @@
                             version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
                             org.wso2.carbon.identity.organization.resource.sharing.policy.management.exception;
                             version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.application.authentication.framework.*;
+                            version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.base;version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.application.authenticator.oidc.*;
+                            version="${identity.outbound.auth.oidc.import.version.range}",
+                            org.wso2.carbon.identity.oauth.common;
+                            version="${identity.inbound.auth.oauth.import.version.range}",
+                            com.nimbusds.jose.*; version="${nimbusds.osgi.version.range}",
+                            net.minidev.json; version="${net.minidev.json.imp.pkg.version.range}",
                         </Import-Package>
                     </instructions>
                 </configuration>

--- a/components/org.wso2.carbon.identity.organization.management.handler/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.handler/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+  ~ Copyright (c) 2023-2025, WSO2 LLC. (http://www.wso2.com).
   ~
   ~ WSO2 LLC. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/OrganizationSessionHandler.java
+++ b/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/OrganizationSessionHandler.java
@@ -21,6 +21,8 @@ package org.wso2.carbon.identity.organization.management.handler;
 import com.nimbusds.jose.util.JSONObjectUtils;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.application.authentication.framework.AuthenticatorStateInfo;
 import org.wso2.carbon.identity.application.authentication.framework.UserSessionManagementService;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.AuthenticatorConfig;
@@ -51,6 +53,8 @@ import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCClaims.ID
  */
 public class OrganizationSessionHandler extends AbstractEventHandler {
 
+    private static final Log LOG = LogFactory.getLog(OrganizationSessionHandler.class);
+
     @Override
     public void handleEvent(Event event) throws IdentityEventException {
 
@@ -61,8 +65,7 @@ public class OrganizationSessionHandler extends AbstractEventHandler {
         }
     }
 
-    private void handleOrgSessionTerminate(Map<String, Object> eventProperties)
-            throws IdentityEventException {
+    private void handleOrgSessionTerminate(Map<String, Object> eventProperties) {
 
         try {
             UserSessionManagementService userSessionManagementService = OrganizationManagementHandlerDataHolder
@@ -107,11 +110,13 @@ public class OrganizationSessionHandler extends AbstractEventHandler {
                 userSessionManagementService.terminateSessionBySessionId(userId, sessionId);
             }
         } catch (SessionManagementException | UserIdNotFoundException e) {
-            throw new IdentityEventException("Error while terminating the org session.", e);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Error while terminating the org session.", e);
+            }
         }
     }
 
-    private String getSessionId(String idToken) throws IdentityEventException {
+    private String getSessionId(String idToken) {
 
         String base64Body = idToken.split("\\.")[1];
         byte[] decoded = Base64.getDecoder().decode(base64Body);
@@ -124,7 +129,9 @@ public class OrganizationSessionHandler extends AbstractEventHandler {
                 }
             }
         } catch (ParseException e) {
-            throw new IdentityEventException("Error while parsing the JWT token.", e);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Error while parsing the ID token.", e);
+            }
         }
         return null;
     }

--- a/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/OrganizationSessionHandler.java
+++ b/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/OrganizationSessionHandler.java
@@ -90,6 +90,7 @@ public class OrganizationSessionHandler extends AbstractEventHandler {
                         String idTokenHint = oidcStateInfo.getIdTokenHint();
                         // Resolve session ID by `isk` claim in ID token hint.
                         sessionId = getSessionId(idTokenHint);
+                        break;
                     }
                 }
             }

--- a/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/OrganizationSessionHandler.java
+++ b/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/OrganizationSessionHandler.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.management.handler;
+
+import com.nimbusds.jose.util.JSONObjectUtils;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.identity.application.authentication.framework.AuthenticatorStateInfo;
+import org.wso2.carbon.identity.application.authentication.framework.UserSessionManagementService;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.AuthenticatorConfig;
+import org.wso2.carbon.identity.application.authentication.framework.context.SessionContext;
+import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
+import org.wso2.carbon.identity.application.authentication.framework.exception.session.mgt.SessionManagementException;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedIdPData;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+import org.wso2.carbon.identity.application.authenticator.oidc.model.OIDCStateInfo;
+import org.wso2.carbon.identity.event.IdentityEventConstants;
+import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.event.event.Event;
+import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
+import org.wso2.carbon.identity.organization.management.handler.internal.OrganizationManagementHandlerDataHolder;
+
+import java.nio.charset.StandardCharsets;
+import java.text.ParseException;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCClaims.IDP_SESSION_KEY;
+
+/**
+ * Event handler to handle organization sessions.
+ */
+public class OrganizationSessionHandler extends AbstractEventHandler {
+
+    @Override
+    public void handleEvent(Event event) throws IdentityEventException {
+
+        String eventName = event.getEventName();
+        Map<String, Object> eventProperties = event.getEventProperties();
+        if (IdentityEventConstants.EventName.SESSION_TERMINATE.name().equals(eventName)) {
+            handleOrgSessionTerminate(eventProperties);
+        }
+    }
+
+    private void handleOrgSessionTerminate(Map<String, Object> eventProperties)
+            throws IdentityEventException {
+
+        try {
+            UserSessionManagementService userSessionManagementService = OrganizationManagementHandlerDataHolder
+                    .getInstance().getUserSessionManagementService();
+
+            SessionContext sessionContext = (SessionContext) eventProperties.get(
+                    IdentityEventConstants.EventProperty.SESSION_CONTEXT);
+            Map<String, AuthenticatedIdPData> authenticatedIdPs = sessionContext.getAuthenticatedIdPs();
+            if (authenticatedIdPs == null ||
+                    !authenticatedIdPs.containsKey(FrameworkConstants.ORGANIZATION_LOGIN_IDP_NAME)) {
+                return;
+            }
+            AuthenticatedIdPData authenticatedIdPData =
+                    authenticatedIdPs.get(FrameworkConstants.ORGANIZATION_LOGIN_IDP_NAME);
+            List<AuthenticatorConfig> authenticators = authenticatedIdPData.getAuthenticators();
+            if (CollectionUtils.isEmpty(authenticators)) {
+                return;
+            }
+            String sessionId = null;
+            for (AuthenticatorConfig authenticator : authenticators) {
+                if (authenticator.getName().equals(FrameworkConstants.ORGANIZATION_AUTHENTICATOR)) {
+                    AuthenticatorStateInfo authenticatorStateInfo = authenticator.getAuthenticatorStateInfo();
+                    if (authenticatorStateInfo instanceof OIDCStateInfo) {
+                        OIDCStateInfo oidcStateInfo = (OIDCStateInfo) authenticatorStateInfo;
+                        String idTokenHint = oidcStateInfo.getIdTokenHint();
+                        // Resolve session ID by `isk` claim in ID token hint.
+                        sessionId = getSessionId(idTokenHint);
+                    }
+                }
+            }
+
+            Map<String, Object> params = (Map<String, Object>) eventProperties.get(
+                    IdentityEventConstants.EventProperty.PARAMS);
+            if (params == null || !params.containsKey(FrameworkConstants.AnalyticsAttributes.USER)) {
+                return;
+            }
+            AuthenticatedUser authenticatedUser = (AuthenticatedUser) params.get(
+                    FrameworkConstants.AnalyticsAttributes.USER);
+            String userId = authenticatedUser.getUserId();
+            if (StringUtils.isNotBlank(sessionId)) {
+                userSessionManagementService.terminateSessionBySessionId(userId, sessionId);
+            }
+        } catch (SessionManagementException | UserIdNotFoundException e) {
+            throw new IdentityEventException("Error while terminating the org session.", e);
+        }
+    }
+
+    private String getSessionId(String idToken) throws IdentityEventException {
+
+        String base64Body = idToken.split("\\.")[1];
+        byte[] decoded = Base64.getDecoder().decode(base64Body);
+        try {
+            Set<Map.Entry<String, Object>> jwtAttributeSet =
+                    JSONObjectUtils.parse(new String(decoded, StandardCharsets.UTF_8)).entrySet();
+            for (Map.Entry<String, Object> entry : jwtAttributeSet) {
+                if (StringUtils.equals(IDP_SESSION_KEY, entry.getKey())) {
+                    return String.valueOf(entry.getValue());
+                }
+            }
+        } catch (ParseException e) {
+            throw new IdentityEventException("Error while parsing the JWT token.", e);
+        }
+        return null;
+    }
+}

--- a/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/OrganizationSessionHandler.java
+++ b/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/OrganizationSessionHandler.java
@@ -83,7 +83,7 @@ public class OrganizationSessionHandler extends AbstractEventHandler {
             }
             String sessionId = null;
             for (AuthenticatorConfig authenticator : authenticators) {
-                if (authenticator.getName().equals(FrameworkConstants.ORGANIZATION_AUTHENTICATOR)) {
+                if (FrameworkConstants.ORGANIZATION_AUTHENTICATOR.equals(authenticator.getName())) {
                     AuthenticatorStateInfo authenticatorStateInfo = authenticator.getAuthenticatorStateInfo();
                     if (authenticatorStateInfo instanceof OIDCStateInfo) {
                         OIDCStateInfo oidcStateInfo = (OIDCStateInfo) authenticatorStateInfo;

--- a/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/internal/OrganizationManagementHandlerDataHolder.java
+++ b/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/internal/OrganizationManagementHandlerDataHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/internal/OrganizationManagementHandlerDataHolder.java
+++ b/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/internal/OrganizationManagementHandlerDataHolder.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.organization.management.handler.internal;
 
+import org.wso2.carbon.identity.application.authentication.framework.UserSessionManagementService;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.governance.IdentityGovernanceService;
@@ -43,6 +44,7 @@ public class OrganizationManagementHandlerDataHolder {
     private ApplicationManagementService applicationManagementService;
     private RealmService realmService;
     private ResourceSharingPolicyHandlerService resourceSharingPolicyHandlerService;
+    private UserSessionManagementService userSessionManagementService;
 
     public static OrganizationManagementHandlerDataHolder getInstance() {
 
@@ -209,6 +211,26 @@ public class OrganizationManagementHandlerDataHolder {
             ResourceSharingPolicyHandlerService resourceSharingPolicyHandlerService) {
 
         this.resourceSharingPolicyHandlerService = resourceSharingPolicyHandlerService;
+    }
+
+    /**
+     * Get {@link UserSessionManagementService}.
+     *
+     * @return UserSessionManagementService {@link UserSessionManagementService}.
+     */
+    public UserSessionManagementService getUserSessionManagementService() {
+
+        return userSessionManagementService;
+    }
+
+    /**
+     * Set {@link UserSessionManagementService}.
+     *
+     * @param userSessionManagementService Instance of {@link UserSessionManagementService}.
+     */
+    public void setUserSessionManagementService(UserSessionManagementService userSessionManagementService) {
+
+        this.userSessionManagementService = userSessionManagementService;
     }
 }
 

--- a/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/internal/OrganizationManagementHandlerServiceComponent.java
+++ b/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/internal/OrganizationManagementHandlerServiceComponent.java
@@ -27,6 +27,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
+import org.wso2.carbon.identity.application.authentication.framework.UserSessionManagementService;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.application.mgt.listener.ApplicationMgtListener;
 import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
@@ -34,6 +35,7 @@ import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.governance.IdentityGovernanceService;
 import org.wso2.carbon.identity.organization.management.application.OrgApplicationManager;
 import org.wso2.carbon.identity.organization.management.handler.GovernanceConfigUpdateHandler;
+import org.wso2.carbon.identity.organization.management.handler.OrganizationSessionHandler;
 import org.wso2.carbon.identity.organization.management.handler.SharedRoleMgtHandler;
 import org.wso2.carbon.identity.organization.management.handler.SharingPolicyCleanUpHandler;
 import org.wso2.carbon.identity.organization.management.handler.listener.SharedRoleMgtListener;
@@ -67,6 +69,7 @@ public class OrganizationManagementHandlerServiceComponent {
             bundleContext.registerService(AbstractEventHandler.class, new SharedRoleMgtHandler(), null);
             bundleContext.registerService(ApplicationMgtListener.class.getName(), new SharedRoleMgtListener(), null);
             bundleContext.registerService(AbstractEventHandler.class, new SharingPolicyCleanUpHandler(), null);
+            bundleContext.registerService(AbstractEventHandler.class, new OrganizationSessionHandler(), null);
             LOG.debug("Organization management handler component activated successfully.");
         } catch (Throwable e) {
             LOG.error("Error while activating organization management handler module.", e);
@@ -212,5 +215,25 @@ public class OrganizationManagementHandlerServiceComponent {
             ResourceSharingPolicyHandlerService resourceSharingPolicyHandlerService) {
 
         OrganizationManagementHandlerDataHolder.getInstance().setResourceSharingPolicyHandlerService(null);
+    }
+
+    @Reference(
+            name = "org.wso2.carbon.identity.application.authentication.framework.UserSessionManagementService",
+            service = org.wso2.carbon.identity.application.authentication.framework.UserSessionManagementService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetUserSessionManagementService"
+    )
+    protected void setUserSessionManagementService(UserSessionManagementService userSessionManagementService) {
+
+        OrganizationManagementHandlerDataHolder.getInstance().setUserSessionManagementService(
+                userSessionManagementService);
+        LOG.debug("UserSessionManagementService set in OrganizationManagementHandlerService bundle.");
+    }
+
+    protected void unsetUserSessionManagementService(UserSessionManagementService userSessionManagementService) {
+
+        OrganizationManagementHandlerDataHolder.getInstance().setUserSessionManagementService(null);
+        LOG.debug("UserSessionManagementService unset in OrganizationManagementHandlerService bundle.");
     }
 }

--- a/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/internal/OrganizationManagementHandlerServiceComponent.java
+++ b/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/internal/OrganizationManagementHandlerServiceComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2023-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,16 @@
                 <artifactId>pax-logging-api</artifactId>
                 <version>${pax.logging.api.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.orbit.com.nimbusds</groupId>
+                <artifactId>nimbus-jose-jwt</artifactId>
+                <version>${nimbusds.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.minidev</groupId>
+                <artifactId>json-smart</artifactId>
+                <version>${json-smart.version}</version>
+            </dependency>
 
             <!-- Kernel Dependencies -->
             <dependency>
@@ -250,6 +260,11 @@
                 <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
                 <artifactId>org.wso2.carbon.identity.oauth</artifactId>
                 <version>${identity.inbound.auth.oauth.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.outbound.auth.oidc</groupId>
+                <artifactId>org.wso2.carbon.identity.application.authenticator.oidc</artifactId>
+                <version>${identity.outbound.auth.oidc.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon</groupId>
@@ -557,6 +572,11 @@
         <apache.felix.scr.ds.annotations.version>1.2.4</apache.felix.scr.ds.annotations.version>
         <pax.logging.api.version>1.10.1</pax.logging.api.version>
 
+        <nimbusds.version>7.3.0.wso2v1</nimbusds.version>
+        <nimbusds.osgi.version.range>[7.3.0,8.0.0)</nimbusds.osgi.version.range>
+        <json-smart.version>2.4.9</json-smart.version>
+        <net.minidev.json.imp.pkg.version.range>[2.3.0, 3.0.0)</net.minidev.json.imp.pkg.version.range>
+
         <identity.organization.management.exp.pkg.version>${project.version}
         </identity.organization.management.exp.pkg.version>
         <org.wso2.identity.organization.mgt.imp.pkg.version.range>[1.0.0,2.0.0)
@@ -578,8 +598,8 @@
         <identity.extension.utils.import.version.range>[1.0.8, 2.0.0)</identity.extension.utils.import.version.range>
         <identity.inbound.auth.oauth.version>7.0.155</identity.inbound.auth.oauth.version>
         <identity.inbound.auth.oauth.import.version.range>[6.11.66, 8.0.0)</identity.inbound.auth.oauth.import.version.range>
-        <identity.outbound.auth.oidc.version>5.7.2</identity.outbound.auth.oidc.version>
-        <identity.outbound.auth.oidc.import.version.range>[5.7.2, 5.8.0)</identity.outbound.auth.oidc.import.version.range>
+        <identity.outbound.auth.oidc.version>5.12.15</identity.outbound.auth.oidc.version>
+        <identity.outbound.auth.oidc.import.version.range>[5.7.2, 6.0.0)</identity.outbound.auth.oidc.import.version.range>
         <org.wso2.carbon.identity.governance.version>1.8.39</org.wso2.carbon.identity.governance.version>
         <identity.governance.imp.pkg.version.range>[1.0.0,3.0.0)</identity.governance.imp.pkg.version.range>
 


### PR DESCRIPTION
## Purpose
> Currently, when root organization session of a sub org user is terminated, sub organization session does not get terminated. With this PR, event handler is introduced to handle the sub organization session termination.

Related Issue - https://github.com/wso2/product-is/issues/22310