### PR TITLE
Support Domain-Qualified Usernames for Non-Deletable Role Assignments

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/OrganizationUserSharingService.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/OrganizationUserSharingService.java
@@ -151,15 +151,16 @@ public interface OrganizationUserSharingService {
      * Retrieve the list of usernames that are not eligible to be removed from the specified role within the given
      * tenant domain, based on the permissions of the requesting organization.
      *
-     * @param roleId               The role ID from which the users are to be removed.
-     * @param deletedUserNamesList The list of usernames intended for removal.
-     * @param tenantDomain         The tenant domain where the role assignment is available.
-     * @param requestingOrgId      The ID of the requesting organization performing the operation.
+     * @param roleId                              The role ID from which the users are to be removed.
+     * @param deletedDomainQualifiedUserNamesList The list of usernames with domain intended for removal.
+     * @param tenantDomain                        The tenant domain where the role assignment is available.
+     * @param requestingOrgId                     The ID of the requesting organization performing the operation.
      * @return A list of usernames that the requesting organization is not permitted to remove from the given role.
      * @throws IdentityRoleManagementException If an error occurs while validating the permissions or retrieving
      *                                         eligible usernames.
      */
-    default List<String> getNonDeletableUserRoleAssignments(String roleId, List<String> deletedUserNamesList,
+    default List<String> getNonDeletableUserRoleAssignments(String roleId,
+                                                            List<String> deletedDomainQualifiedUserNamesList,
                                                             String tenantDomain, String requestingOrgId)
             throws IdentityRoleManagementException {
 

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/OrganizationUserSharingServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/OrganizationUserSharingServiceImpl.java
@@ -140,11 +140,13 @@ public class OrganizationUserSharingServiceImpl implements OrganizationUserShari
     }
 
     @Override
-    public List<String> getNonDeletableUserRoleAssignments(String roleId, List<String> deletedUserNamesList,
+    public List<String> getNonDeletableUserRoleAssignments(String roleId,
+                                                           List<String> deletedDomainQualifiedUserNamesList,
                                                            String tenantDomain, String requestingOrgId)
             throws IdentityRoleManagementException {
 
-        return organizationUserSharingDAO.getNonDeletableUserRoleAssignments(roleId, deletedUserNamesList,
+        return organizationUserSharingDAO.getNonDeletableUserRoleAssignments(roleId,
+                deletedDomainQualifiedUserNamesList,
                 tenantDomain, requestingOrgId);
     }
 

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/constant/SQLConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/constant/SQLConstants.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.organization.management.organization.user.sharing.constant;
 
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.SQLConstants.SQLPlaceholders.COLUMN_NAME_UM_DOMAIN_NAME;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.SQLConstants.SQLPlaceholders.COLUMN_NAME_UM_EDIT_OPERATION;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.SQLConstants.SQLPlaceholders.COLUMN_NAME_UM_PERMITTED_ORG_ID;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.SQLConstants.SQLPlaceholders.COLUMN_NAME_UM_TENANT_ID;
@@ -57,11 +58,14 @@ public class SQLConstants {
             "WHERE UM_USER_ID = ? AND UM_ORG_ID = ?";
     public static final String GET_RESTRICTED_USERNAMES_BY_ROLE_AND_ORG =
             "SELECT r.UM_USER_NAME FROM UM_HYBRID_USER_ROLE r "
+                    + "INNER JOIN UM_DOMAIN d "
+                    + "ON r.UM_DOMAIN_ID = d.UM_DOMAIN_ID AND r.UM_TENANT_ID = d.UM_TENANT_ID "
                     + "INNER JOIN UM_HYBRID_USER_ROLE_RESTRICTED_EDIT_PERMISSIONS p "
                     + "ON r.UM_ID = p.UM_HYBRID_USER_ROLE_ID AND r.UM_TENANT_ID = p.UM_HYBRID_USER_ROLE_TENANT_ID "
                     + "INNER JOIN UM_HYBRID_ROLE h "
                     + "ON r.UM_ROLE_ID = h.UM_ID AND r.UM_TENANT_ID = h.UM_TENANT_ID "
                     + "WHERE h.UM_UUID = :" + COLUMN_NAME_UM_UUID + "; "
+                    + "AND d.UM_DOMAIN_NAME = :" + COLUMN_NAME_UM_DOMAIN_NAME + "; "
                     + "AND r.UM_USER_NAME IN (" + PLACEHOLDER_NAME_USER_NAMES + ") "
                     + "AND r.UM_TENANT_ID = :" + COLUMN_NAME_UM_TENANT_ID + "; "
                     + "AND p.UM_PERMITTED_ORG_ID != :" + COLUMN_NAME_UM_PERMITTED_ORG_ID + "; "
@@ -87,7 +91,7 @@ public class SQLConstants {
                     "WHERE UR.UM_USER_NAME = :" + SQLPlaceholders.COLUMN_NAME_UM_USER_NAME + "; " +
                     "AND H.UM_UUID = :" + SQLPlaceholders.COLUMN_NAME_UM_UUID + "; " +
                     "AND UR.UM_TENANT_ID = :" + SQLPlaceholders.COLUMN_NAME_UM_TENANT_ID + "; " +
-                    "AND D.UM_DOMAIN_NAME = :" + SQLPlaceholders.COLUMN_NAME_UM_DOMAIN_NAME + ";";
+                    "AND D.UM_DOMAIN_NAME = :" + COLUMN_NAME_UM_DOMAIN_NAME + ";";
     public static final String INSERT_RESTRICTED_EDIT_PERMISSION =
             "INSERT INTO UM_HYBRID_USER_ROLE_RESTRICTED_EDIT_PERMISSIONS (" +
                     "UM_HYBRID_USER_ROLE_ID, UM_HYBRID_USER_ROLE_TENANT_ID, " +
@@ -109,7 +113,7 @@ public class SQLConstants {
                     "AND UHR.UM_TENANT_ID = :" + SQLPlaceholders.COLUMN_NAME_UM_TENANT_ID + "; " +
                     "AND UHR.UM_DOMAIN_ID = (SELECT UM_DOMAIN_ID FROM UM_DOMAIN WHERE " +
                     "UM_TENANT_ID = :" + SQLPlaceholders.COLUMN_NAME_UM_TENANT_ID + "; " +
-                    "AND UM_DOMAIN_NAME = :" + SQLPlaceholders.COLUMN_NAME_UM_DOMAIN_NAME + ";);";
+                    "AND UM_DOMAIN_NAME = :" + COLUMN_NAME_UM_DOMAIN_NAME + ";);";
     public static final String GET_USER_ASSOCIATIONS_OF_USER_IN_GIVEN_ORGS =
             "SELECT UM_ID, UM_USER_ID, UM_ORG_ID, UM_ASSOCIATED_USER_ID, UM_ASSOCIATED_ORG_ID, UM_SHARED_TYPE " +
                     "FROM UM_ORG_USER_ASSOCIATION " +

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/dao/OrganizationUserSharingDAO.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/dao/OrganizationUserSharingDAO.java
@@ -139,16 +139,17 @@ public interface OrganizationUserSharingDAO {
      * Retrieve the list of usernames that are not eligible to be removed from the specified role within the given
      * tenant domain, based on the permissions of the requesting organization.
      *
-     * @param roleId               The role ID from which the users are to be removed.
-     * @param deletedUserNamesList The list of usernames intended for removal.
-     * @param tenantDomain         The tenant domain where the operation is being performed.
-     * @param requestingOrgId      The ID of the requesting organization performing the operation.
+     * @param roleId                              The role ID from which the users are to be removed.
+     * @param deletedDomainQualifiedUserNamesList The list of usernames with domain intended for removal.
+     * @param tenantDomain                        The tenant domain where the operation is being performed.
+     * @param requestingOrgId                     The ID of the requesting organization performing the operation.
      * @return A list of usernames that the requesting organization is not permitted to remove from the given role.
      * @throws IdentityRoleManagementException If an error occurs while validating the permissions or retrieving
      *                                         eligible usernames.
      */
-    default List<String> getNonDeletableUserRoleAssignments(String roleId, List<String> deletedUserNamesList,
-                                                                    String tenantDomain, String requestingOrgId)
+    default List<String> getNonDeletableUserRoleAssignments(String roleId,
+                                                            List<String> deletedDomainQualifiedUserNamesList,
+                                                            String tenantDomain, String requestingOrgId)
             throws IdentityRoleManagementException {
 
         throw new NotImplementedException("getNonDeletableUserRoleAssignments method is not implemented.");

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/SharedUserRoleGovernanceListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/SharedUserRoleGovernanceListener.java
@@ -67,10 +67,11 @@ public class SharedUserRoleGovernanceListener extends AbstractRoleManagementList
                 return;
             }
 
-            List<String> deletedUserNamesList = USER_ID_RESOLVER.getNamesByIDs(deletedUserIDList, tenantDomain);
+            List<String> deletedDomainQualifiedUserNamesList =
+                    USER_ID_RESOLVER.getNamesByIDs(deletedUserIDList, tenantDomain);
             List<String> nonDeletableUserNamesList =
-                    getOrganizationUserSharingService().getNonDeletableUserRoleAssignments(roleID, deletedUserNamesList,
-                            tenantDomain, Utils.getOrganizationId());
+                    getOrganizationUserSharingService().getNonDeletableUserRoleAssignments(roleID,
+                            deletedDomainQualifiedUserNamesList, tenantDomain, Utils.getOrganizationId());
 
             if (CollectionUtils.isNotEmpty(nonDeletableUserNamesList)) {
                 String errorMessage = String.format(


### PR DESCRIPTION
## Purpose
Previously, the retrieval of non-deletable user role assignments did not consider domain-qualified usernames, leading to potential mismatches in multi-domain environments. This update ensures that role assignment checks are correctly performed by grouping usernames based on their respective domains.

## Goals
- Accurately retrieve non-deletable user role assignments by considering domain-qualified usernames.
- Ensure domain-specific constraints are respected during query execution.
- Improve code maintainability by structuring queries per domain.

## Approach
- Introduced logic to group usernames by domain before executing queries.
- Modified the query execution process to handle domain-separated usernames, ensuring accurate retrieval.
- Preserved existing functionality while enhancing support for multi-domain IAM environments.