### PR TITLE
Add missing dependencies for AuditLogBuilder in OSGi imports

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.application/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.application/pom.xml
@@ -96,6 +96,14 @@
             <groupId>commons-collections.wso2</groupId>
             <artifactId>commons-collections</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.central.log.mgt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.utils</artifactId>
+        </dependency>
         <!--Test Dependencies-->
         <dependency>
             <groupId>org.testng</groupId>
@@ -170,6 +178,7 @@
                             org.wso2.carbon.identity.core.model; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.core.persistence; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.core.util;version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.central.log.mgt.*; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.idp.mgt;version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.oauth; version="${identity.inbound.auth.oauth.import.version.range}",
                             org.wso2.carbon.identity.oauth.common; version="${identity.inbound.auth.oauth.import.version.range}",
@@ -183,6 +192,7 @@
                             org.wso2.carbon.user.core.common;version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.user.core.tenant;version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.utils.multitenancy;version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.utils;version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.identity.organization.management.service; version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
                             org.wso2.carbon.identity.organization.management.service.constant; version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
                             org.wso2.carbon.identity.organization.management.service.exception; version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",

--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
@@ -688,12 +688,12 @@ public class FragmentApplicationMgtListener extends AbstractApplicationMgtListen
                         if (LoggerUtils.isEnableV2AuditLogs()) {
                             AuditLog.AuditLogBuilder auditLogBuilder = new AuditLog.AuditLogBuilder(
                                     IdentityUtil.getInitiatorId(username, tenantDomain),
-                                    LoggerUtils.Target.Application.name(),
+                                    LoggerUtils.Target.User.name(),
                                     updatedApplicationName,
                                     LoggerUtils.Target.Application.name(),
                                     LogConstants.ApplicationManagement.UPDATE_APPLICATION_ACTION)
-                                    .data(buildAuditData(updatedApplicationName, sharedAppOrgId,
-                                            updatedApplicationName, sharedAppId, "Application conflict"));
+                                    .data(buildAuditData(updatedApplicationName, sharedAppOrgId, updatedApplicationName,
+                                            sharedAppId, "Application name conflict."));
                             LoggerUtils.triggerAuditLogEvent(auditLogBuilder, true);
                         }
                         LOG.warn(String.format(


### PR DESCRIPTION
## Purpose
$subject

Related PRs: https://github.com/wso2-extensions/identity-organization-management/pull/478
Related Issues:: https://github.com/wso2/product-is/issues/23085

The Warn Log:

<img width="775" alt="Screenshot 2025-02-17 at 23 50 52" src="https://github.com/user-attachments/assets/90afc43f-7a82-42f1-b9b6-c853d0e79a0c" />

The Audit Log:
```
TID: [-1234] [2025-02-17 23:49:50,456] [009775cb-b626-4a29-b32e-54958186be5d]  WARN {AUDIT_LOG} -
 {"id":"5514df35-95ad-45b2-8f2f-90e97e8f3980","recordedAt":"2025-02-17T18:19:50.452509Z",
"requestId":"009775cb-b626-4a29-b32e-54958186be5d","initiatorId":"aad2f0aa-d22f-4db5-9286-50060af0495e",
"initiatorType":"User","targetId":"pickup","targetType":"Application","action":"update-application",
"data":{"sharedTenantDomain":"46487945-eb2a-476b-8914-28609ef57fd9","parentAppName":"pickup",
"conflictingAppId":"67ae6c28-c9d5-4e37-8d4c-333e0378a215","conflictingAppName":"pickup",
"failureReason":"Application name conflict."}}
```