### PR TITLE
Improve Organization-User Association Check for Performance and Ensure Multi-DB Compatibility

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/OrganizationUserSharingService.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/OrganizationUserSharingService.java
@@ -148,6 +148,20 @@ public interface OrganizationUserSharingService {
     }
 
     /**
+     * Checks if the given user has any associations in the specified organization.
+     *
+     * @param associatedUserId The ID of the associated user.
+     * @param associatedOrgId  The organization ID where the user's identity is managed.
+     * @return True if the user has associations in the specified organization.
+     * @throws OrganizationManagementServerException If an error occurs while checking user associations.
+     */
+    default boolean hasUserAssociations(String associatedUserId, String associatedOrgId)
+            throws OrganizationManagementServerException {
+
+        throw new NotImplementedException("hasUserAssociations method is not implemented.");
+    }
+
+    /**
      * Retrieve the list of usernames that are not eligible to be removed from the specified role within the given
      * tenant domain, based on the permissions of the requesting organization.
      *

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/OrganizationUserSharingService.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/OrganizationUserSharingService.java
@@ -148,11 +148,11 @@ public interface OrganizationUserSharingService {
     }
 
     /**
-     * Checks if the given user has any associations in the specified organization.
+     * Checks if the given user has at least one association with any child organization.
      *
      * @param associatedUserId The ID of the associated user.
      * @param associatedOrgId  The organization ID where the user's identity is managed.
-     * @return True if the user has associations in the specified organization.
+     * @return True if the user has at least one association with any organization.
      * @throws OrganizationManagementServerException If an error occurs while checking user associations.
      */
     default boolean hasUserAssociations(String associatedUserId, String associatedOrgId)

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/OrganizationUserSharingServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/OrganizationUserSharingServiceImpl.java
@@ -140,6 +140,13 @@ public class OrganizationUserSharingServiceImpl implements OrganizationUserShari
     }
 
     @Override
