### PR TITLE
Remove Unnecessary Query Parameters from rolesRef in Shared Users GET API Response

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/constant/UserSharingConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/constant/UserSharingConstants.java
@@ -91,7 +91,7 @@ public class UserSharingConstants {
     public static final String APPLICATION_AUTHENTICATION_TYPE = "APPLICATION";
 
     public static final String API_REF_GET_SHARED_ROLES_OF_USER_IN_ORG =
-            "/api/server/v1/users/%s/shared-roles?orgId=%s&after=&before=&limit=2&filter=&recursive=false";
+            "/api/server/v1/users/%s/shared-roles?orgId=%s";
 
     /*
     Minimum permissions required for org creator to logged in to the console and view user, groups, roles, SP,


### PR DESCRIPTION
## Purpose
The `rolesRef` field in the response of the Shared Users GET API (`/users/{userId}/shared-organizations`) currently includes unnecessary query parameters (`&after=&before=&limit=&filter=&recursive`). This PR removes these redundant parameters to improve API response clarity.

## Goals
- Ensure the `rolesRef` field only contains the base URL without unnecessary query parameters.
- Provide a cleaner and more intuitive API response.

## Approach
- Updated the API response logic to exclude unnecessary query parameters from `rolesRef`.
- Verified the new response format.
