### PR TITLE
Fix Issue with Overwriting Previously Shared Organizations in Selective User Sharing

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/OrganizationUserSharingService.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/OrganizationUserSharingService.java
@@ -221,14 +221,26 @@ public interface OrganizationUserSharingService {
      *
      * @param associatedUserId The ID of the associated user.
      * @param orgIds           The list of organization IDs.
-     * @param sharedType       The type of sharing relationship to filter the associations.
      * @return The list of {@link UserAssociation}s for the given user in the specified organizations.
      * @throws OrganizationManagementServerException If an error occurs while retrieving the user associations.
      */
     default List<UserAssociation> getUserAssociationsOfGivenUserOnGivenOrgs(String associatedUserId,
-                                                                            List<String> orgIds, SharedType sharedType)
+                                                                            List<String> orgIds)
             throws OrganizationManagementServerException {
 
         throw new NotImplementedException("getUserAssociationsOfGivenUserOnGivenOrgs method is not implemented.");
+    }
+
+    /**
+     * Updates the shared type of user association.
+     *
+     * @param id         The ID of the user association.
+     * @param sharedType The new shared type to be set for the user association.
+     * @throws OrganizationManagementServerException If an error occurs while updating the shared type.
+     */
+    default void updateSharedTypeOfUserAssociation(int id, SharedType sharedType)
+            throws OrganizationManagementServerException {
+
+        throw new NotImplementedException("updateSharedTypeOfUserAssociation method is not implemented.");
     }
 }

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/OrganizationUserSharingService.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/OrganizationUserSharingService.java
@@ -24,6 +24,7 @@ import org.wso2.carbon.identity.organization.management.organization.user.sharin
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.models.UserAssociation;
 import org.wso2.carbon.identity.organization.management.service.exception.NotImplementedException;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementServerException;
 import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementException;
 
 import java.util.List;
@@ -213,5 +214,21 @@ public interface OrganizationUserSharingService {
             throws UserSharingMgtException {
 
         throw new NotImplementedException("getRolesSharedWithUserInOrganization method is not implemented.");
+    }
+
+    /**
+     * Get the user associations of the associated user in the given organizations.
+     *
+     * @param associatedUserId The ID of the associated user.
+     * @param orgIds           The list of organization IDs.
+     * @param sharedType       The type of sharing relationship to filter the associations.
+     * @return The list of {@link UserAssociation}s for the given user in the specified organizations.
+     * @throws OrganizationManagementServerException If an error occurs while retrieving the user associations.
+     */
+    default List<UserAssociation> getUserAssociationsOfGivenUserOnGivenOrgs(String associatedUserId,
+                                                                            List<String> orgIds, SharedType sharedType)
+            throws OrganizationManagementServerException {
+
+        throw new NotImplementedException("getUserAssociationsOfGivenUserOnGivenOrgs method is not implemented.");
     }
 }

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/OrganizationUserSharingServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/OrganizationUserSharingServiceImpl.java
@@ -173,12 +173,17 @@ public class OrganizationUserSharingServiceImpl implements OrganizationUserShari
     }
 
     @Override
-    public List<UserAssociation> getUserAssociationsOfGivenUserOnGivenOrgs(String associatedUserId, List<String> orgIds,
-                                                                           SharedType sharedType)
+    public List<UserAssociation> getUserAssociationsOfGivenUserOnGivenOrgs(String associatedUserId, List<String> orgIds)
             throws OrganizationManagementServerException {
 
-        return organizationUserSharingDAO.getUserAssociationsOfGivenUserOnGivenOrgs(associatedUserId, orgIds,
-                sharedType);
+        return organizationUserSharingDAO.getUserAssociationsOfGivenUserOnGivenOrgs(associatedUserId, orgIds);
+    }
+
+    @Override
+    public void updateSharedTypeOfUserAssociation(int id, SharedType sharedType)
+            throws OrganizationManagementServerException {
+
+        organizationUserSharingDAO.updateSharedTypeOfUserAssociation(id, sharedType);
     }
 
     private AbstractUserStoreManager getAbstractUserStoreManager(int tenantId) throws UserStoreException {

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/OrganizationUserSharingServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/OrganizationUserSharingServiceImpl.java
@@ -32,6 +32,7 @@ import org.wso2.carbon.identity.organization.management.organization.user.sharin
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.models.UserAssociation;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementServerException;
 import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementException;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.api.UserStoreException;
@@ -169,6 +170,15 @@ public class OrganizationUserSharingServiceImpl implements OrganizationUserShari
             throws UserSharingMgtException {
 
         return organizationUserSharingDAO.getRolesSharedWithUserInOrganization(username, tenantId, domainName);
+    }
+
+    @Override
+    public List<UserAssociation> getUserAssociationsOfGivenUserOnGivenOrgs(String associatedUserId, List<String> orgIds,
+                                                                           SharedType sharedType)
+            throws OrganizationManagementServerException {
+
+        return organizationUserSharingDAO.getUserAssociationsOfGivenUserOnGivenOrgs(associatedUserId, orgIds,
+                sharedType);
     }
 
     private AbstractUserStoreManager getAbstractUserStoreManager(int tenantId) throws UserStoreException {

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImpl.java
@@ -540,6 +540,17 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
         return getOrgsToShareUserWith(sharingInitiatedOrgId, userShare.getPolicy());
     }
 
+    /**
+     * Retrieves the user associations of a given user within the organization tree.
+     * The root organization of the tree is the policy-holding organization.
+     * This method takes a base share object, which contains the policy-holding organization for the share,
+     * and retrieves the user associations for the organizations in that tree.
+     *
+     * @param userShare The user share object, which can be either selective or general.
+     * @param sharingInitiatedOrgId The ID of the organization from which the sharing request was initiated.
+     * @return A list of user associations within the organization tree.
+     * @throws OrganizationManagementException If an error occurs while retrieving the user associations.
+     */
     private List<UserAssociation> getUserAssociationsOfGivenUserOnOrgTree(BaseUserShare userShare,
                                                                           String sharingInitiatedOrgId)
             throws OrganizationManagementException {

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImpl.java
@@ -330,8 +330,16 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
         }
     }
 
-    //Methods for asynchronously process user sharing and unsharing.
+    //Asynchronous Processing Methods.
 
+    /**
+     * Processes selective user sharing based on the provided user criteria and organization details.
+     * This method iterates over the user criteria map and shares users selectively with the specified organizations.
+     *
+     * @param userCriteria         A map containing user criteria, such as user IDs.
+     * @param organizations        A list of organizations to which users will be shared selectively.
+     * @param sharingInitiatedOrgId The ID of the organization that initiated the user sharing.
+     */
     private void processSelectiveUserShare(Map<String, UserCriteriaType> userCriteria,
                                            List<SelectiveUserShareOrgDetailsDO> organizations,
                                            String sharingInitiatedOrgId) {
@@ -362,6 +370,15 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
         }
     }
 
+    /**
+     * Processes general user sharing based on the provided user criteria and sharing policy.
+     * This method iterates over the user criteria map and shares users according to the specified policy.
+     *
+     * @param userCriteria         A map containing user criteria, such as user IDs.
+     * @param policy               The sharing policy defining the scope of sharing.
+     * @param roleIds              A list of role IDs to be assigned during sharing.
+     * @param sharingInitiatedOrgId The ID of the organization that initiated the user sharing.
+     */
     private void processGeneralUserShare(Map<String, UserCriteriaType> userCriteria, PolicyEnum policy,
                                          List<String> roleIds, String sharingInitiatedOrgId) {
 
@@ -391,6 +408,14 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
         }
     }
 
+    /**
+     * Processes selective user unsharing based on the provided user criteria and organization details.
+     * This method iterates over the user criteria map and unshare users selectively from the specified organizations.
+     *
+     * @param userCriteria         A map containing user criteria, such as user IDs.
+     * @param organizations        A list of organizations from which users will be unshared selectively.
+     * @param sharingInitiatedOrgId The ID of the organization that initiated the user unsharing.
+     */
     private void processSelectiveUserUnshare(Map<String, UserCriteriaType> userCriteria, List<String> organizations,
                                              String sharingInitiatedOrgId) {
 
@@ -420,6 +445,13 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
         }
     }
 
+    /**
+     * Processes general user unsharing based on the provided user criteria.
+     * This method iterates over the user criteria map and unshare users from all associated organizations.
+     *
+     * @param userCriteria         A map containing user criteria, such as user IDs.
+     * @param sharingInitiatedOrgId The ID of the organization that initiated the user unsharing.
+     */
     private void processGeneralUserUnshare(Map<String, UserCriteriaType> userCriteria, String sharingInitiatedOrgId) {
 
         try {
@@ -447,8 +479,17 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
         }
     }
 
-    //Methods for sharing and unsharing users by user Ids.
+    //User Sharing & Unsharing Helper Methods.
 
+    /**
+     * Shares a user with selected organizations based on the provided user list and sharing policies.
+     * If the user is not a resident user in the initiating organization, the sharing is skipped.
+     * Each organization is processed with the appropriate role and policy before sharing.
+     *
+     * @param userIds               The list of user IDs to be selectively shared.
+     * @param organizations         The list of organizations where the user should be shared.
+     * @param sharingInitiatedOrgId The ID of the organization that initiated the sharing.
+     */
     private void selectiveUserShareByUserIds(UserIdList userIds, List<SelectiveUserShareOrgDetailsDO> organizations,
                                              String sharingInitiatedOrgId)
             throws UserSharingMgtException {
@@ -480,6 +521,15 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
         }
     }
 
+    /**
+     * Shares a user with all applicable organizations based on the provided policy.
+     * If the user is not a resident user in the initiating organization, the sharing is skipped.
+     *
+     * @param userIds               The list of user IDs to be shared.
+     * @param policy                The policy defining the scope of sharing.
+     * @param roleIds               The list of role IDs to be assigned during sharing.
+     * @param sharingInitiatedOrgId The ID of the organization that initiated the sharing.
+     */
     private void generalUserShareByUserIds(UserIdList userIds, PolicyEnum policy, List<String> roleIds,
                                            String sharingInitiatedOrgId)
             throws UserSharingMgtException {
@@ -505,6 +555,14 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
         }
     }
 
+    /**
+     * Unshare a user from selected organizations based on the provided user list.
+     * If a resource-sharing policy exists for the user, it is deleted.
+     *
+     * @param userIds               The list of user IDs to be unshared.
+     * @param organizations         The list of organizations from which the user should be unshared.
+     * @param unsharingInitiatedOrgId The ID of the organization that initiated the unsharing.
+     */
     private void selectiveUserUnshareByUserIds(UserIdList userIds, List<String> organizations,
                                                String unsharingInitiatedOrgId)
             throws UserSharingMgtServerException {
@@ -525,6 +583,13 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
         }
     }
 