+    public boolean hasUserAssociations(String associatedUserId, String associatedOrgId)
+            throws OrganizationManagementServerException {
+
+        return organizationUserSharingDAO.hasUserAssociations(associatedUserId, associatedOrgId);
+    }
+
+    @Override
     public List<String> getNonDeletableUserRoleAssignments(String roleId, List<String> deletedUserNamesList,
                                                            String tenantDomain, String requestingOrgId)
             throws IdentityRoleManagementException {

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImpl.java
@@ -917,10 +917,7 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
     private boolean isUserAlreadyShared(String associatedUserId, String associatedOrgId)
             throws OrganizationManagementException {
 
-        List<UserAssociation> userAssociationsOfGivenUser =
-                getSharedUserAssociationsOfGivenUser(associatedUserId, associatedOrgId);
-
-        return userAssociationsOfGivenUser != null && !userAssociationsOfGivenUser.isEmpty();
+        return getOrganizationUserSharingService().hasUserAssociations(associatedUserId, associatedOrgId);
     }
 
     /**

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImpl.java
@@ -330,7 +330,7 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
         }
     }
 
-    //Asynchronous Processing Methods.
+    // Asynchronous Processing Methods.
 
     /**
      * Processes selective user sharing based on the provided user criteria and organization details.
@@ -479,7 +479,7 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
         }
     }
 
-    //User Sharing & Unsharing Helper Methods.
+    // User Sharing & Unsharing Helper Methods.
 
     /**
      * Shares a user with selected organizations based on the provided user list and sharing policies.
@@ -574,7 +574,7 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
                     getOrganizationUserSharingService().unshareOrganizationUserInSharedOrganization(associatedUserId,
                             organizationId);
 
-                    //Delete resource sharing policy if it has been stored for future shares.
+                    // Delete resource sharing policy if it has been stored for future shares.
                     deleteResourceSharingPolicyIfAny(organizationId, associatedUserId, unsharingInitiatedOrgId);
                 }
             } catch (OrganizationManagementException | ResourceSharingPolicyMgtException e) {
@@ -597,7 +597,7 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
             try {
                 getOrganizationUserSharingService().unshareOrganizationUsers(associatedUserId, unsharingInitiatedOrgId);
 
-                //Delete resource sharing policy if it has been stored for future shares.
+                // Delete resource sharing policy if it has been stored for future shares.
                 getResourceSharingPolicyHandlerService().deleteResourceSharingPolicyByResourceTypeAndId(
                         ResourceType.USER, associatedUserId, unsharingInitiatedOrgId);
             } catch (OrganizationManagementException | ResourceSharingPolicyMgtException e) {
@@ -606,7 +606,7 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
         }
     }
 
-    //Business Logic Methods.
+    // Business Logic Methods.
 
     /**
      * Shares a user with the specified organizations.
@@ -1033,7 +1033,7 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
         }
     }
 
-    //Resource Sharing Policy Management Methods.
+    // Resource Sharing Policy Management Methods.
 
     /**
      * Saves a new resource sharing policy for a user.
@@ -1077,10 +1077,10 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
     private void updateResourceSharingPolicy(BaseUserShare baseUserShare, String sharingInitiatedOrgId)
             throws ResourceSharingPolicyMgtException {
 
-        //Delete old sharing policy.
+        // Delete old sharing policy.
         removeResourceSharingPolicy(baseUserShare, sharingInitiatedOrgId);
 
-        //Create new sharing policy.
+        // Create new sharing policy.
         if (isApplicableOrganizationScopeForSavingPolicy(baseUserShare.getPolicy())) {
             saveUserSharingPolicy(baseUserShare, sharingInitiatedOrgId);
         }
@@ -1164,7 +1164,7 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
                 organizationId, ResourceType.USER, associatedUserId, unsharingInitiatedOrgId);
     }
 
-    //Role Management Helper Methods.
+    // Role Management Helper Methods.
 
     /**
      * Retrieves a list of role IDs based on the provided role and audience details.
@@ -1351,7 +1351,7 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
             return;
         }
 
-        //Assign roles if any are present.
+        // Assign roles if any are present.
         assignRolesIfPresent(userAssociation, sharingInitiatedOrgId, roleIds);
     }
 
@@ -1474,7 +1474,7 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
         return String.format(API_REF_GET_SHARED_ROLES_OF_USER_IN_ORG, userId, orgId);
     }
 
-    //Validation Methods.
+    // Validation Methods.
 
     private <T extends UserCriteriaType> void validateUserShareInput(BaseUserShareDO<T> baseUserShareDO)
             throws UserSharingMgtClientException {
@@ -1602,7 +1602,7 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
         throw new UserSharingMgtClientException(error.getCode(), error.getMessage(), error.getDescription());
     }
 
-    //Async helpers.
+    // Async helpers.
 
     /**
      * Restores thread-local properties for async execution.
@@ -1621,7 +1621,7 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
         IdentityUtil.threadLocalProperties.get().putAll(threadLocalProperties);
     }
 
-    //Service getters.
+    // Service getters.
 
     private OrganizationUserSharingService getOrganizationUserSharingService() {
 

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/constant/SQLConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/constant/SQLConstants.java
@@ -176,12 +176,11 @@ public class SQLConstants {
         public static final String COLUMN_NAME_UM_EDIT_OPERATION = "UM_EDIT_OPERATION";
         public static final String COLUMN_NAME_UM_PERMITTED_ORG_ID = "UM_PERMITTED_ORG_ID";
         public static final String COLUMN_NAME_UM_ROLE_UUID = "UM_UUID";
+        public static final String HAS_USER_ASSOCIATIONS = "has_user_associations";
 
         public static final String PLACEHOLDER_NAME_USER_NAMES = "USER_NAMES";
         public static final String PLACEHOLDER_ROLE_IDS = "ROLE_IDS";
         public static final String PLACEHOLDER_ORG_IDS = "ORG_IDS";
-
-        public static final String HAS_USER_ASSOCIATIONS = "has_user_associations";
     }
 
     /**

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/constant/SQLConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/constant/SQLConstants.java
@@ -49,6 +49,36 @@ public class SQLConstants {
             "UM_USER_ID, UM_ORG_ID, UM_ASSOCIATED_USER_ID, UM_ASSOCIATED_ORG_ID, UM_SHARED_TYPE " +
             "FROM UM_ORG_USER_ASSOCIATION WHERE UM_ASSOCIATED_USER_ID = ? AND UM_ASSOCIATED_ORG_ID = ? AND " +
             "UM_SHARED_TYPE = ?";
+    public static final String CHECK_USER_ORG_ASSOCIATION_EXISTS =
+            "SELECT EXISTS ( " +
+                    "    SELECT 1 FROM UM_ORG_USER_ASSOCIATION " +
+                    "    WHERE UM_ASSOCIATED_USER_ID = :" + SQLPlaceholders.COLUMN_NAME_ASSOCIATED_USER_ID + "; " +
+                    "    AND UM_ASSOCIATED_ORG_ID = :" + SQLPlaceholders.COLUMN_NAME_ASSOCIATED_ORG_ID + "; " +
+                    ") AS has_user_associations;";
+    public static final String CHECK_USER_ORG_ASSOCIATION_EXISTS_ORACLE =
+            "SELECT CASE " +
+                    "    WHEN EXISTS ( " +
+                    "        SELECT 1 FROM UM_ORG_USER_ASSOCIATION " +
+                    "        WHERE UM_ASSOCIATED_USER_ID = :" + SQLPlaceholders.COLUMN_NAME_ASSOCIATED_USER_ID + "; " +
+                    "        AND UM_ASSOCIATED_ORG_ID = :" + SQLPlaceholders.COLUMN_NAME_ASSOCIATED_ORG_ID + "; " +
+                    "    ) THEN 1 ELSE 0 " +
+                    "END AS has_user_associations FROM DUAL;";
+    public static final String CHECK_USER_ORG_ASSOCIATION_EXISTS_MSSQL =
+            "SELECT CASE " +
+                    "    WHEN EXISTS ( " +
+                    "        SELECT 1 FROM UM_ORG_USER_ASSOCIATION " +
+                    "        WHERE UM_ASSOCIATED_USER_ID = :" + SQLPlaceholders.COLUMN_NAME_ASSOCIATED_USER_ID + "; " +
+                    "        AND UM_ASSOCIATED_ORG_ID = :" + SQLPlaceholders.COLUMN_NAME_ASSOCIATED_ORG_ID + "; " +
+                    "    ) THEN 1 ELSE 0 " +
+                    "END AS has_user_associations;";
+    public static final String CHECK_USER_ORG_ASSOCIATION_EXISTS_DB2 =
+            "SELECT CASE " +
+                    "    WHEN EXISTS ( " +
+                    "        SELECT 1 FROM UM_ORG_USER_ASSOCIATION " +
+                    "        WHERE UM_ASSOCIATED_USER_ID = :" + SQLPlaceholders.COLUMN_NAME_ASSOCIATED_USER_ID + "; " +
+                    "        AND UM_ASSOCIATED_ORG_ID = :" + SQLPlaceholders.COLUMN_NAME_ASSOCIATED_ORG_ID + "; " +
+                    "    ) THEN 1 ELSE 0 " +
+                    "END AS has_user_associations FROM SYSIBM.SYSDUMMY1;";
     public static final String GET_ORGANIZATION_USER_ASSOCIATION_FOR_ROOT_USER_IN_ORG = "SELECT UM_ID, UM_USER_ID, " +
             "UM_ORG_ID, UM_ASSOCIATED_USER_ID, UM_ASSOCIATED_ORG_ID, UM_SHARED_TYPE FROM UM_ORG_USER_ASSOCIATION " +
             "WHERE UM_ASSOCIATED_USER_ID = ? AND UM_ORG_ID = ?";
@@ -150,6 +180,21 @@ public class SQLConstants {
         public static final String PLACEHOLDER_NAME_USER_NAMES = "USER_NAMES";
         public static final String PLACEHOLDER_ROLE_IDS = "ROLE_IDS";
         public static final String PLACEHOLDER_ORG_IDS = "ORG_IDS";
+
+        public static final String HAS_USER_ASSOCIATIONS = "has_user_associations";
+    }
+
+    /**
+     * Database types related to organization user sharing SQL operations.
+     */
+    public static final class DBTypes {
+
+        public static final String DB_TYPE_DB2 = "db2";
+        public static final String DB_TYPE_MSSQL = "mssql";
+        public static final String DB_TYPE_MYSQL = "mysql";
+        public static final String DB_TYPE_ORACLE = "oracle";
+        public static final String DB_TYPE_POSTGRESQL = "postgresql";
+        public static final String DB_TYPE_DEFAULT = "default";
     }
 
 }

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/dao/OrganizationUserSharingDAO.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/dao/OrganizationUserSharingDAO.java
@@ -114,11 +114,11 @@ public interface OrganizationUserSharingDAO {
     }
 
     /**
-     * Checks if the given user has any associations in the specified organization.
+     * Checks if the given user has at least one association with any child organization.
      *
      * @param associatedUserId The ID of the associated user.
      * @param associatedOrgId  The organization ID where the user's identity is managed.
-     * @return True if the user has associations in the specified organization.
+     * @return True if the user has at least one association with any organization.
      * @throws OrganizationManagementServerException If an error occurs while checking user associations.
      */
     default boolean hasUserAssociations(String associatedUserId, String associatedOrgId)

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/dao/OrganizationUserSharingDAO.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/dao/OrganizationUserSharingDAO.java
@@ -114,6 +114,20 @@ public interface OrganizationUserSharingDAO {
     }
 
     /**
+     * Checks if the given user has any associations in the specified organization.
+     *
+     * @param associatedUserId The ID of the associated user.
+     * @param associatedOrgId  The organization ID where the user's identity is managed.
+     * @return True if the user has associations in the specified organization.
+     * @throws OrganizationManagementServerException If an error occurs while checking user associations.
+     */
+    default boolean hasUserAssociations(String associatedUserId, String associatedOrgId)
+            throws OrganizationManagementServerException {
+
+        throw new NotImplementedException("hasUserAssociations method is not implemented.");
+    }
+
+    /**
      * Get the organization user association of a given user in a given organization.
      *
      * @param associatedUserId ID of the associated user.

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/dao/OrganizationUserSharingDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/dao/OrganizationUserSharingDAOImpl.java
@@ -547,8 +547,7 @@ public class OrganizationUserSharingDAOImpl implements OrganizationUserSharingDA
             return dbQueryMap.get(DB_TYPE_ORACLE);
         } else if (isPostgreSqlDB()) {
             return dbQueryMap.get(DB_TYPE_POSTGRESQL);
-        } else {
-            return dbQueryMap.get(DB_TYPE_DEFAULT);
         }
+        return dbQueryMap.get(DB_TYPE_DEFAULT);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -582,7 +582,7 @@
         <org.wso2.identity.organization.mgt.imp.pkg.version.range>[1.0.0,2.0.0)
         </org.wso2.identity.organization.mgt.imp.pkg.version.range>
 
-        <identity.organization.management.core.version>1.1.22</identity.organization.management.core.version>
+        <identity.organization.management.core.version>1.1.23</identity.organization.management.core.version>
         <org.wso2.identity.organization.mgt.core.imp.pkg.version.range>[1.0.0,2.0.0)
         </org.wso2.identity.organization.mgt.core.imp.pkg.version.range>
 


### PR DESCRIPTION
## Purpose
The existing implementation retrieves the full list of user-organization associations to check if an association exists. This approach is inefficient, particularly for large datasets, as it unnecessarily loads data instead of simply checking for existence.

This PR introduces an optimized SQL query using `EXISTS`, ensuring improved performance and compatibility across multiple database types.

## Goals
- Improve query efficiency by replacing the full association retrieval with an `EXISTS` check.
- Ensure compatibility with all required database types: H2, IBM DB2, MSSQL, MySQL, MySQL Cluster, Oracle, Oracle RAC, and PostgreSQL.
- Centralize query selection logic in `OrganizationUserSharingDAOImpl` for easier maintainability and scalability.

## Approach
- Replaced fetching a full list of associations with a direct EXISTS query for better performance.
- Introduced a centralized query selection mechanism in `OrganizationUserSharingDAOImpl` to ensure compatibility across multiple database types.
- Implemented a mapping system to dynamically select the appropriate query based on the database in use.
- Improved exception handling for better error reporting and debugging.

---

## Related Issue
[Enhance Organization-User Association Check for Performance #22991](https://github.com/wso2/product-is/issues/22991)
