### PR TITLE
Allow application name modification for sub org managed applications

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
@@ -176,10 +176,10 @@ public class FragmentApplicationMgtListener extends AbstractApplicationMgtListen
                     IdentityUtil.threadLocalProperties.get().put(IS_APP_NAME_UPDATED, true);
                 }
             } else if (!isInternalProcess(tenantDomain)) {
-                if (existingApplication != null &&
+                if (isFragmentApp(existingApplication) &&
                         !existingApplication.getApplicationName().equals(serviceProvider.getApplicationName())) {
                     throw new IdentityApplicationManagementClientException(
-                            "Application name modification is not allowed for this organization.");
+                            "Application name modification is not allowed for shared applications.");
                 }
             }
         } catch (OrganizationManagementException e) {


### PR DESCRIPTION
## Purpose
$subject

Fixes: https://github.com/wso2/product-is/issues/23239

## Goals
Currently, modification of application names for sub-org-managed applications is restricted. This PR allows the modification of sub-org-managed applications.

**Tested outflows:**
- Root app name update allowed. It's shared app's name should be updated
- Invoke app name update call for sub org's shared app via REST API -> This should be blocked
- Invoke sub org own app's name update patch call -> This should allowed