+    /**
+     * Unshare a user from all applicable organizations based on the provided user list.
+     * If a resource-sharing policy exists for the user, it is deleted.
+     *
+     * @param userIds               The list of user IDs to be unshared.
+     * @param unsharingInitiatedOrgId The ID of the organization that initiated the unsharing.
+     */
     private void generalUserUnshareByUserIds(UserIdList userIds, String unsharingInitiatedOrgId)
             throws UserSharingMgtServerException {
 
@@ -541,8 +606,15 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
         }
     }
 
-    //Methods containing main business logic.
+    //Business Logic Methods.
 
+    /**
+     * Shares a user with the specified organizations.
+     *
+     * @param associatedUserId       The ID of the user to be shared.
+     * @param baseUserShareObjects   The list of user share objects containing sharing details.
+     * @param sharingInitiatedOrgId  The ID of the organization initiating the sharing.
+     */
     private void shareUser(String associatedUserId, List<BaseUserShare> baseUserShareObjects,
                            String sharingInitiatedOrgId)
             throws OrganizationManagementException, UserSharingMgtException, IdentityRoleManagementException,
@@ -561,6 +633,14 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
         }
     }
 
+    /**
+     * Creates a new user share by sharing the user with the specified organizations based on the sharing policy of
+     * each user share object and saving the sharing policy if applicable.
+     *
+     * @param sharingInitiatedOrgId The ID of the organization initiating the sharing.
+     * @param userSharingOrgsForEachUserShareObject A map containing user share objects and their corresponding
+     *                                              organizations.
+     */
     private void createNewUserShare(String sharingInitiatedOrgId,
                                     Map<BaseUserShare, List<String>> userSharingOrgsForEachUserShareObject)
             throws OrganizationManagementException, UserSharingMgtException, IdentityRoleManagementException,
@@ -577,6 +657,15 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
         }
     }
 
+    /**
+     * Handles the case where the user is already shared with some organizations. It updates the sharing details
+     * and roles for the user in the specified organizations and cleans up old associations if necessary.
+     *
+     * @param associatedUserId The ID of the user to be shared.
+     * @param sharingInitiatedOrgId The ID of the organization initiating the sharing.
+     * @param userSharingOrgsForEachUserShareObject A map containing user share objects and their corresponding
+     *                                              organizations.
+     */
     private void handleExistingSharedUser(String associatedUserId, String sharingInitiatedOrgId,
                                           Map<BaseUserShare, List<String>> userSharingOrgsForEachUserShareObject)
             throws UserSharingMgtException, IdentityRoleManagementException, OrganizationManagementException,
@@ -607,10 +696,17 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
             shareWithNewOrganizations(baseUserShare, sharingInitiatedOrgId, userSharingOrgList, retainedSharedOrgs);
             updateResourceSharingPolicy(entry.getKey(), sharingInitiatedOrgId);
         }
-
         cleanUpOldUserAssociationsIfExists(associatedUserId, sharingInitiatedOrgId, userSharingAllOrgs);
     }
 
+    /**
+     * Retrieves a map of user share objects and their corresponding organizations to share user based on the sharing
+     * policy and type.
+     *
+     * @param baseUserShareObjects The list of user share objects containing sharing details.
+     * @param sharingInitiatedOrgId The ID of the organization initiating the sharing.
+     * @return A map containing user share objects and their corresponding organizations.
+     */
     private Map<BaseUserShare, List<String>> getUserSharingOrgsForEachUserShareObject(
             List<BaseUserShare> baseUserShareObjects, String sharingInitiatedOrgId)
             throws OrganizationManagementException {
@@ -623,6 +719,14 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
         return userSharingOrgsForEachUserShareObject;
     }
 
+    /**
+     * Extracts a list of organization with which the user is expected to be shared according to the given policy of
+     * the base user share object.
+     *
+     * @param baseUserShare The base user share object containing sharing details.
+     * @param sharingInitiatedOrgId The ID of the organization initiating the sharing.
+     * @return A list of organization IDs based on the sharing policy and type.
+     */
     private List<String> extractOrgListBasedOnSharingPolicyAndType(BaseUserShare baseUserShare,
                                                                    String sharingInitiatedOrgId)
             throws OrganizationManagementException {
@@ -635,326 +739,14 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
     }
 
     /**
-     * Retrieves the user associations of a given user within the organization tree.
-     * The root organization of the tree is the policy-holding organization.
-     * This method takes a base share object, which contains the policy-holding organization for the share,
-     * and retrieves the user associations for the organizations in that tree.
+     * Extracts a list of organizations based on the given sharing policy.
+     * Depending on the policy, this method retrieves child organizations that should be included
+     * in the user-sharing scope.
      *
-     * @param baseUserShare The user share object, which can be either selective or general.
-     * @param sharingInitiatedOrgId The ID of the organization from which the sharing request was initiated.
-     * @return A list of user associations within the organization tree.
-     * @throws OrganizationManagementException If an error occurs while retrieving the user associations.
+     * @param policyHoldingOrgId The ID of the organization holding the policy.
+     * @param policy            The sharing policy that determines which organizations to include.
+     * @return A list of organization IDs that should be included in the sharing scope.
      */
