### PR TITLE
[Claim] Return Shared Type Claim in User Profile Responses

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/constant/UserSharingConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/constant/UserSharingConstants.java
@@ -67,7 +67,7 @@ public class UserSharingConstants {
     public static final String DEFAULT_PROFILE = "default";
     public static final String CLAIM_MANAGED_ORGANIZATION = "http://wso2.org/claims/identity/managedOrg";
     public static final String ID_CLAIM_READ_ONLY = "http://wso2.org/claims/identity/isReadOnlyUser";
-    public static final String CLAIM_USER_SHARED_TYPE = "http://wso2.org/claims/identity/sharedType"
+    public static final String CLAIM_USER_SHARED_TYPE = "http://wso2.org/claims/identity/sharedType";
 
     public static final String ORG_MGT_PERMISSION = "/permission/admin/manage/identity/organizationmgt";
     public static final String ORG_ROLE_MGT_PERMISSION = "/permission/admin/manage/identity/rolemgt";

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/constant/UserSharingConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/constant/UserSharingConstants.java
@@ -67,6 +67,7 @@ public class UserSharingConstants {
     public static final String DEFAULT_PROFILE = "default";
     public static final String CLAIM_MANAGED_ORGANIZATION = "http://wso2.org/claims/identity/managedOrg";
     public static final String ID_CLAIM_READ_ONLY = "http://wso2.org/claims/identity/isReadOnlyUser";
+    public static final String CLAIM_USER_SHARED_TYPE = "http://wso2.org/claims/identity/sharedType"
 
     public static final String ORG_MGT_PERMISSION = "/permission/admin/manage/identity/organizationmgt";
     public static final String ORG_ROLE_MGT_PERMISSION = "/permission/admin/manage/identity/rolemgt";

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/SharedUserOperationEventListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/SharedUserOperationEventListener.java
@@ -54,13 +54,11 @@ import org.wso2.carbon.user.core.service.RealmService;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import static org.wso2.carbon.identity.claim.metadata.mgt.util.ClaimConstants.SHARED_PROFILE_VALUE_RESOLVING_METHOD;
 import static org.wso2.carbon.identity.claim.metadata.mgt.util.ClaimConstants.SharedProfileValueResolvingMethod.FROM_FIRST_FOUND_IN_HIERARCHY;

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/test/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/SharedUserOperationEventListenerTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/test/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/SharedUserOperationEventListenerTest.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.identity.core.model.IdentityEventListenerConfig;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.OrganizationUserSharingService;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.SharedType;
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.internal.OrganizationUserSharingDataHolder;
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.models.UserAssociation;
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.util.OrganizationSharedUserUtil;
@@ -431,12 +432,12 @@ public class SharedUserOperationEventListenerTest {
                 Only groups claim will be returned, because no value resolved from origin for
                 given name and custom claim.
                  */
-                {claimValuesWithOutCustomClaim, null, 1},
+                {claimValuesWithOutCustomClaim, null, 2},
                 /*
                  Only groups claim and custom claim will be returned, because no value resolved from origin
                  for given name.
                  */
-                {claimValuesWithCustomClaim, "value1", 2},
+                {claimValuesWithCustomClaim, "value1", 3},
         };
     }
 
@@ -671,6 +672,7 @@ public class SharedUserOperationEventListenerTest {
         userAssociationOfUser1InOrgL1.setOrganizationId(L1_ORG_ID);
         userAssociationOfUser1InOrgL1.setAssociatedUserId(USER_1_IN_ROOT);
         userAssociationOfUser1InOrgL1.setUserResidentOrganizationId(ROOT_ORG_ID);
+        userAssociationOfUser1InOrgL1.setSharedType(SharedType.SHARED);
         when(organizationUserSharingService.getUserAssociation(SHARED_USER_OF_USER_1_IN_L1_ORG, L1_ORG_ID)).thenReturn(
                 userAssociationOfUser1InOrgL1);
 
@@ -679,8 +681,27 @@ public class SharedUserOperationEventListenerTest {
         userAssociationOfUser1InOrgL2.setOrganizationId(L2_ORG_ID);
         userAssociationOfUser1InOrgL2.setAssociatedUserId(USER_1_IN_ROOT);
         userAssociationOfUser1InOrgL2.setUserResidentOrganizationId(ROOT_ORG_ID);
+        userAssociationOfUser1InOrgL2.setSharedType(SharedType.INVITED);
         when(organizationUserSharingService.getUserAssociation(SHARED_USER_OF_USER_1_IN_L2_ORG, L2_ORG_ID)).thenReturn(
                 userAssociationOfUser1InOrgL2);
+
+        UserAssociation userAssociationOfUser1InOrgL3 = new UserAssociation();
+        userAssociationOfUser1InOrgL3.setUserId(SHARED_USER_OF_USER_1_IN_L1_ORG);
+        userAssociationOfUser1InOrgL3.setOrganizationId(L1_ORG_ID);
+        userAssociationOfUser1InOrgL3.setAssociatedUserId(USER_1_IN_ROOT);
+        userAssociationOfUser1InOrgL3.setUserResidentOrganizationId(ROOT_ORG_ID);
+        userAssociationOfUser1InOrgL3.setSharedType(SharedType.SHARED);
+        when(organizationUserSharingService.getUserAssociation(SHARED_USER_OF_USER_1_IN_L1_ORG, L1_ORG_ID)).thenReturn(
+                userAssociationOfUser1InOrgL3);
+
+        UserAssociation userAssociationOfUser1InOrgL4 = new UserAssociation();
+        userAssociationOfUser1InOrgL4.setUserId(SHARED_USER_OF_USER_1_IN_L2_ORG);
+        userAssociationOfUser1InOrgL4.setOrganizationId(L2_ORG_ID);
+        userAssociationOfUser1InOrgL4.setAssociatedUserId(USER_1_IN_ROOT);
+        userAssociationOfUser1InOrgL4.setUserResidentOrganizationId(ROOT_ORG_ID);
+        userAssociationOfUser1InOrgL4.setSharedType(SharedType.NOT_SPECIFIED);
+        when(organizationUserSharingService.getUserAssociation(SHARED_USER_OF_USER_1_IN_L2_ORG, L2_ORG_ID)).thenReturn(
+                userAssociationOfUser1InOrgL4);
 
         when(organizationUserSharingService.getUserAssociation(USER_1_IN_ROOT, ROOT_ORG_ID)).thenReturn(null);
     }

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/test/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/SharedUserOperationEventListenerTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/test/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/SharedUserOperationEventListenerTest.java
@@ -99,6 +99,7 @@ public class SharedUserOperationEventListenerTest {
     private static final String CUSTOM_CLAIM_1 = "http://wso2.org/claims/customAttribute1";
     private static final String CUSTOM_CLAIM_2 = "http://wso2.org/claims/customAttribute2";
     private static final String MANAGED_ORG_CLAIM = "http://wso2.org/claims/identity/managedOrg";
+    private static final String USER_SHARED_TYPE_CLAIM = "http://wso2.org/claims/identity/sharedType";
 
     @Mock
     OrganizationManager organizationManager;
@@ -350,6 +351,74 @@ public class SharedUserOperationEventListenerTest {
         }
     }
 
+    @DataProvider(name = "dataProviderForTestDoPostGetUserClaimValueWithIDForSharedType")
+    public Object[][] dataProviderForTestDoPostGetUserClaimValueWithIDForSharedType() {
+
+        return new Object[][]{
+                // If sharedType is NOT_SPECIFIED, expected sharedType should be INVITED.
+                {SHARED_USER_OF_USER_1_IN_L2_ORG, L1_ORG_TENANT_DOMAIN, L1_ORG_ID, true, SharedType.NOT_SPECIFIED,
+                        SharedType.INVITED.name()},
+
+                // If sharedType is SHARED, expected sharedType should be SHARED.
+                {SHARED_USER_OF_USER_1_IN_L2_ORG, L2_ORG_TENANT_DOMAIN, L2_ORG_ID, true, SharedType.SHARED,
+                        SharedType.SHARED.name()},
+
+                // If sharedType is OWNER, expected sharedType should be OWNER.
+                {SHARED_USER_OF_USER_1_IN_L2_ORG, L1_ORG_TENANT_DOMAIN, L1_ORG_ID, true, SharedType.OWNER,
+                        SharedType.OWNER.name()},
+
+                // If sharedType is INVITED, expected sharedType should be INVITED.
+                {SHARED_USER_OF_USER_1_IN_L2_ORG, L2_ORG_TENANT_DOMAIN, L2_ORG_ID, true, SharedType.INVITED,
+                        SharedType.INVITED.name()},
+        };
+    }
+
+    @Test(dataProvider = "dataProviderForTestDoPostGetUserClaimValueWithIDForSharedType")
+    public void testDoPostGetUserClaimValueWithIDForSharedType(String userId, String tenantDomain,
+                                                               String organizationId, boolean isOrganization,
+                                                               SharedType sharedType, String expectedSharedType)
+            throws Exception {
+
+        setUpClaims();
+        setUpUserSharing();
+        mockCarbonContextForTenant(tenantDomain, organizationId, privilegedCarbonContext);
+        mockOrgIdResolverByTenantDomain();
+        organizationManagementUtilMockedStatic.when(() -> OrganizationManagementUtil.isOrganization(anyString()))
+                .thenReturn(isOrganization);
+        identityTenantUtil.when(() -> IdentityTenantUtil.getTenantId(anyString())).thenReturn(1);
+        when(realmService.getTenantUserRealm(anyInt())).thenReturn(tenantUserRealm);
+        when(tenantUserRealm.getUserStoreManager()).thenReturn(userStoreManager);
+
+        // Mock user association to return specified shared type
+        UserAssociation userAssociation = new UserAssociation();
+        userAssociation.setUserId(userId);
+        userAssociation.setOrganizationId(organizationId);
+        userAssociation.setSharedType(sharedType);
+        when(organizationUserSharingService.getUserAssociation(userId, organizationId)).thenReturn(userAssociation);
+
+        // Mock LocalClaim to return "FromSharedProfile" when getClaimProperty is called
+        LocalClaim mockLocalClaim = mock(LocalClaim.class);
+        when(mockLocalClaim.getClaimProperty(SHARED_PROFILE_VALUE_RESOLVING_METHOD))
+                .thenReturn("FromSharedProfile");
+
+        // Ensure claimManagementService.getLocalClaim(...) returns an Optional containing the mockLocalClaim
+        when(claimManagementService.getLocalClaim(anyString(), anyString()))
+                .thenReturn(Optional.of(mockLocalClaim));
+
+        try (MockedStatic<IdentityUtil> identityUtil = Mockito.mockStatic(IdentityUtil.class)) {
+            mockListenerEnabledStatus(true, true, identityUtil);
+            SharedUserOperationEventListener sharedUserOperationEventListener = new SharedUserOperationEventListener();
+            List<String> claimValues = new ArrayList<>();
+            boolean listenerStatus =
+                    sharedUserOperationEventListener.doPostGetUserClaimValueWithID(userId, USER_SHARED_TYPE_CLAIM,
+                            claimValues, DEFAULT_PROFILE, userStoreManager);
+
+            assertEquals(claimValues.size(), 1, "Expected exactly one claim value.");
+            assertEquals(claimValues.get(0), expectedSharedType, "SharedType claim value should match expected value.");
+            assertTrue(listenerStatus);
+        }
+    }
+
     @DataProvider(name = "dataProviderForTestDoPostGetUserClaimValuesWithID")
     public Object[][] dataProviderForTestDoPostGetUserClaimValuesWithID() {
 
@@ -429,13 +498,13 @@ public class SharedUserOperationEventListenerTest {
 
         return new Object[][]{
                 /*
-                Only groups claim will be returned, because no value resolved from origin for
+                Only groups claim and the shareType claim will be returned, because no value resolved from origin for
                 given name and custom claim.
                  */
                 {claimValuesWithOutCustomClaim, null, 2},
                 /*
-                 Only groups claim and custom claim will be returned, because no value resolved from origin
-                 for given name.
+                 Only groups claim, custom claim and the shareType claim will be returned, because no value resolved
+                 from origin for given name.
                  */
                 {claimValuesWithCustomClaim, "value1", 3},
         };
@@ -672,7 +741,7 @@ public class SharedUserOperationEventListenerTest {
         userAssociationOfUser1InOrgL1.setOrganizationId(L1_ORG_ID);
         userAssociationOfUser1InOrgL1.setAssociatedUserId(USER_1_IN_ROOT);
         userAssociationOfUser1InOrgL1.setUserResidentOrganizationId(ROOT_ORG_ID);
-        userAssociationOfUser1InOrgL1.setSharedType(SharedType.SHARED);
+        userAssociationOfUser1InOrgL1.setSharedType(SharedType.NOT_SPECIFIED);
         when(organizationUserSharingService.getUserAssociation(SHARED_USER_OF_USER_1_IN_L1_ORG, L1_ORG_ID)).thenReturn(
                 userAssociationOfUser1InOrgL1);
 
@@ -681,27 +750,9 @@ public class SharedUserOperationEventListenerTest {
         userAssociationOfUser1InOrgL2.setOrganizationId(L2_ORG_ID);
         userAssociationOfUser1InOrgL2.setAssociatedUserId(USER_1_IN_ROOT);
         userAssociationOfUser1InOrgL2.setUserResidentOrganizationId(ROOT_ORG_ID);
-        userAssociationOfUser1InOrgL2.setSharedType(SharedType.INVITED);
+        userAssociationOfUser1InOrgL2.setSharedType(SharedType.SHARED);
         when(organizationUserSharingService.getUserAssociation(SHARED_USER_OF_USER_1_IN_L2_ORG, L2_ORG_ID)).thenReturn(
                 userAssociationOfUser1InOrgL2);
-
-        UserAssociation userAssociationOfUser1InOrgL3 = new UserAssociation();
-        userAssociationOfUser1InOrgL3.setUserId(SHARED_USER_OF_USER_1_IN_L1_ORG);
-        userAssociationOfUser1InOrgL3.setOrganizationId(L1_ORG_ID);
-        userAssociationOfUser1InOrgL3.setAssociatedUserId(USER_1_IN_ROOT);
-        userAssociationOfUser1InOrgL3.setUserResidentOrganizationId(ROOT_ORG_ID);
-        userAssociationOfUser1InOrgL3.setSharedType(SharedType.SHARED);
-        when(organizationUserSharingService.getUserAssociation(SHARED_USER_OF_USER_1_IN_L1_ORG, L1_ORG_ID)).thenReturn(
-                userAssociationOfUser1InOrgL3);
-
-        UserAssociation userAssociationOfUser1InOrgL4 = new UserAssociation();
-        userAssociationOfUser1InOrgL4.setUserId(SHARED_USER_OF_USER_1_IN_L2_ORG);
-        userAssociationOfUser1InOrgL4.setOrganizationId(L2_ORG_ID);
-        userAssociationOfUser1InOrgL4.setAssociatedUserId(USER_1_IN_ROOT);
-        userAssociationOfUser1InOrgL4.setUserResidentOrganizationId(ROOT_ORG_ID);
-        userAssociationOfUser1InOrgL4.setSharedType(SharedType.NOT_SPECIFIED);
-        when(organizationUserSharingService.getUserAssociation(SHARED_USER_OF_USER_1_IN_L2_ORG, L2_ORG_ID)).thenReturn(
-                userAssociationOfUser1InOrgL4);
 
         when(organizationUserSharingService.getUserAssociation(USER_1_IN_ROOT, ROOT_ORG_ID)).thenReturn(null);
     }


### PR DESCRIPTION
## Purpose
Ensure that the shared type claim is returned in user profile responses by updating the `SharedUserOperationEventListener`.

## Goals
- Dynamically populate the shared type value when retrieving user claims.
- Set the default value for old shared users as `INVITED`.
- Ensure that the claim is correctly populated in all relevant user retrieval methods.

## Approach
- Updated `doPostGetUserClaimValuesWithID`, `doPostGetUsersClaimValuesWithID`, and `doPostGetUserClaimValueWithID` to set the sharedType claim dynamically.
- Introduced `setRuntimeClaims(claimMap, Collections.singleton(CLAIM_USER_SHARED_TYPE), userAssociation)` to resolve the shared type from user associations.
- Implemented `getClaimBasedOnSharedType()` to determine the shared type from userAssociation, defaulting to `INVITED` for older shared users. (This defaulting to `INVITED` is necessary because some older shared user data still has the attribute set to `NOT_SPECIFIED`, as the shared user type was introduced in WSO2 IS 7.1. Since we cannot return `NOT_SPECIFIED` in the response, previous `OWNERS` are also considered as `INVITED`.)

## Related PRs
Merge after: [[Claim][IS] Add Shared Type Local Claim and Map to SCIM2 Claim #6511](https://github.com/wso2/carbon-identity-framework/pull/6511)
Merge after: [[Claim][IS] Update SCIM2 Schema to Include Shared Type Attribute #613](https://github.com/wso2-extensions/identity-inbound-provisioning-scim2/pull/613)

---

## Related Issues
[Display user shared type in shared user profile #23071](https://github.com/wso2/product-is/issues/23071)