### PR TITLE
Inherit local claim properties and attribute mappings during organization creation

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.application/src/test/java/org/wso2/carbon/identity/organization/management/application/handler/OrgClaimMgtHandlerTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/test/java/org/wso2/carbon/identity/organization/management/application/handler/OrgClaimMgtHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023-2025, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -25,6 +25,7 @@ import org.mockito.MockitoAnnotations;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.claim.metadata.mgt.ClaimMetadataManagementService;
 import org.wso2.carbon.identity.claim.metadata.mgt.model.AttributeMapping;
@@ -33,8 +34,12 @@ import org.wso2.carbon.identity.claim.metadata.mgt.util.ClaimConstants;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.event.event.Event;
 import org.wso2.carbon.identity.organization.management.application.internal.OrgApplicationMgtDataHolder;
+import org.wso2.carbon.identity.organization.management.ext.Constants;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.organization.management.service.model.BasicOrganization;
+import org.wso2.carbon.identity.organization.management.service.model.Organization;
+import org.wso2.carbon.identity.organization.management.service.model.ParentOrganizationDO;
+import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
 import org.wso2.carbon.user.api.RealmConfiguration;
 import org.wso2.carbon.user.api.UserRealm;
 import org.wso2.carbon.user.core.UserCoreConstants;
@@ -89,8 +94,14 @@ public class OrgClaimMgtHandlerTest {
     private static final String TEST_ORG_ID = "org123";
     private static final String TEST_CHILD_ORG_ID = "child123";
     private static final String TEST_PRIMARY_USER_STORE = "PRIMARY";
+    private static final String TEST_SECONDARY_USER_STORE = "SECONDARY";
     private static final String TEST_LOCAL_CLAIM_URI = "http://wso2.org/claims/test";
+    private static final String TEST_CUSTOM_LOCAL_CLAIM_URI = "http://wso2.org/claims/custom";
     private static final String TEST_LOCAL_CLAIM_DISPLAY_NAME = "test";
+    private static final String TEST_UPDATED_LOCAL_CLAIM_DISPLAY_NAME = "updated";
+    private static final String TEST_USER_STORE_ATTRIBUTE_MAPPING = "check";
+    private static final String TEST_PRIMARY_ATTRIBUTE_MAPPING = "attributeMapping";
+    private static final String TEST_CUSTOM_PRIMARY_ATTRIBUTE_MAPPING = "customAttributeMapping";
     private static final String TEST_LOCAL_CLAIM_DIALECT = ClaimConstants.LOCAL_CLAIM_DIALECT_URI;
 
     @BeforeMethod
@@ -148,12 +159,8 @@ public class OrgClaimMgtHandlerTest {
         eventProperties.put(MAPPED_ATTRIBUTES, new ArrayList<>(mappedAttributes));
 
         // Create local claim properties.
-        Map<String, String> localClaimProperties = new HashMap<>();
-        localClaimProperties.put(ClaimConstants.CLAIM_URI_PROPERTY, TEST_LOCAL_CLAIM_URI);
-        localClaimProperties.put(ClaimConstants.DIALECT_PROPERTY, TEST_LOCAL_CLAIM_DIALECT);
-        localClaimProperties.put(ClaimConstants.DISPLAY_NAME_PROPERTY, TEST_LOCAL_CLAIM_DISPLAY_NAME);
-        localClaimProperties.put(ClaimConstants.EXCLUDED_USER_STORES_PROPERTY, String.format("%s,%s",
-                TEST_PRIMARY_USER_STORE, rootOrgSecondaryUserStore));
+        Map<String, String> localClaimProperties =
+                getLocalClaimProperties(String.format("%s,%s", TEST_PRIMARY_USER_STORE, rootOrgSecondaryUserStore));
         eventProperties.put(LOCAL_CLAIM_PROPERTIES, localClaimProperties);
 
         Event event = new Event(POST_UPDATE_LOCAL_CLAIM, eventProperties);
@@ -168,8 +175,8 @@ public class OrgClaimMgtHandlerTest {
         when(organizationManager.resolveTenantDomain(anyString())).thenReturn(TEST_CHILD_ORD_TENANT_DOMAIN);
 
         // Mock the existing local claim.
-        LocalClaim subOrgLocalClaim = createSubOrgLocalClaim(
-                new AttributeMapping(subOrgSecondaryUserStore, "check"),
+        LocalClaim subOrgLocalClaim = createLocalClaim(TEST_LOCAL_CLAIM_URI, TEST_PRIMARY_ATTRIBUTE_MAPPING,
+                new AttributeMapping(subOrgSecondaryUserStore, TEST_USER_STORE_ATTRIBUTE_MAPPING),
                 subOrgSecondaryUserStore);
         when(claimMetadataManagementService.getLocalClaims(TEST_CHILD_ORD_TENANT_DOMAIN))
                 .thenReturn(new ArrayList<>(Collections.singletonList(subOrgLocalClaim)));
@@ -199,24 +206,135 @@ public class OrgClaimMgtHandlerTest {
                 .anyMatch(mapping -> subOrgSecondaryUserStore.equals(mapping.getUserStoreDomain())));
     }
 
-    private LocalClaim createSubOrgLocalClaim(AttributeMapping secondaryUserStoreMapping,
-                                              String excludedUserStores) {
+    @DataProvider(name = "claimPropertyAndAttributeMappingInheritanceDataProvider")
+    public Object[][] claimPropertyAndAttributeMappingInheritanceDataProvider() {
 
-        // Existing Local Claim in sub organization.
-        LocalClaim localClaim = new LocalClaim(TEST_LOCAL_CLAIM_URI);
+        return new Object[][] {
+                { true, true }, { true, false }, { false, true }, { false, false }
+        };
+    }
+
+    /**
+     * Test for Claim Properties and PRIMARY User Store Attribute Mapping inheritance during an Organization creation.
+     */
+    @Test(dataProvider = "claimPropertyAndAttributeMappingInheritanceDataProvider")
+    public void testClaimPropertyAndAttributeMappingInheritance(boolean isClaimPropertiesDifferent,
+                                                                boolean isMappedAttributesDifferent) throws Exception {
+
+        try (MockedStatic<OrganizationManagementUtil> organizationManagementUtil
+                     = mockStatic(OrganizationManagementUtil.class)) {
+
+            Organization organization = new Organization();
+            organization.setParent(new ParentOrganizationDO());
+            organization.setId(TEST_ORG_ID);
+
+            when(OrganizationManagementUtil.isOrganization(TEST_ORG_ID)).thenReturn(true);
+            when(organizationManager.resolveTenantDomain(null)).thenReturn(TEST_TENANT_DOMAIN);
+
+            // Create test event properties.
+            Map<String, Object> eventProperties = new HashMap<>();
+            eventProperties.put(Constants.EVENT_PROP_ORGANIZATION, organization);
+
+            // Change the parent organization's claim's PRIMARY user store attribute mapping.
+            String primaryAttributeMapping = isMappedAttributesDifferent ? TEST_CUSTOM_PRIMARY_ATTRIBUTE_MAPPING
+                    : TEST_PRIMARY_ATTRIBUTE_MAPPING;
+            LocalClaim defaultParentOrgLocalClaim = createLocalClaim(TEST_LOCAL_CLAIM_URI, primaryAttributeMapping,
+                    new AttributeMapping(TEST_SECONDARY_USER_STORE, TEST_USER_STORE_ATTRIBUTE_MAPPING),
+                    TEST_SECONDARY_USER_STORE);
+
+            // Change the parent organization's claim's display name claim property value.
+            if (isClaimPropertiesDifferent) {
+                defaultParentOrgLocalClaim.setClaimProperty(ClaimConstants.DISPLAY_NAME_PROPERTY,
+                        TEST_UPDATED_LOCAL_CLAIM_DISPLAY_NAME);
+            }
+            // Add a custom claim to parent organization. This should not be inherited.
+            LocalClaim customClaim = createLocalClaim(TEST_CUSTOM_LOCAL_CLAIM_URI, TEST_PRIMARY_ATTRIBUTE_MAPPING,
+                    null, null);
+
+            // Create the parent organization's local claims.
+            List<LocalClaim> parentOrgLocalClaims = new ArrayList<>();
+            parentOrgLocalClaims.add(defaultParentOrgLocalClaim);
+            parentOrgLocalClaims.add(customClaim);
+            when(claimMetadataManagementService.getLocalClaims(TEST_TENANT_DOMAIN)).thenReturn(parentOrgLocalClaims);
+
+            // Create the sub organization's local claim.
+            LocalClaim defaultCreatedOrgLocalClaim
+                    = createLocalClaim(TEST_LOCAL_CLAIM_URI, TEST_PRIMARY_ATTRIBUTE_MAPPING, null, null);
+            when(claimMetadataManagementService.getLocalClaims(TEST_ORG_ID))
+                    .thenReturn(new ArrayList<>(Collections.singletonList(defaultCreatedOrgLocalClaim)));
+
+            // Method execution.
+            Event event = new Event(Constants.EVENT_POST_ADD_ORGANIZATION, eventProperties);
+            orgClaimMgtHandler.handleEvent(event);
+
+            // Capture the LocalClaim passed to updateLocalClaim and verify its content.
+            ArgumentCaptor<LocalClaim> localClaimCaptor = ArgumentCaptor.forClass(LocalClaim.class);
+
+            if (isClaimPropertiesDifferent || isMappedAttributesDifferent) {
+                verify(claimMetadataManagementService, times(1))
+                        .updateLocalClaim(localClaimCaptor.capture(), anyString());
+                LocalClaim updatedClaim = localClaimCaptor.getValue();
+
+                // Assert it's the default claim which is updated and not the custom claim added.
+                Assert.assertEquals(updatedClaim.getClaimURI(), TEST_LOCAL_CLAIM_URI);
+
+                // Assert the ExcludedUserStores claim property is excluded when inheriting the properties.
+                Assert.assertNull(updatedClaim.getClaimProperties().get(ClaimConstants.EXCLUDED_USER_STORES_PROPERTY));
+
+                // Assert only the primary user store mapping was inherited.
+                List<AttributeMapping> updatedAttributeMappings = updatedClaim.getMappedAttributes();
+                Assert.assertEquals(updatedAttributeMappings.size(), 1);
+                Assert.assertTrue(updatedAttributeMappings.stream()
+                        .anyMatch(mapping -> TEST_PRIMARY_USER_STORE.equals(mapping.getUserStoreDomain())));
+                if (isMappedAttributesDifferent) {
+                    Assert.assertTrue(updatedAttributeMappings.stream().anyMatch(
+                            mapping -> TEST_CUSTOM_PRIMARY_ATTRIBUTE_MAPPING.equals(mapping.getAttributeName())));
+                } else {
+                    Assert.assertTrue(updatedAttributeMappings.stream().anyMatch(
+                            mapping -> TEST_PRIMARY_ATTRIBUTE_MAPPING.equals(mapping.getAttributeName())));
+                }
+                // Assert the display name claim property is inherited correctly.
+                if (isClaimPropertiesDifferent) {
+                    Assert.assertTrue(updatedClaim.getClaimProperties().get(ClaimConstants.DISPLAY_NAME_PROPERTY)
+                            .equals(TEST_UPDATED_LOCAL_CLAIM_DISPLAY_NAME));
+                } else {
+                    Assert.assertTrue(updatedClaim.getClaimProperties().get(ClaimConstants.DISPLAY_NAME_PROPERTY)
+                            .equals(TEST_LOCAL_CLAIM_DISPLAY_NAME));
+                }
+            } else {
+                verify(claimMetadataManagementService, times(0))
+                        .updateLocalClaim(localClaimCaptor.capture(), anyString());
+            }
+        }
+    }
+
+    private LocalClaim createLocalClaim(String claimURI, String attributeMapping,
+                                        AttributeMapping secondaryUserStoreMapping, String excludedUserStores) {
+
+        LocalClaim localClaim = new LocalClaim(claimURI);
 
         List<AttributeMapping> subOrgClaimMappedAttributes = new ArrayList<>();
-        subOrgClaimMappedAttributes.add(new AttributeMapping(TEST_PRIMARY_USER_STORE, "test"));
-        subOrgClaimMappedAttributes.add(secondaryUserStoreMapping);
+        subOrgClaimMappedAttributes.add(new AttributeMapping(TEST_PRIMARY_USER_STORE, attributeMapping));
+        if (secondaryUserStoreMapping != null) {
+            subOrgClaimMappedAttributes.add(secondaryUserStoreMapping);
+        }
         localClaim.setMappedAttributes(subOrgClaimMappedAttributes);
 
-        Map<String, String> subOrgClaimProperties = new HashMap<>();
-        subOrgClaimProperties.put(ClaimConstants.CLAIM_URI_PROPERTY, TEST_LOCAL_CLAIM_URI);
-        subOrgClaimProperties.put(ClaimConstants.DIALECT_PROPERTY, TEST_LOCAL_CLAIM_DIALECT);
-        subOrgClaimProperties.put(ClaimConstants.DISPLAY_NAME_PROPERTY, "test");
-        subOrgClaimProperties.put(ClaimConstants.EXCLUDED_USER_STORES_PROPERTY, excludedUserStores);
+        Map<String, String> subOrgClaimProperties = getLocalClaimProperties(excludedUserStores);
         localClaim.setClaimProperties(subOrgClaimProperties);
 
         return localClaim;
+    }
+
+    private static Map<String, String> getLocalClaimProperties(String excludedUserStores) {
+
+        Map<String, String> localClaimProperties = new HashMap<>();
+        localClaimProperties.put(ClaimConstants.CLAIM_URI_PROPERTY, TEST_LOCAL_CLAIM_URI);
+        localClaimProperties.put(ClaimConstants.DIALECT_PROPERTY, TEST_LOCAL_CLAIM_DIALECT);
+        localClaimProperties.put(ClaimConstants.DISPLAY_NAME_PROPERTY, TEST_LOCAL_CLAIM_DISPLAY_NAME);
+        if (excludedUserStores != null) {
+            localClaimProperties.put(ClaimConstants.EXCLUDED_USER_STORES_PROPERTY, excludedUserStores);
+        }
+        return localClaimProperties;
     }
 }


### PR DESCRIPTION
## Purpose
Fixes: https://github.com/wso2/product-is/issues/22061

## Goals
The following goals are achieved through this fix:

- The claim properties get propagated during the organization's creation.
- The attribute mapping name for the **PRIMARY** user store gets propagated during the organization's creation.
- The attribute mapping names for the other user stores are not inherited.
- The **ExcludedUserStores** is excluded when inheriting the properties.
- The custom local claims are not inherited.

**IMPORTANT**: This approach is slightly rudimentary, as any changes in the claim properties and attribute mappings would update the local claim in the database.

## Approach
Let the OrgClaimMgtHandler subscribe to the POST_ADD_ORGANIZATION event, and handle the claim propagation accordingly.