-    private List<UserAssociation> getUserAssociationsOfGivenUserOnOrgTree(BaseUserShare baseUserShare,
-                                                                          String sharingInitiatedOrgId)
-            throws OrganizationManagementException {
-
-        String associatedUserId = baseUserShare.getUserId();
-        String orgId = (baseUserShare instanceof SelectiveUserShare)
-                ? ((SelectiveUserShare) baseUserShare).getOrganizationId()
-                : sharingInitiatedOrgId;
-
-        List<String> orgsInOrgTree = getOrganizationManager().getChildOrganizationsIds(orgId, true);
-        orgsInOrgTree.add(orgId);
-
-        return getOrganizationUserSharingService().getUserAssociationsOfGivenUserOnGivenOrgs(associatedUserId,
-                orgsInOrgTree);
-    }
-
-    private void cleanUpOldUserAssociationsIfExists(String associatedUserId, String sharingInitiatedOrgId,
-                                                    List<String> userSharingAllOrgs)
-            throws OrganizationManagementException, UserSharingMgtException, ResourceSharingPolicyMgtException {
-
-        List<UserAssociation> allUserAssociations =
-                getSharedUserAssociationsOfGivenUser(associatedUserId, sharingInitiatedOrgId);
-        List<String> unsharedOrgs = new ArrayList<>();
-
-        for (UserAssociation association : allUserAssociations) {
-            if (!userSharingAllOrgs.contains(association.getOrganizationId())) {
-                unshareUserFromPreviousOrg(association, sharingInitiatedOrgId);
-                unsharedOrgs.add(association.getOrganizationId());
-            }
-        }
-
-        for (String unsharedOrg : unsharedOrgs) {
-            deleteResourceSharingPolicy(unsharedOrg, associatedUserId, sharingInitiatedOrgId);
-        }
-    }
-
-    private void updateSharedTypeOfExistingUserAssociation(UserAssociation association) {
-//todo: roles deletion lock
-        try {
-            if (SharedType.INVITED.equals(association.getSharedType())) {
-                getOrganizationUserSharingService().updateSharedTypeOfUserAssociation(association.getId(),
-                        SharedType.SHARED);
-            }
-        } catch (OrganizationManagementException e) {
-            LOG.error("Error occurred while converting the shared type of the user association of: " +
-                    association.getAssociatedUserId() + " from Invited to shared", e);
-        }
-    }
-
-    private void unshareUserFromPreviousOrg(UserAssociation association, String sharingInitiatedOrgId)
-            throws UserSharingMgtException {
-
-        selectiveUserUnshareByUserIds(new UserIdList(Collections.singletonList(association.getAssociatedUserId())),
-                Collections.singletonList(association.getOrganizationId()), sharingInitiatedOrgId);
-    }
-
-    private void shareWithNewOrganizations(BaseUserShare baseUserShare, String sharingInitiatedOrgId,
-                                           List<String> userSharingOrgList, List<String> alreadySharedOrgs)
-            throws OrganizationManagementException, UserSharingMgtException, IdentityRoleManagementException {
-
-        List<String> newlySharedOrgs = new ArrayList<>(userSharingOrgList);
-        newlySharedOrgs.removeAll(alreadySharedOrgs);
-
-        for (String orgId : newlySharedOrgs) {
-            shareAndAssignRolesIfPresent(orgId, baseUserShare, sharingInitiatedOrgId);
-        }
-    }
-
-    private List<String> getChildOrgsOfSharingInitiatedOrg(String sharingInitiatedOrgId)
-            throws UserSharingMgtServerException {
-
-        try {
-            return getOrganizationManager().getChildOrganizationsIds(getOrganizationId(), false);
-        } catch (OrganizationManagementException e) {
-            String errorMessage = String.format(
-                    ERROR_CODE_GET_IMMEDIATE_CHILD_ORGS.getMessage(), sharingInitiatedOrgId);
-            throw new UserSharingMgtServerException(ERROR_CODE_GET_IMMEDIATE_CHILD_ORGS, errorMessage);
-        }
-    }
-
-    private boolean hasRoleChanges(List<String> oldSharedRoleIds, List<String> newRoleIds) {
-
-        return !new HashSet<>(oldSharedRoleIds).equals(new HashSet<>(newRoleIds));
-    }
-
-    private void updateRolesIfNecessary(UserAssociation userAssociation, List<String> roleIds,
-                                        String sharingInitiatedOrgId)
-            throws OrganizationManagementException, IdentityRoleManagementException, UserSharingMgtException {
-
-        List<String> currentSharedRoleIds = getCurrentSharedRoleIdsForSharedUser(userAssociation);
-        List<String> newSharedRoleIds = getRolesToBeAddedAfterUpdate(userAssociation, currentSharedRoleIds, roleIds);
-
-        if (hasRoleChanges(currentSharedRoleIds, newSharedRoleIds)) {
-            assignRolesIfPresent(userAssociation, sharingInitiatedOrgId, newSharedRoleIds);
-        }
-    }
-
-    private List<String> getCurrentSharedRoleIdsForSharedUser(UserAssociation userAssociation)
-            throws OrganizationManagementException, IdentityRoleManagementException {
-
-        String userId = userAssociation.getUserId();
-        String orgId = userAssociation.getOrganizationId();
-        String tenantDomain = getOrganizationManager().resolveTenantDomain(orgId);
-
-        List<String> allUserRolesOfSharedUser = getRoleManagementService().getRoleIdListOfUser(userId, tenantDomain);
-
-        return getOrganizationUserSharingService().getSharedUserRolesFromUserRoles(allUserRolesOfSharedUser,
-                tenantDomain);
-    }
-
-    private void updateResourceSharingPolicy(BaseUserShare baseUserShare, String sharingInitiatedOrgId)
-            throws ResourceSharingPolicyMgtException {
-
-        //Delete old sharing policy.
-        removeResourceSharingPolicy(baseUserShare, sharingInitiatedOrgId);
-
-        //Create new sharing policy.
-        if (isApplicableOrganizationScopeForSavingPolicy(baseUserShare.getPolicy())) {
-            saveUserSharingPolicy(baseUserShare, sharingInitiatedOrgId);
-        }
-    }
-
-    private void removeResourceSharingPolicy(BaseUserShare baseUserShare, String sharingInitiatedOrgId)
-            throws ResourceSharingPolicyMgtException {
-
-        String policyHoldingOrgId =
-                baseUserShare instanceof SelectiveUserShare ? ((SelectiveUserShare) baseUserShare).getOrganizationId() :
-                        sharingInitiatedOrgId;
-
-        deleteResourceSharingPolicy(policyHoldingOrgId, baseUserShare.getUserId(), sharingInitiatedOrgId);
-    }
-
-    private void deleteResourceSharingPolicy(String policyHoldingOrgId, String associatedUserId,
-                                             String sharingInitiatedOrgId)
-            throws ResourceSharingPolicyMgtException {
-
-        getResourceSharingPolicyHandlerService().deleteResourceSharingPolicyInOrgByResourceTypeAndId(
-                policyHoldingOrgId, ResourceType.USER, associatedUserId, sharingInitiatedOrgId);
-    }
-
-    private void saveUserSharingPolicy(BaseUserShare baseUserShare, String sharingInitiatedOrgId)
-            throws ResourceSharingPolicyMgtException {
-
-        ResourceSharingPolicyHandlerService resourceSharingPolicyHandlerService =
-                getResourceSharingPolicyHandlerService();
-
-        ResourceSharingPolicy resourceSharingPolicy =
-                new ResourceSharingPolicy.Builder().withResourceType(ResourceType.USER)
-                        .withResourceId(baseUserShare.getUserId())
-                        .withInitiatingOrgId(sharingInitiatedOrgId)
-                        .withPolicyHoldingOrgId(getPolicyHoldingOrgId(baseUserShare, sharingInitiatedOrgId))
-                        .withSharingPolicy(baseUserShare.getPolicy()).build();
-
-        List<SharedResourceAttribute> sharedResourceAttributes = new ArrayList<>();
-        for (String roleId : baseUserShare.getRoles()) {
-            SharedResourceAttribute sharedResourceAttribute =
-                    new SharedResourceAttribute.Builder().withSharedAttributeType(SharedAttributeType.ROLE)
-                            .withSharedAttributeId(roleId).build();
-            sharedResourceAttributes.add(sharedResourceAttribute);
-        }
-
-        resourceSharingPolicyHandlerService.addResourceSharingPolicyWithAttributes(resourceSharingPolicy,
-                sharedResourceAttributes);
-
-    }
-
-    /**
-     * Determines the policy-holding organization ID based on the type of user share.
-     * For a selective user share, the policy-holding organization is the organization specified in the selective
-     * share request.
-     * For a general user share, the policy-holding organization is the organization from which the
-     * sharing request was initiated.
-     *
-     * @param baseUserShare             The user share object, which can be either selective or general.
-     * @param sharingInitiatedOrgId The ID of the organization from which the sharing request was initiated.
-     * @return The ID of the policy-holding organization based on the type of user share.
-     */
-    private String getPolicyHoldingOrgId(BaseUserShare baseUserShare, String sharingInitiatedOrgId) {
-
-        if (baseUserShare instanceof SelectiveUserShare) {
-            return ((SelectiveUserShare) baseUserShare).getOrganizationId();
-        } else {
-            return sharingInitiatedOrgId;
-        }
-    }
-
-    private boolean isApplicableOrganizationScopeForSavingPolicy(PolicyEnum policy) {
-
-        return OrganizationScope.EXISTING_ORGS_AND_FUTURE_ORGS_ONLY.equals(policy.getOrganizationScope()) ||
-                OrganizationScope.FUTURE_ORGS_ONLY.equals(policy.getOrganizationScope());
-    }
-
-    private void shareAndAssignRolesIfPresent(String orgId, BaseUserShare baseUserShare,
-                                              String sharingInitiatedOrgId)
-            throws OrganizationManagementException, IdentityRoleManagementException, UserSharingMgtException {
-
-        String associatedUserId = baseUserShare.getUserId();
-        List<String> roleIds = baseUserShare.getRoles();
-        UserAssociation userAssociation;
-
-        try {
-            userAssociation = shareUserWithOrganization(orgId, associatedUserId, sharingInitiatedOrgId);
-        } catch (OrganizationManagementException e) {
-            String errorMessage = String.format(ERROR_CODE_USER_SHARE.getMessage(), associatedUserId, e.getMessage());
-            LOG.error(errorMessage, e);
-            return;
-        }
-
-        //Assign roles if any are present.
-        assignRolesIfPresent(userAssociation, sharingInitiatedOrgId, roleIds);
-    }
-
-    private boolean isUserAlreadyShared(String associatedUserId, String associatedOrgId)
-            throws OrganizationManagementException {
-//todo: fetch single
-        List<UserAssociation> userAssociationsOfGivenUser =
-                getSharedUserAssociationsOfGivenUser(associatedUserId, associatedOrgId);
-
-        return userAssociationsOfGivenUser != null && !userAssociationsOfGivenUser.isEmpty();
-    }
-
-    private List<UserAssociation> getSharedUserAssociationsOfGivenUser(String associatedUserId, String associatedOrgId)
-            throws OrganizationManagementException {
-
-        return getOrganizationUserSharingService().getUserAssociationsOfGivenUser(associatedUserId, associatedOrgId);
-    }
-
-    private List<String> getRolesToBeAddedAfterUpdate(UserAssociation userAssociation, List<String> currentRoleIds,
-                                                      List<String> newRoleIds)
-            throws OrganizationManagementException, IdentityRoleManagementException {
-
-        // Roles to be added are those in newRoleIds that are not in currentRoleIds.
-        List<String> rolesToBeAdded = new ArrayList<>(newRoleIds);
-        rolesToBeAdded.removeAll(currentRoleIds);
-
-        // Roles to be removed are those in currentRoleIds that are not in newRoleIds.
-        List<String> rolesToBeRemoved = new ArrayList<>(currentRoleIds);
-        rolesToBeRemoved.removeAll(newRoleIds);
-
-        deleteOldSharedRoles(userAssociation, rolesToBeRemoved);
-        return rolesToBeAdded;
-    }
-
-    private void deleteOldSharedRoles(UserAssociation userAssociation, List<String> rolesToBeRemoved)
-            throws OrganizationManagementException, IdentityRoleManagementException {
-
-        String userId = userAssociation.getUserId();
-        String orgId = userAssociation.getOrganizationId();
-        String targetOrgTenantDomain = getOrganizationManager().resolveTenantDomain(orgId);
-
-        for (String roleId : rolesToBeRemoved) {
-            getRoleManagementService().updateUserListOfRole(roleId, Collections.emptyList(),
-                    Collections.singletonList(userId), targetOrgTenantDomain);
-        }
-    }
-
-    private void assignRolesIfPresent(UserAssociation userAssociation, String sharingInitiatedOrgId,
-                                      List<String> roleIds)
-            throws OrganizationManagementException, IdentityRoleManagementException, UserSharingMgtException {
-
-        if (!roleIds.isEmpty()) {
-            assignRolesToTheSharedUser(userAssociation, sharingInitiatedOrgId, roleIds);
-        }
-    }
-
-    private void assignRolesToTheSharedUser(UserAssociation userAssociation, String sharingInitiatedOrgId,
-                                            List<String> roleIds)
-            throws OrganizationManagementException, IdentityRoleManagementException, UserSharingMgtException {
-
-        String userId = userAssociation.getUserId();
-        String orgId = userAssociation.getOrganizationId();
-        String sharingInitiatedOrgTenantDomain = getOrganizationManager().resolveTenantDomain(sharingInitiatedOrgId);
-        String targetOrgTenantDomain = getOrganizationManager().resolveTenantDomain(orgId);
-
-        String usernameWithDomain = userIDResolver.getNameByID(userId, targetOrgTenantDomain);
-        String username = UserCoreUtil.removeDomainFromName(usernameWithDomain);
-        String domainName = UserCoreUtil.extractDomainFromName(usernameWithDomain);
-
-        RoleManagementService roleManagementService = getRoleManagementService();
-        Map<String, String> sharedRoleToMainRoleMappingsBySubOrg =
-                roleManagementService.getSharedRoleToMainRoleMappingsBySubOrg(roleIds,
-                        sharingInitiatedOrgTenantDomain);
-
-        List<String> mainRoles = new ArrayList<>();
-        for (String roleId : roleIds) {
-            mainRoles.add(sharedRoleToMainRoleMappingsBySubOrg.getOrDefault(roleId, roleId));
-        }
-
-        Map<String, String> mainRoleToSharedRoleMappingsBySubOrg =
-                roleManagementService.getMainRoleToSharedRoleMappingsBySubOrg(mainRoles, targetOrgTenantDomain);
-
-        for (String role : mainRoleToSharedRoleMappingsBySubOrg.values()) {
-            roleManagementService.updateUserListOfRole(role, Collections.singletonList(userId),
-                    Collections.emptyList(), targetOrgTenantDomain);
-            roleManagementService.getRoleListOfUser(userId, targetOrgTenantDomain);
-
-            getOrganizationUserSharingService().addEditRestrictionsForSharedUserRole(role, username,
-                    targetOrgTenantDomain, domainName, EditOperation.DELETE, sharingInitiatedOrgId);
-        }
-    }
-
-    private UserAssociation shareUserWithOrganization(String orgId, String associatedUserId, String associatedOrgId)
-            throws OrganizationManagementException {
-
-        OrganizationUserSharingService organizationUserSharingService = getOrganizationUserSharingService();
-        organizationUserSharingService.shareOrganizationUser(orgId, associatedUserId, associatedOrgId,
-                SharedType.SHARED);
-        return organizationUserSharingService.getUserAssociationOfAssociatedUserByOrgId(associatedUserId, orgId);
-    }
-
     private List<String> extractOrgListBasedOnSharingPolicy(String policyHoldingOrgId, PolicyEnum policy)
             throws OrganizationManagementException {
 
@@ -1004,6 +796,387 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
         return new ArrayList<>(userSharingOrgList);
     }
 
+    /**
+     * Retrieves the user associations of a given user within the organization tree.
+     * The root organization of the tree is the policy-holding organization.
+     * This method takes a base share object, which contains the policy-holding organization for the share,
+     * and retrieves the user associations for the organizations in that tree.
+     *
+     * @param baseUserShare The user share object, which can be either selective or general.
+     * @param sharingInitiatedOrgId The ID of the organization from which the sharing request was initiated.
+     * @return A list of user associations within the organization tree.
+     */
+    private List<UserAssociation> getUserAssociationsOfGivenUserOnOrgTree(BaseUserShare baseUserShare,
+                                                                          String sharingInitiatedOrgId)
+            throws OrganizationManagementException {
+
+        String associatedUserId = baseUserShare.getUserId();
+        String orgId = (baseUserShare instanceof SelectiveUserShare)
+                ? ((SelectiveUserShare) baseUserShare).getOrganizationId()
+                : sharingInitiatedOrgId;
+
+        List<String> orgsInOrgTree = getOrganizationManager().getChildOrganizationsIds(orgId, true);
+        orgsInOrgTree.add(orgId);
+
+        return getOrganizationUserSharingService().getUserAssociationsOfGivenUserOnGivenOrgs(associatedUserId,
+                orgsInOrgTree);
+    }
+
+    /**
+     * In the cases where the user sharing is shifted from general to selective without unsharing the user from all
+     * organizations, this method cleans up the old user associations and resource sharing policies under the
+     * organizations which are not selected in the selective user share.
+     *
+     * @param associatedUserId       The ID of the associated user.
+     * @param sharingInitiatedOrgId  The ID of the organization initiating the sharing.
+     * @param userSharingAllOrgs     The list of all organizations with which the user is shared.
+     */
+    private void cleanUpOldUserAssociationsIfExists(String associatedUserId, String sharingInitiatedOrgId,
+                                                    List<String> userSharingAllOrgs)
+            throws OrganizationManagementException, UserSharingMgtException, ResourceSharingPolicyMgtException {
+
+        List<UserAssociation> allUserAssociations =
+                getSharedUserAssociationsOfGivenUser(associatedUserId, sharingInitiatedOrgId);
+        List<String> unsharedOrgs = new ArrayList<>();
+
+        for (UserAssociation association : allUserAssociations) {
+            if (!userSharingAllOrgs.contains(association.getOrganizationId())) {
+                unshareUserFromPreviousOrg(association, sharingInitiatedOrgId);
+                unsharedOrgs.add(association.getOrganizationId());
+            }
+        }
+
+        for (String unsharedOrg : unsharedOrgs) {
+            deleteResourceSharingPolicy(unsharedOrg, associatedUserId, sharingInitiatedOrgId);
+        }
+    }
+
+    /**
+     * Updates the shared type of existing user association from INVITED to SHARED if applicable.
+     * This method checks if the current user has previously been associated with the sharing organization via an
+     * invitation, and if so, changes the type of the user association to SHARED. This is because the user
+     * association of that particular user will now be considered as a shared user rather than an invited user.
+     * This decision prioritizes the user share over the invitation since user sharing is done by a parent
+     * organization's admin.
+     *
+     * @param association The user association to be updated.
+     */
+    private void updateSharedTypeOfExistingUserAssociation(UserAssociation association) {
+
+        try {
+            if (SharedType.INVITED.equals(association.getSharedType())) {
+                getOrganizationUserSharingService().updateSharedTypeOfUserAssociation(association.getId(),
+                        SharedType.SHARED);
+            }
+        } catch (OrganizationManagementException e) {
+            LOG.error("Error occurred while converting the shared type of the user association of: " +
+                    association.getAssociatedUserId() + " from Invited to shared", e);
+        }
+    }
+
+    /**
+     * Unshare a user from a previously shared organization.
+     *
+     * @param association The user association to be unshared.
+     * @param sharingInitiatedOrgId The ID of the organization initiating the unsharing.
+     */
+    private void unshareUserFromPreviousOrg(UserAssociation association, String sharingInitiatedOrgId)
+            throws UserSharingMgtException {
+
+        selectiveUserUnshareByUserIds(new UserIdList(Collections.singletonList(association.getAssociatedUserId())),
+                Collections.singletonList(association.getOrganizationId()), sharingInitiatedOrgId);
+    }
+
+    /**
+     * Shares the user with new organizations that are not already shared.
+     *
+     * @param baseUserShare         The base user share object containing sharing details.
+     * @param sharingInitiatedOrgId The ID of the organization initiating the sharing.
+     * @param userSharingOrgList    The list of organizations to share the user with.
+     * @param alreadySharedOrgs     The list of organizations the user is already shared with.
+     */
+    private void shareWithNewOrganizations(BaseUserShare baseUserShare, String sharingInitiatedOrgId,
+                                           List<String> userSharingOrgList, List<String> alreadySharedOrgs)
+            throws OrganizationManagementException, UserSharingMgtException, IdentityRoleManagementException {
+
+        List<String> newlySharedOrgs = new ArrayList<>(userSharingOrgList);
+        newlySharedOrgs.removeAll(alreadySharedOrgs);
+
+        for (String orgId : newlySharedOrgs) {
+            shareAndAssignRolesIfPresent(orgId, baseUserShare, sharingInitiatedOrgId);
+        }
+    }
+
+    /**
+     * This method checks if at least one of the organizations has an association with this user.
+     *
+     * @param associatedUserId The ID of the user to check.
+     * @param associatedOrgId  The ID of the organization.
+     * @return {@code true} if the user has at least one associated organization, {@code false} otherwise.
+     */
+    private boolean isUserAlreadyShared(String associatedUserId, String associatedOrgId)
+            throws OrganizationManagementException {
+
+        List<UserAssociation> userAssociationsOfGivenUser =
+                getSharedUserAssociationsOfGivenUser(associatedUserId, associatedOrgId);
+
+        return userAssociationsOfGivenUser != null && !userAssociationsOfGivenUser.isEmpty();
+    }
+
+    /**
+     * Retrieves the list of shared user associations for a given user.
+     *
+     * @param associatedUserId The ID of the associated user.
+     * @param associatedOrgId  The ID of the associated organization.
+     * @return A list of {@code UserAssociation} objects representing shared user associations.
+     */
+    private List<UserAssociation> getSharedUserAssociationsOfGivenUser(String associatedUserId, String associatedOrgId)
+            throws OrganizationManagementException {
+
+        return getOrganizationUserSharingService().getUserAssociationsOfGivenUser(associatedUserId, associatedOrgId);
+    }
+
+    /**
+     * Shares a user with a specified organization and returns the user association.
+     * This is where the user association will be created.
+     *
+     * @param orgId            The ID of the organization to share the user with.
+     * @param associatedUserId The ID of the user to be shared.
+     * @param associatedOrgId  The ID of the organization that initiated the sharing.
+     * @return A {@code UserAssociation} representing the created association.
+     */
+    private UserAssociation shareUserWithOrganization(String orgId, String associatedUserId, String associatedOrgId)
+            throws OrganizationManagementException {
+
+        OrganizationUserSharingService organizationUserSharingService = getOrganizationUserSharingService();
+        organizationUserSharingService.shareOrganizationUser(orgId, associatedUserId, associatedOrgId,
+                SharedType.SHARED);
+        return organizationUserSharingService.getUserAssociationOfAssociatedUserByOrgId(associatedUserId, orgId);
+    }
+
+    /**
+     * Retrieves the name of an organization based on its ID.
+     *
+     * @param organizationId The ID of the organization.
+     * @return The name of the organization.
+     */
+    private String getOrganizationName(String organizationId) throws OrganizationManagementException {
+
+        return getOrganizationManager().getOrganizationNameById(organizationId);
+    }
+
+    /**
+     * Checks if the specified user is a non-resident user in the given organization.
+     *
+     * @param userId The ID of the user.
+     * @param orgId  The ID of the organization.
+     * @return {@code true} if the user is not a resident user, {@code false} otherwise.
+     */
+    private boolean isNotResidentUserInOrg(String userId, String orgId) {
+
+        try {
+            String tenantDomain = getOrganizationManager().resolveTenantDomain(orgId);
+            int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
+            AbstractUserStoreManager userStoreManager = getAbstractUserStoreManager(tenantId);
+            String associatedOrgId =
+                    OrganizationSharedUserUtil.getUserManagedOrganizationClaim(userStoreManager, userId);
+            return associatedOrgId != null;
+        } catch (UserStoreException | OrganizationManagementException e) {
+            LOG.error("Error occurred while checking if the user is a resident user in the organization.", e);
+            return true;
+        }
+    }
+
+    /**
+     * Filters the list of organizations to include only those that are immediate child organizations
+     * of the sharing-initiated organization.
+     * Any organizations that do not meet this criterion will be logged as skipped.
+     *
+     * @param organizations         The list of organizations to be filtered.
+     * @param sharingInitiatedOrgId The ID of the organization that initiated the sharing process.
+     * @return A list of organizations that are valid based on the immediate child organization criteria.
+     */
+    private List<SelectiveUserShareOrgDetailsDO> filterValidOrganizations(
+            List<SelectiveUserShareOrgDetailsDO> organizations, String sharingInitiatedOrgId)
+            throws UserSharingMgtServerException {
+
+        List<String> immediateChildOrgs = getImmediateChildOrgsOfSharingInitiatedOrg(sharingInitiatedOrgId);
+
+        List<SelectiveUserShareOrgDetailsDO> validOrganizations = organizations.stream()
+                .filter(org -> immediateChildOrgs.contains(org.getOrganizationId()))
+                .collect(Collectors.toList());
+
+        List<String> skippedOrganizations = organizations.stream()
+                .map(SelectiveUserShareOrgDetailsDO::getOrganizationId)
+                .filter(orgId -> !immediateChildOrgs.contains(orgId))
+                .collect(Collectors.toList());
+
+        if (!skippedOrganizations.isEmpty()) {
+            LOG.warn(String.format(LOG_WARN_SKIP_ORG_SHARE_MESSAGE, skippedOrganizations));
+        }
+
+        return validOrganizations;
+    }
+
+    /**
+     * Retrieves the list of immediate child organizations for a given organization.
+     *
+     * @param sharingInitiatedOrgId The ID of the organization that initiated the sharing.
+     * @return A list of organization IDs representing the immediate child organizations.
+     */
+    private List<String> getImmediateChildOrgsOfSharingInitiatedOrg(String sharingInitiatedOrgId)
+            throws UserSharingMgtServerException {
+
+        try {
+            return getOrganizationManager().getChildOrganizationsIds(getOrganizationId(), false);
+        } catch (OrganizationManagementException e) {
+            String errorMessage = String.format(
+                    ERROR_CODE_GET_IMMEDIATE_CHILD_ORGS.getMessage(), sharingInitiatedOrgId);
+            throw new UserSharingMgtServerException(ERROR_CODE_GET_IMMEDIATE_CHILD_ORGS, errorMessage);
+        }
+    }
+
+    //Resource Sharing Policy Management Methods.
+
+    /**
+     * Saves a new resource sharing policy for a user.
+     *
+     * @param baseUserShare          The user share details containing policy information.
+     * @param sharingInitiatedOrgId  The ID of the organization that initiated the sharing.
+     */
+    private void saveUserSharingPolicy(BaseUserShare baseUserShare, String sharingInitiatedOrgId)
+            throws ResourceSharingPolicyMgtException {
+
+        ResourceSharingPolicyHandlerService resourceSharingPolicyHandlerService =
+                getResourceSharingPolicyHandlerService();
+
+        ResourceSharingPolicy resourceSharingPolicy =
+                new ResourceSharingPolicy.Builder().withResourceType(ResourceType.USER)
+                        .withResourceId(baseUserShare.getUserId())
+                        .withInitiatingOrgId(sharingInitiatedOrgId)
+                        .withPolicyHoldingOrgId(getPolicyHoldingOrgId(baseUserShare, sharingInitiatedOrgId))
+                        .withSharingPolicy(baseUserShare.getPolicy()).build();
+
+        List<SharedResourceAttribute> sharedResourceAttributes = new ArrayList<>();
+        for (String roleId : baseUserShare.getRoles()) {
+            SharedResourceAttribute sharedResourceAttribute =
+                    new SharedResourceAttribute.Builder().withSharedAttributeType(SharedAttributeType.ROLE)
+                            .withSharedAttributeId(roleId).build();
+            sharedResourceAttributes.add(sharedResourceAttribute);
+        }
+
+        resourceSharingPolicyHandlerService.addResourceSharingPolicyWithAttributes(resourceSharingPolicy,
+                sharedResourceAttributes);
+
+    }
+
+    /**
+     * Updates the resource sharing policy for a user by deleting the old policy
+     * and saving the new policy if applicable.
+     *
+     * @param baseUserShare          The user share details containing policy information.
+     * @param sharingInitiatedOrgId  The ID of the organization that initiated the sharing.
+     */
+    private void updateResourceSharingPolicy(BaseUserShare baseUserShare, String sharingInitiatedOrgId)
+            throws ResourceSharingPolicyMgtException {
+
+        //Delete old sharing policy.
+        removeResourceSharingPolicy(baseUserShare, sharingInitiatedOrgId);
+
+        //Create new sharing policy.
+        if (isApplicableOrganizationScopeForSavingPolicy(baseUserShare.getPolicy())) {
+            saveUserSharingPolicy(baseUserShare, sharingInitiatedOrgId);
+        }
+    }
+
+    /**
+     * Removes the resource sharing policy associated with the given user share.
+     *
+     * @param baseUserShare          The user share details containing policy information.
+     * @param sharingInitiatedOrgId  The ID of the organization that initiated the sharing.
+     */
+    private void removeResourceSharingPolicy(BaseUserShare baseUserShare, String sharingInitiatedOrgId)
+            throws ResourceSharingPolicyMgtException {
+
+        String policyHoldingOrgId =
+                baseUserShare instanceof SelectiveUserShare ? ((SelectiveUserShare) baseUserShare).getOrganizationId() :
+                        sharingInitiatedOrgId;
+
+        deleteResourceSharingPolicy(policyHoldingOrgId, baseUserShare.getUserId(), sharingInitiatedOrgId);
+    }
+
+    /**
+     * Deletes the resource sharing policy for a given user in an organization.
+     *
+     * @param policyHoldingOrgId     The ID of the organization holding the policy.
+     * @param associatedUserId       The ID of the associated user.
+     * @param sharingInitiatedOrgId  The ID of the organization that initiated the sharing.
+     */
+    private void deleteResourceSharingPolicy(String policyHoldingOrgId, String associatedUserId,
+                                             String sharingInitiatedOrgId)
+            throws ResourceSharingPolicyMgtException {
+
+        getResourceSharingPolicyHandlerService().deleteResourceSharingPolicyInOrgByResourceTypeAndId(
+                policyHoldingOrgId, ResourceType.USER, associatedUserId, sharingInitiatedOrgId);
+    }
+
+    /**
+     * Determines the policy-holding organization ID based on the type of user share.
+     * For a selective user share, the policy-holding organization is the organization specified in the selective
+     * share request.
+     * For a general user share, the policy-holding organization is the organization from which the
+     * sharing request was initiated.
+     *
+     * @param baseUserShare             The user share object, which can be either selective or general.
+     * @param sharingInitiatedOrgId The ID of the organization from which the sharing request was initiated.
+     * @return The ID of the policy-holding organization based on the type of user share.
+     */
+    private String getPolicyHoldingOrgId(BaseUserShare baseUserShare, String sharingInitiatedOrgId) {
+
+        if (baseUserShare instanceof SelectiveUserShare) {
+            return ((SelectiveUserShare) baseUserShare).getOrganizationId();
+        } else {
+            return sharingInitiatedOrgId;
+        }
+    }
+
+    /**
+     * Determines whether a given policy scope allows saving the resource sharing policy.
+     *
+     * @param policy The policy enumeration containing the organization scope.
+     * @return {@code true} if the policy allows saving, {@code false} otherwise.
+     */
+    private boolean isApplicableOrganizationScopeForSavingPolicy(PolicyEnum policy) {
+
+        return OrganizationScope.EXISTING_ORGS_AND_FUTURE_ORGS_ONLY.equals(policy.getOrganizationScope()) ||
+                OrganizationScope.FUTURE_ORGS_ONLY.equals(policy.getOrganizationScope());
+    }
+
+    /**
+     * Deletes the resource sharing policy associated with a given user in an organization.
+     *
+     * @param organizationId       The ID of the organization that holds the policy.
+     * @param associatedUserId     The ID of the user whose policy is to be deleted.
+     * @param unsharingInitiatedOrgId The ID of the organization initiating the unsharing process.
+     */
+    private void deleteResourceSharingPolicyIfAny(String organizationId, String associatedUserId,
+                                                  String unsharingInitiatedOrgId)
+            throws ResourceSharingPolicyMgtException {
+
+        getResourceSharingPolicyHandlerService().deleteResourceSharingPolicyInOrgByResourceTypeAndId(
+                organizationId, ResourceType.USER, associatedUserId, unsharingInitiatedOrgId);
+    }
+
+    //Role Management Helper Methods.
+
+    /**
+     * Retrieves a list of role IDs based on the provided role and audience details.
+     * This will return the role Ids in the parent organization that match to the given role-audience combination.
+     *
+     * @param rolesWithAudience    A list of roles with associated audience information.
+     * @param sharingInitiatedOrgId The ID of the organization that initiated the sharing.
+     * @return A list of role IDs that match the given role-audience combination.
+     */
     private List<String> getRoleIds(List<RoleWithAudienceDO> rolesWithAudience, String sharingInitiatedOrgId)
             throws UserSharingMgtException {
 
@@ -1028,6 +1201,16 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
         }
     }
 
+    /**
+     * Determines the audience ID based on the role's audience type.
+     * If the audience is an organization, it returns the given organization ID.
+     * If the audience is an application, it retrieves the application's resource ID.
+     *
+     * @param role           The role with audience details.
+     * @param originalOrgId  The ID of the organization where the role is being shared.
+     * @param tenantDomain   The tenant domain associated with the organization.
+     * @return The audience ID associated with the role.
+     */
     private String getAudienceId(RoleWithAudienceDO role, String originalOrgId, String tenantDomain) {
 
         if (role == null || role.getAudienceType() == null) {
@@ -1048,6 +1231,13 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
         return null;
     }
 
+    /**
+     * Retrieves the resource ID of an application based on its name within the specified tenant domain.
+     *
+     * @param audienceName The name of the application.
+     * @param tenantDomain The tenant domain where the application exists.
+     * @return The resource ID of the application, or null if not found.
+     */
     private String getApplicationResourceId(String audienceName, String tenantDomain)
             throws IdentityApplicationManagementException {
 
@@ -1061,6 +1251,15 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
         return null;
     }
 
+    /**
+     * Retrieves the role ID associated with a given role name and audience within a specific tenant domain.
+     *
+     * @param roleName      The name of the role.
+     * @param audienceType  The type of audience (organization or application).
+     * @param audienceId    The audience ID.
+     * @param tenantDomain  The tenant domain where the role exists.
+     * @return An {@code Optional<String>} containing the role ID if found, otherwise empty.
+     */
     private Optional<String> getRoleIdFromAudience(String roleName, String audienceType, String audienceId,
                                                    String tenantDomain) {
 
@@ -1077,73 +1276,208 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
         }
     }
 
-    private void deleteResourceSharingPolicyIfAny(String organizationId, String associatedUserId,
-                                                  String unsharingInitiatedOrgId)
-            throws ResourceSharingPolicyMgtException {
+    /**
+     * Checks if there are any role changes when updating a shared user.
+     *
+     * @param oldSharedRoleIds The list of old shared role IDs.
+     * @param newRoleIds The list of new role IDs.
+     * @return True if there are role changes, false otherwise.
+     */
+    private boolean hasRoleChanges(List<String> oldSharedRoleIds, List<String> newRoleIds) {
 
-        getResourceSharingPolicyHandlerService().deleteResourceSharingPolicyInOrgByResourceTypeAndId(
-                organizationId, ResourceType.USER, associatedUserId, unsharingInitiatedOrgId);
+        return !new HashSet<>(oldSharedRoleIds).equals(new HashSet<>(newRoleIds));
     }
 
-    private String getOrganizationName(String organizationId) throws OrganizationManagementException {
+    /**
+     * Updates the roles assigned to a shared user if necessary.
+     * It retrieves the current shared roles and determines the roles to be added.
+     * If there are any changes in the roles, the new roles are assigned.
+     *
+     * @param userAssociation        The user association object containing user and organization details.
+     * @param roleIds                The list of role IDs to be updated.
+     * @param sharingInitiatedOrgId  The ID of the organization that initiated the sharing.
+     */
+    private void updateRolesIfNecessary(UserAssociation userAssociation, List<String> roleIds,
+                                        String sharingInitiatedOrgId)
+            throws OrganizationManagementException, IdentityRoleManagementException, UserSharingMgtException {
 
-        return getOrganizationManager().getOrganizationNameById(organizationId);
+        List<String> currentSharedRoleIds = getCurrentSharedRoleIdsForSharedUser(userAssociation);
+        List<String> newSharedRoleIds = getRolesToBeAddedAfterUpdate(userAssociation, currentSharedRoleIds, roleIds);
+
+        if (hasRoleChanges(currentSharedRoleIds, newSharedRoleIds)) {
+            assignRolesIfPresent(userAssociation, sharingInitiatedOrgId, newSharedRoleIds);
+        }
     }
 
+    /**
+     * Retrieves the role IDs currently assigned to a shared user within an organization.
+     *
+     * @param userAssociation The user association object containing user and organization details.
+     * @return A list of role IDs currently assigned to the shared user.
+     */
+    private List<String> getCurrentSharedRoleIdsForSharedUser(UserAssociation userAssociation)
+            throws OrganizationManagementException, IdentityRoleManagementException {
+
+        String userId = userAssociation.getUserId();
+        String orgId = userAssociation.getOrganizationId();
+        String tenantDomain = getOrganizationManager().resolveTenantDomain(orgId);
+
+        List<String> allUserRolesOfSharedUser = getRoleManagementService().getRoleIdListOfUser(userId, tenantDomain);
+
+        return getOrganizationUserSharingService().getSharedUserRolesFromUserRoles(allUserRolesOfSharedUser,
+                tenantDomain);
+    }
+
+    /**
+     * Shares a user with a specified organization and assigns roles if present.
+     * This is where the user association will be created, and roles will be assigned to the shared user if any
+     * roles are present.
+     * It attempts to share the user with the specified organization and assigns roles accordingly.
+     *
+     * @param orgId                 The ID of the organization to share the user with.
+     * @param baseUserShare         The base user share object containing user and role information.
+     * @param sharingInitiatedOrgId The ID of the organization that initiated the sharing.
+     */
+    private void shareAndAssignRolesIfPresent(String orgId, BaseUserShare baseUserShare,
+                                              String sharingInitiatedOrgId)
+            throws OrganizationManagementException, IdentityRoleManagementException, UserSharingMgtException {
+
+        String associatedUserId = baseUserShare.getUserId();
+        List<String> roleIds = baseUserShare.getRoles();
+        UserAssociation userAssociation;
+
+        try {
+            userAssociation = shareUserWithOrganization(orgId, associatedUserId, sharingInitiatedOrgId);
+        } catch (OrganizationManagementException e) {
+            String errorMessage = String.format(ERROR_CODE_USER_SHARE.getMessage(), associatedUserId, e.getMessage());
+            LOG.error(errorMessage, e);
+            return;
+        }
+
+        //Assign roles if any are present.
+        assignRolesIfPresent(userAssociation, sharingInitiatedOrgId, roleIds);
+    }
+
+    /**
+     * Determines the roles that need to be added after an update by comparing the current roles
+     * with the new set of roles. Note that this will only be affected to the roles which have been assigned to user
+     * with the sharing of that user. If this particular user has been assigned to some roles within the sub
+     * organization, there won't be any effect to those roles.
+     *
+     * @param userAssociation The user association object containing user and organization details.
+     * @param currentRoleIds  The list of role IDs currently assigned to the shared user.
+     * @param newRoleIds      The list of new role IDs to be assigned.
+     * @return A list of roles that need to be added.
+     */
+    private List<String> getRolesToBeAddedAfterUpdate(UserAssociation userAssociation, List<String> currentRoleIds,
+                                                      List<String> newRoleIds)
+            throws OrganizationManagementException, IdentityRoleManagementException {
+
+        // Roles to be added are those in newRoleIds that are not in currentRoleIds.
+        List<String> rolesToBeAdded = new ArrayList<>(newRoleIds);
+        rolesToBeAdded.removeAll(currentRoleIds);
+
+        // Roles to be removed are those in currentRoleIds that are not in newRoleIds.
+        List<String> rolesToBeRemoved = new ArrayList<>(currentRoleIds);
+        rolesToBeRemoved.removeAll(newRoleIds);
+
+        deleteOldSharedRoles(userAssociation, rolesToBeRemoved);
+        return rolesToBeAdded;
+    }
+
+    /**
+     * Removes roles that are no longer assigned to the shared user.
+     *
+     * @param userAssociation The user association object containing user and organization details.
+     * @param rolesToBeRemoved The list of role IDs to be removed.
+     */
+    private void deleteOldSharedRoles(UserAssociation userAssociation, List<String> rolesToBeRemoved)
+            throws OrganizationManagementException, IdentityRoleManagementException {
+
+        String userId = userAssociation.getUserId();
+        String orgId = userAssociation.getOrganizationId();
+        String targetOrgTenantDomain = getOrganizationManager().resolveTenantDomain(orgId);
+
+        for (String roleId : rolesToBeRemoved) {
+            getRoleManagementService().updateUserListOfRole(roleId, Collections.emptyList(),
+                    Collections.singletonList(userId), targetOrgTenantDomain);
+        }
+    }
+
+    /**
+     * Assigns roles to the shared user if any roles are present.
+     *
+     * @param userAssociation        The user association object containing user and organization details.
+     * @param sharingInitiatedOrgId  The ID of the organization that initiated the sharing.
+     * @param roleIds                The list of role IDs to be assigned.
+     */
+    private void assignRolesIfPresent(UserAssociation userAssociation, String sharingInitiatedOrgId,
+                                      List<String> roleIds)
+            throws OrganizationManagementException, IdentityRoleManagementException, UserSharingMgtException {
+
+        if (!roleIds.isEmpty()) {
+            assignRolesToTheSharedUser(userAssociation, sharingInitiatedOrgId, roleIds);
+        }
+    }
+
+    /**
+     * Assigns the specified roles to the shared user within the target organization.
+     * This method ensures that the shared user receives the appropriate roles (the roles ids of the corresponding
+     * roles in the sub organization) based on the mappings between shared and main roles.
+     *
+     * @param userAssociation        The user association object containing user and organization details.
+     * @param sharingInitiatedOrgId  The ID of the organization that initiated the sharing.
+     * @param roleIds                The list of role IDs to be assigned.
+     */
+    private void assignRolesToTheSharedUser(UserAssociation userAssociation, String sharingInitiatedOrgId,
+                                            List<String> roleIds)
+            throws OrganizationManagementException, IdentityRoleManagementException, UserSharingMgtException {
+
+        String userId = userAssociation.getUserId();
+        String orgId = userAssociation.getOrganizationId();
+        String sharingInitiatedOrgTenantDomain = getOrganizationManager().resolveTenantDomain(sharingInitiatedOrgId);
+        String targetOrgTenantDomain = getOrganizationManager().resolveTenantDomain(orgId);
+
+        String usernameWithDomain = userIDResolver.getNameByID(userId, targetOrgTenantDomain);
+        String username = UserCoreUtil.removeDomainFromName(usernameWithDomain);
+        String domainName = UserCoreUtil.extractDomainFromName(usernameWithDomain);
+
+        RoleManagementService roleManagementService = getRoleManagementService();
+        Map<String, String> sharedRoleToMainRoleMappingsBySubOrg =
+                roleManagementService.getSharedRoleToMainRoleMappingsBySubOrg(roleIds,
+                        sharingInitiatedOrgTenantDomain);
+
+        List<String> mainRoles = new ArrayList<>();
+        for (String roleId : roleIds) {
+            mainRoles.add(sharedRoleToMainRoleMappingsBySubOrg.getOrDefault(roleId, roleId));
+        }
+
+        Map<String, String> mainRoleToSharedRoleMappingsBySubOrg =
+                roleManagementService.getMainRoleToSharedRoleMappingsBySubOrg(mainRoles, targetOrgTenantDomain);
+
+        for (String role : mainRoleToSharedRoleMappingsBySubOrg.values()) {
+            roleManagementService.updateUserListOfRole(role, Collections.singletonList(userId),
+                    Collections.emptyList(), targetOrgTenantDomain);
+            roleManagementService.getRoleListOfUser(userId, targetOrgTenantDomain);
+
+            getOrganizationUserSharingService().addEditRestrictionsForSharedUserRole(role, username,
+                    targetOrgTenantDomain, domainName, EditOperation.DELETE, sharingInitiatedOrgId);
+        }
+    }
+
+    /**
+     * Constructs a reference URL to retrieve the shared roles of a user within an organization.
+     *
+     * @param userId The ID of the user.
+     * @param orgId  The ID of the organization.
+     * @return The formatted reference URL for retrieving shared roles.
+     */
     private String getRolesRef(String userId, String orgId) {
 
         return String.format(API_REF_GET_SHARED_ROLES_OF_USER_IN_ORG, userId, orgId);
     }
 
-    private boolean isNotResidentUserInOrg(String userId, String orgId) {
-
-        try {
-            String tenantDomain = getOrganizationManager().resolveTenantDomain(orgId);
-            int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
-            AbstractUserStoreManager userStoreManager = getAbstractUserStoreManager(tenantId);
-            String associatedOrgId =
-                    OrganizationSharedUserUtil.getUserManagedOrganizationClaim(userStoreManager, userId);
-            return associatedOrgId != null;
-        } catch (UserStoreException | OrganizationManagementException e) {
-            LOG.error("Error occurred while checking if the user is a resident user in the organization.", e);
-            return true;
-        }
-    }
-
-    private AbstractUserStoreManager getAbstractUserStoreManager(int tenantId) throws UserStoreException {
-
-        try {
-            RealmService realmService = OrganizationUserSharingDataHolder.getInstance().getRealmService();
-            UserRealm tenantUserRealm = realmService.getTenantUserRealm(tenantId);
-            return (AbstractUserStoreManager) tenantUserRealm.getUserStoreManager();
-        } catch (org.wso2.carbon.user.api.UserStoreException e) {
-            throw new UserStoreException("Error occurred while retrieving the user store manager.", e);
-        }
-    }
-
-    private List<SelectiveUserShareOrgDetailsDO> filterValidOrganizations(
-            List<SelectiveUserShareOrgDetailsDO> organizations, String sharingInitiatedOrgId)
-            throws UserSharingMgtServerException {
-
-        List<String> immediateChildOrgs = getChildOrgsOfSharingInitiatedOrg(sharingInitiatedOrgId);
-
-        List<SelectiveUserShareOrgDetailsDO> validOrganizations = organizations.stream()
-                .filter(org -> immediateChildOrgs.contains(org.getOrganizationId()))
-                .collect(Collectors.toList());
-
-        List<String> skippedOrganizations = organizations.stream()
-                .map(SelectiveUserShareOrgDetailsDO::getOrganizationId)
-                .filter(orgId -> !immediateChildOrgs.contains(orgId))
-                .collect(Collectors.toList());
-
-        if (!skippedOrganizations.isEmpty()) {
-            LOG.warn(String.format(LOG_WARN_SKIP_ORG_SHARE_MESSAGE, skippedOrganizations));
-        }
-
-        return validOrganizations;
-    }
-
-    //Validation methods.
+    //Validation Methods.
 
     private <T extends UserCriteriaType> void validateUserShareInput(BaseUserShareDO<T> baseUserShareDO)
             throws UserSharingMgtClientException {
@@ -1271,6 +1605,25 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
         throw new UserSharingMgtClientException(error.getCode(), error.getMessage(), error.getDescription());
     }
 
+    //Async helpers.
+
+    /**
+     * Restores thread-local properties for async execution.
+     */
+    private void restoreThreadLocalContext(String tenantDomain, int tenantId, String username,
+                                           Map<String, Object> threadLocalProperties) {
+
+        PrivilegedCarbonContext.startTenantFlow();
+        PrivilegedCarbonContext carbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
+
+        carbonContext.setTenantDomain(tenantDomain, true);
+        carbonContext.setTenantId(tenantId);
+        carbonContext.setUsername(username);
+
+        // Restore all thread-local properties.
+        IdentityUtil.threadLocalProperties.get().putAll(threadLocalProperties);
+    }
+
     //Service getters.
 
     private OrganizationUserSharingService getOrganizationUserSharingService() {
@@ -1298,22 +1651,14 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
         return OrganizationUserSharingDataHolder.getInstance().getApplicationManagementService();
     }
 
-    //Async helpers.
+    private AbstractUserStoreManager getAbstractUserStoreManager(int tenantId) throws UserStoreException {
 
-    /**
-     * Restores thread-local properties for async execution.
-     */
-    private void restoreThreadLocalContext(String tenantDomain, int tenantId, String username,
-                                           Map<String, Object> threadLocalProperties) {
-
-        PrivilegedCarbonContext.startTenantFlow();
-        PrivilegedCarbonContext carbonContext = PrivilegedCarbonContext.getThreadLocalCarbonContext();
-
-        carbonContext.setTenantDomain(tenantDomain, true);
-        carbonContext.setTenantId(tenantId);
-        carbonContext.setUsername(username);
-
-        // Restore all thread-local properties.
-        IdentityUtil.threadLocalProperties.get().putAll(threadLocalProperties);
+        try {
+            RealmService realmService = OrganizationUserSharingDataHolder.getInstance().getRealmService();
+            UserRealm tenantUserRealm = realmService.getTenantUserRealm(tenantId);
+            return (AbstractUserStoreManager) tenantUserRealm.getUserStoreManager();
+        } catch (org.wso2.carbon.user.api.UserStoreException e) {
+            throw new UserStoreException("Error occurred while retrieving the user store manager.", e);
+        }
     }
 }

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImpl.java
@@ -336,24 +336,29 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
                                            List<SelectiveUserShareOrgDetailsDO> organizations,
                                            String sharingInitiatedOrgId) {
 
-        for (Map.Entry<String, UserCriteriaType> criterion : userCriteria.entrySet()) {
-            String criterionKey = criterion.getKey();
-            UserCriteriaType criterionValues = criterion.getValue();
+        try {
+            for (Map.Entry<String, UserCriteriaType> criterion : userCriteria.entrySet()) {
+                String criterionKey = criterion.getKey();
+                UserCriteriaType criterionValues = criterion.getValue();
 
-            try {
-                if (USER_IDS.equals(criterionKey)) {
-                    if (criterionValues instanceof UserIdList) {
-                        selectiveUserShareByUserIds((UserIdList) criterionValues, organizations,
-                                sharingInitiatedOrgId);
+                try {
+                    if (USER_IDS.equals(criterionKey)) {
+                        if (criterionValues instanceof UserIdList) {
+                            selectiveUserShareByUserIds((UserIdList) criterionValues, organizations,
+                                    sharingInitiatedOrgId);
+                        } else {
+                            LOG.error("Invalid user criteria provided for selective user share: " + criterionKey);
+                        }
                     } else {
                         LOG.error("Invalid user criteria provided for selective user share: " + criterionKey);
                     }
-                } else {
-                    LOG.error("Invalid user criteria provided for selective user share: " + criterionKey);
+                } catch (UserSharingMgtException e) {
+                    LOG.error("Error occurred while sharing user from user criteria: " + USER_IDS, e);
                 }
-            } catch (UserSharingMgtException e) {
-                LOG.error("Error occurred while sharing user from user criteria: " + USER_IDS, e);
             }
+            LOG.debug("Completed selective user share initiated from " + sharingInitiatedOrgId + ".");
+        } finally {
+            PrivilegedCarbonContext.endTenantFlow();
         }
     }
 
@@ -442,6 +447,8 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
         }
     }
 
+    //Methods for sharing and unsharing users by user Ids.
+
     private void selectiveUserShareByUserIds(UserIdList userIds, List<SelectiveUserShareOrgDetailsDO> organizations,
                                              String sharingInitiatedOrgId)
             throws UserSharingMgtException {
@@ -471,8 +478,6 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
             }
         }
     }
-
-    //Methods for sharing and unsharing users by user Ids.
 
     private void generalUserShareByUserIds(UserIdList userIds, PolicyEnum policy, List<String> roleIds,
                                            String sharingInitiatedOrgId)

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/constant/SQLConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/constant/SQLConstants.java
@@ -110,6 +110,12 @@ public class SQLConstants {
                     "AND UHR.UM_DOMAIN_ID = (SELECT UM_DOMAIN_ID FROM UM_DOMAIN WHERE " +
                     "UM_TENANT_ID = :" + SQLPlaceholders.COLUMN_NAME_UM_TENANT_ID + "; " +
                     "AND UM_DOMAIN_NAME = :" + SQLPlaceholders.COLUMN_NAME_UM_DOMAIN_NAME + ";);";
+    public static final String GET_USER_ASSOCIATIONS_OF_USER_IN_GIVEN_ORGS =
+            "SELECT UM_ID, UM_USER_ID, UM_ORG_ID, UM_ASSOCIATED_USER_ID, UM_ASSOCIATED_ORG_ID, UM_SHARED_TYPE " +
+                    "FROM UM_ORG_USER_ASSOCIATION " +
+                    "WHERE UM_ASSOCIATED_USER_ID = :" + SQLPlaceholders.COLUMN_NAME_ASSOCIATED_USER_ID + "; " +
+                    "AND UM_ORG_ID IN (" + SQLPlaceholders.PLACEHOLDER_ORG_IDS + ") " +
+                    "AND UM_SHARED_TYPE = :" + SQLPlaceholders.COLUMN_NAME_UM_SHARED_TYPE + ";";
 
     /**
      * SQL placeholders related to organization user sharing SQL operations.
@@ -140,6 +146,7 @@ public class SQLConstants {
 
         public static final String PLACEHOLDER_NAME_USER_NAMES = "USER_NAMES";
         public static final String PLACEHOLDER_ROLE_IDS = "ROLE_IDS";
+        public static final String PLACEHOLDER_ORG_IDS = "ORG_IDS";
     }
 
 }

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/constant/SQLConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/constant/SQLConstants.java
@@ -114,8 +114,11 @@ public class SQLConstants {
             "SELECT UM_ID, UM_USER_ID, UM_ORG_ID, UM_ASSOCIATED_USER_ID, UM_ASSOCIATED_ORG_ID, UM_SHARED_TYPE " +
                     "FROM UM_ORG_USER_ASSOCIATION " +
                     "WHERE UM_ASSOCIATED_USER_ID = :" + SQLPlaceholders.COLUMN_NAME_ASSOCIATED_USER_ID + "; " +
-                    "AND UM_ORG_ID IN (" + SQLPlaceholders.PLACEHOLDER_ORG_IDS + ") " +
-                    "AND UM_SHARED_TYPE = :" + SQLPlaceholders.COLUMN_NAME_UM_SHARED_TYPE + ";";
+                    "AND UM_ORG_ID IN (" + SQLPlaceholders.PLACEHOLDER_ORG_IDS + ");";
+    public static final String UPDATE_USER_ASSOCIATION_SHARED_TYPE =
+            "UPDATE UM_ORG_USER_ASSOCIATION " +
+                    "SET UM_SHARED_TYPE = :" + SQLPlaceholders.COLUMN_NAME_UM_SHARED_TYPE + "; " +
+                    "WHERE UM_ID = :" + SQLPlaceholders.COLUMN_NAME_UM_ID + ";";
 
     /**
      * SQL placeholders related to organization user sharing SQL operations.

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/dao/OrganizationUserSharingDAO.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/dao/OrganizationUserSharingDAO.java
@@ -208,14 +208,26 @@ public interface OrganizationUserSharingDAO {
      *
      * @param associatedUserId The ID of the associated user.
      * @param orgIds           The list of organization IDs.
-     * @param sharedType       The type of sharing relationship to filter the associations.
      * @return The list of {@link UserAssociation}s for the given user in the specified organizations.
      * @throws OrganizationManagementServerException If an error occurs while retrieving the user associations.
      */
     default List<UserAssociation> getUserAssociationsOfGivenUserOnGivenOrgs(String associatedUserId,
-                                                                            List<String> orgIds, SharedType sharedType)
+                                                                            List<String> orgIds)
             throws OrganizationManagementServerException {
 
         throw new NotImplementedException("getUserAssociationsOfAssociatedUserOnGivenOrgs method is not implemented.");
+    }
+
+    /**
+     * Updates the shared type of user association.
+     *
+     * @param id         The ID of the user association.
+     * @param sharedType The new shared type to be set for the user association.
+     * @throws OrganizationManagementServerException If an error occurs while updating the shared type.
+     */
+    default void updateSharedTypeOfUserAssociation(int id, SharedType sharedType)
+            throws OrganizationManagementServerException {
+
+        throw new NotImplementedException("updateSharedTypeOfUserAssociation method is not implemented.");
     }
 }

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/dao/OrganizationUserSharingDAO.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/dao/OrganizationUserSharingDAO.java
@@ -202,4 +202,20 @@ public interface OrganizationUserSharingDAO {
 
         throw new NotImplementedException("getRolesSharedWithUserInOrganization method is not implemented.");
     }
+
+    /**
+     * Get the user associations of the associated user in the given organizations.
+     *
+     * @param associatedUserId The ID of the associated user.
+     * @param orgIds           The list of organization IDs.
+     * @param sharedType       The type of sharing relationship to filter the associations.
+     * @return The list of {@link UserAssociation}s for the given user in the specified organizations.
+     * @throws OrganizationManagementServerException If an error occurs while retrieving the user associations.
+     */
+    default List<UserAssociation> getUserAssociationsOfGivenUserOnGivenOrgs(String associatedUserId,
+                                                                            List<String> orgIds, SharedType sharedType)
+            throws OrganizationManagementServerException {
+
+        throw new NotImplementedException("getUserAssociationsOfAssociatedUserOnGivenOrgs method is not implemented.");
+    }
 }

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/dao/OrganizationUserSharingDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/dao/OrganizationUserSharingDAOImpl.java
@@ -46,6 +46,7 @@ import static org.wso2.carbon.identity.organization.management.organization.user
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.SQLConstants.GET_RESTRICTED_USERNAMES_BY_ROLE_AND_ORG;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.SQLConstants.GET_SHARED_ROLES_OF_SHARED_USER;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.SQLConstants.GET_SHARED_USER_ROLES;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.SQLConstants.GET_USER_ASSOCIATIONS_OF_USER_IN_GIVEN_ORGS;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.SQLConstants.GET_USER_ROLE_IN_TENANT;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.SQLConstants.INSERT_RESTRICTED_EDIT_PERMISSION;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.SQLConstants.SQLPlaceholders.COLUMN_NAME_ASSOCIATED_ORG_ID;
@@ -63,6 +64,7 @@ import static org.wso2.carbon.identity.organization.management.organization.user
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.SQLConstants.SQLPlaceholders.COLUMN_NAME_UM_UUID;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.SQLConstants.SQLPlaceholders.COLUMN_NAME_USER_ID;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.SQLConstants.SQLPlaceholders.PLACEHOLDER_NAME_USER_NAMES;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.SQLConstants.SQLPlaceholders.PLACEHOLDER_ORG_IDS;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.SQLConstants.SQLPlaceholders.PLACEHOLDER_ROLE_IDS;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.ErrorMessage.ERROR_CODE_ERROR_INSERTING_RESTRICTED_PERMISSION;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.ErrorMessage.ERROR_CODE_ERROR_RETRIEVING_USER_ROLE_ID;
@@ -411,6 +413,55 @@ public class OrganizationUserSharingDAOImpl implements OrganizationUserSharingDA
                     });
         } catch (DataAccessException e) {
             throw new UserSharingMgtServerException(ERROR_CODE_GET_ROLES_SHARED_WITH_SHARED_USER);
+        }
+    }
+
+    public List<UserAssociation> getUserAssociationsOfGivenUserOnGivenOrgs(String associatedUserId, List<String> orgIds,
+                                                                           SharedType sharedType)
+            throws OrganizationManagementServerException {
+
+        if (CollectionUtils.isEmpty(orgIds)) {
+            return Collections.emptyList();
+        }
+
+        String orgIdPlaceholder = "ORG_ID_";
+        List<String> orgIdPlaceholders = new ArrayList<>();
+        for (int i = 1; i <= orgIds.size(); i++) {
+            orgIdPlaceholders.add(":" + orgIdPlaceholder + i + ";");
+        }
+
+        String fetchUserAssociationsQuery =
+                GET_USER_ASSOCIATIONS_OF_USER_IN_GIVEN_ORGS.replace(PLACEHOLDER_ORG_IDS,
+                        String.join(", ", orgIdPlaceholders));
+
+        NamedJdbcTemplate namedJdbcTemplate = getNewTemplate();
+
+        try {
+            return namedJdbcTemplate.executeQuery(
+                    fetchUserAssociationsQuery,
+                    (resultSet, rowNumber) -> {
+                        UserAssociation userAssociation = new UserAssociation();
+                        userAssociation.setId(resultSet.getInt(COLUMN_NAME_UM_ID));
+                        userAssociation.setUserId(resultSet.getString(COLUMN_NAME_USER_ID));
+                        userAssociation.setOrganizationId(resultSet.getString(COLUMN_NAME_ORG_ID));
+                        userAssociation.setAssociatedUserId(resultSet.getString(COLUMN_NAME_ASSOCIATED_USER_ID));
+                        userAssociation.setUserResidentOrganizationId(
+                                resultSet.getString(COLUMN_NAME_ASSOCIATED_ORG_ID));
+                        userAssociation.setSharedType(
+                                SharedType.fromString(resultSet.getString(COLUMN_NAME_UM_SHARED_TYPE)));
+                        return userAssociation;
+                    },
+                    namedPreparedStatement -> {
+                        namedPreparedStatement.setString(COLUMN_NAME_ASSOCIATED_USER_ID, associatedUserId);
+                        namedPreparedStatement.setString(COLUMN_NAME_UM_SHARED_TYPE, sharedType.name());
+                        int index = 1;
+                        for (String orgId : orgIds) {
+                            namedPreparedStatement.setString(orgIdPlaceholder + index, orgId);
+                            index++;
+                        }
+                    });
+        } catch (DataAccessException e) {
+            throw handleServerException(ERROR_CODE_ERROR_GET_ORGANIZATION_USER_ASSOCIATIONS, e);
         }
     }
 }

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/dao/OrganizationUserSharingDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/dao/OrganizationUserSharingDAOImpl.java
@@ -66,6 +66,7 @@ import static org.wso2.carbon.identity.organization.management.organization.user
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.SQLConstants.SQLPlaceholders.PLACEHOLDER_NAME_USER_NAMES;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.SQLConstants.SQLPlaceholders.PLACEHOLDER_ORG_IDS;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.SQLConstants.SQLPlaceholders.PLACEHOLDER_ROLE_IDS;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.SQLConstants.UPDATE_USER_ASSOCIATION_SHARED_TYPE;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.ErrorMessage.ERROR_CODE_ERROR_INSERTING_RESTRICTED_PERMISSION;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.ErrorMessage.ERROR_CODE_ERROR_RETRIEVING_USER_ROLE_ID;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.ErrorMessage.ERROR_CODE_GET_ROLES_SHARED_WITH_SHARED_USER;
@@ -416,8 +417,8 @@ public class OrganizationUserSharingDAOImpl implements OrganizationUserSharingDA
         }
     }
 
-    public List<UserAssociation> getUserAssociationsOfGivenUserOnGivenOrgs(String associatedUserId, List<String> orgIds,
-                                                                           SharedType sharedType)
+    @Override
+    public List<UserAssociation> getUserAssociationsOfGivenUserOnGivenOrgs(String associatedUserId, List<String> orgIds)
             throws OrganizationManagementServerException {
 
         if (CollectionUtils.isEmpty(orgIds)) {
@@ -453,7 +454,6 @@ public class OrganizationUserSharingDAOImpl implements OrganizationUserSharingDA
                     },
                     namedPreparedStatement -> {
                         namedPreparedStatement.setString(COLUMN_NAME_ASSOCIATED_USER_ID, associatedUserId);
-                        namedPreparedStatement.setString(COLUMN_NAME_UM_SHARED_TYPE, sharedType.name());
                         int index = 1;
                         for (String orgId : orgIds) {
                             namedPreparedStatement.setString(orgIdPlaceholder + index, orgId);
@@ -464,4 +464,22 @@ public class OrganizationUserSharingDAOImpl implements OrganizationUserSharingDA
             throw handleServerException(ERROR_CODE_ERROR_GET_ORGANIZATION_USER_ASSOCIATIONS, e);
         }
     }
+
+    @Override
+    public void updateSharedTypeOfUserAssociation(int id, SharedType sharedType)
+            throws OrganizationManagementServerException {
+        NamedJdbcTemplate namedJdbcTemplate = getNewTemplate();
+
+        try {
+            namedJdbcTemplate.executeUpdate(
+                    UPDATE_USER_ASSOCIATION_SHARED_TYPE,
+                    namedPreparedStatement -> {
+                        namedPreparedStatement.setInt(COLUMN_NAME_UM_ID, id);
+                        namedPreparedStatement.setString(COLUMN_NAME_UM_SHARED_TYPE, sharedType.name());
+                    });
+        } catch (DataAccessException e) {
+            throw handleServerException(ERROR_CODE_ERROR_GET_ORGANIZATION_USER_ASSOCIATIONS, e);
+        }
+    }
+
 }

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/dao/OrganizationUserSharingDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/dao/OrganizationUserSharingDAOImpl.java
@@ -437,7 +437,6 @@ public class OrganizationUserSharingDAOImpl implements OrganizationUserSharingDA
                         String.join(", ", orgIdPlaceholders));
 
         NamedJdbcTemplate namedJdbcTemplate = getNewTemplate();
-
         try {
             return namedJdbcTemplate.executeQuery(
                     fetchUserAssociationsQuery,
@@ -469,8 +468,8 @@ public class OrganizationUserSharingDAOImpl implements OrganizationUserSharingDA
     @Override
     public void updateSharedTypeOfUserAssociation(int id, SharedType sharedType)
             throws OrganizationManagementServerException {
-        NamedJdbcTemplate namedJdbcTemplate = getNewTemplate();
 
+        NamedJdbcTemplate namedJdbcTemplate = getNewTemplate();
         try {
             namedJdbcTemplate.executeUpdate(
                     UPDATE_USER_ASSOCIATION_SHARED_TYPE,
@@ -482,5 +481,4 @@ public class OrganizationUserSharingDAOImpl implements OrganizationUserSharingDA
             throw handleServerException(ERROR_CODE_ERROR_UPDATE_ORGANIZATION_USER_ASSOCIATIONS, e);
         }
     }
-
 }

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/dao/OrganizationUserSharingDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/dao/OrganizationUserSharingDAOImpl.java
@@ -76,6 +76,7 @@ import static org.wso2.carbon.identity.organization.management.service.constant.
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_GET_ORGANIZATION_USER_ASSOCIATIONS;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_GET_ORGANIZATION_USER_ASSOCIATION_FOR_USER_AT_SHARED_ORG;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_GET_ORGANIZATION_USER_ASSOCIATION_OF_SHARED_USER;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ERROR_UPDATE_ORGANIZATION_USER_ASSOCIATIONS;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.getNewTemplate;
 import static org.wso2.carbon.identity.organization.management.service.util.Utils.handleServerException;
 import static org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants.Error.UNEXPECTED_SERVER_ERROR;
@@ -478,7 +479,7 @@ public class OrganizationUserSharingDAOImpl implements OrganizationUserSharingDA
                         namedPreparedStatement.setString(COLUMN_NAME_UM_SHARED_TYPE, sharedType.name());
                     });
         } catch (DataAccessException e) {
-            throw handleServerException(ERROR_CODE_ERROR_GET_ORGANIZATION_USER_ASSOCIATIONS, e);
+            throw handleServerException(ERROR_CODE_ERROR_UPDATE_ORGANIZATION_USER_ASSOCIATIONS, e);
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -582,7 +582,7 @@
         <org.wso2.identity.organization.mgt.imp.pkg.version.range>[1.0.0,2.0.0)
         </org.wso2.identity.organization.mgt.imp.pkg.version.range>
 
-        <identity.organization.management.core.version>1.1.21</identity.organization.management.core.version>
+        <identity.organization.management.core.version>1.1.22</identity.organization.management.core.version>
         <org.wso2.identity.organization.mgt.core.imp.pkg.version.range>[1.0.0,2.0.0)
         </org.wso2.identity.organization.mgt.core.imp.pkg.version.range>
 


### PR DESCRIPTION
## Purpose
Resolves the issue where a shared user was only retained in the last organization from the request payload, causing previous shared organizations to be removed.

## Goals
Ensure that users remain shared across all specified organizations in the request payload by keeping track of organizations from the ongoing request.

## Approach
Introduced a new mechanism to track organizations for which the user-sharing request has been initiated.
- Maintains a list (orgsInCurrentRequest) to track organizations in the current request.
- Filters out already processed organizations from previous requests to prevent unintended removals.
- Ensures user associations persist correctly across all requested organizations.

---
## Related Issue
[Shared User Removed from Previously Selected Organizations in Selective User Sharing #22927](https://github.com/wso2/product-is/issues/22927)