### PR TITLE
Restrict fragment application deletion by resource ID

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
@@ -519,7 +519,10 @@ public class FragmentApplicationMgtListener extends AbstractApplicationMgtListen
                                             .containsKey(DELETE_FRAGMENT_APPLICATION))) {
                         return true;
                     }
-                    return false;
+                    throw new IdentityApplicationManagementClientException(
+                            format("Cannot delete shared application with resource id: %s. Delete is allowed " +
+                                    "only when the main application is deleted, or its sharing is revoked.",
+                                    application.getApplicationResourceId()));
                 }
             } catch (OrganizationManagementException e) {
                 throw new IdentityApplicationManagementException(

--- a/components/org.wso2.carbon.identity.organization.management.application/src/test/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListenerTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/test/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListenerTest.java
@@ -39,14 +39,18 @@ import org.wso2.carbon.identity.application.common.model.ServiceProvider;
 import org.wso2.carbon.identity.application.common.model.ServiceProviderProperty;
 import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.organization.management.application.dao.OrgApplicationMgtDAO;
 import org.wso2.carbon.identity.organization.management.application.internal.OrgApplicationMgtDataHolder;
 import org.wso2.carbon.identity.organization.management.application.model.MainApplicationDO;
+import org.wso2.carbon.identity.organization.management.application.model.SharedApplicationDO;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
 
 import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -58,6 +62,9 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertTrue;
 import static org.testng.AssertJUnit.assertEquals;
 import static org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants.IS_API_BASED_AUTHENTICATION_ENABLED_PROPERTY_NAME;
+import static org.wso2.carbon.identity.organization.management.application.constant.OrgApplicationMgtConstants.DELETE_FRAGMENT_APPLICATION;
+import static org.wso2.carbon.identity.organization.management.application.constant.OrgApplicationMgtConstants.DELETE_MAIN_APPLICATION;
+import static org.wso2.carbon.identity.organization.management.application.constant.OrgApplicationMgtConstants.DELETE_SHARE_FOR_MAIN_APPLICATION;
 import static org.wso2.carbon.identity.organization.management.application.constant.OrgApplicationMgtConstants.IS_FRAGMENT_APP;
 
 /**
@@ -73,6 +80,9 @@ public class FragmentApplicationMgtListenerTest {
 
     @Mock
     private ApplicationManagementService applicationManagementService;
+
+    @Mock
+    private SharedApplicationDO sharedApplicationDO;
 
     @InjectMocks
     private FragmentApplicationMgtListener fragmentApplicationMgtListener;
@@ -96,6 +106,7 @@ public class FragmentApplicationMgtListenerTest {
 
         MockitoAnnotations.openMocks(this);
         serviceProvider = mock(ServiceProvider.class);
+        sharedApplicationDO = mock(SharedApplicationDO.class);
         OrgApplicationMgtDataHolder.getInstance().setOrganizationManager(organizationManager);
         OrgApplicationMgtDataHolder.getInstance().setOrgApplicationMgtDAO(orgApplicationMgtDAO);
         OrgApplicationMgtDataHolder.getInstance().setApplicationManagementService(applicationManagementService);
@@ -249,6 +260,61 @@ public class FragmentApplicationMgtListenerTest {
                         .doPreUpdateApplication(sharedApplication, tenantDomain, userName);
                 assertTrue(result);
             }
+        }
+    }
+
+    @DataProvider(name = "testFragmentApplicationPreDeletionDataProvider")
+    public Object[][] testFragmentApplicationPreDeletionDataProvider() {
+
+        return new Object[][]{
+                {new String[]{DELETE_MAIN_APPLICATION}, false, true, false},
+                {new String[]{DELETE_SHARE_FOR_MAIN_APPLICATION}, false, true, false},
+                {new String[]{DELETE_FRAGMENT_APPLICATION}, false, true, false},
+                {new String[]{DELETE_FRAGMENT_APPLICATION}, true, true, true},
+                {new String[]{}, true, true, true},
+                {new String[]{}, false, true, true},
+                {new String[]{}, false, false, false},
+        };
+    }
+
+    @Test(dataProvider = "testFragmentApplicationPreDeletionDataProvider")
+    public void testFragmentApplicationPreDeletion(String[] threadLocalPropertiesSet, boolean isShareWithAllChildren,
+                                                   boolean isSharedApplicationPresent, boolean isExceptionExpected)
+            throws IdentityApplicationManagementException, OrganizationManagementException {
+
+        Map<String, Object> threadLocalProperties = new HashMap<>();
+        for (String property : threadLocalPropertiesSet) {
+            threadLocalProperties.put(property, true);
+        }
+        IdentityUtil.threadLocalProperties.set(threadLocalProperties);
+
+        ServiceProviderProperty[] spProperties = new ServiceProviderProperty[]{
+                mockServiceProviderProperty(IS_FRAGMENT_APP, TRUE)
+        };
+        when(serviceProvider.getSpProperties()).thenReturn(spProperties);
+        when(applicationManagementService.getServiceProvider(applicationName, tenantDomain))
+                .thenReturn(serviceProvider);
+        when(serviceProvider.getApplicationID()).thenReturn(1);
+        when(serviceProvider.getApplicationResourceId()).thenReturn(applicationResourceID);
+
+        if (isSharedApplicationPresent) {
+            when(orgApplicationMgtDAO.getSharedApplication(1, tenantDomain))
+                    .thenReturn(Optional.ofNullable(sharedApplicationDO));
+            when(sharedApplicationDO.shareWithAllChildren()).thenReturn(isShareWithAllChildren);
+        }
+        if (isExceptionExpected) {
+            IdentityApplicationManagementClientException thrownException =
+                    Assert.expectThrows(IdentityApplicationManagementClientException.class,
+                            () -> fragmentApplicationMgtListener
+                                    .doPreDeleteApplication(applicationName, tenantDomain, userName));
+
+            assertEquals(String.format("Cannot delete shared application with resource id: %s. " +
+                            "Delete is allowed only when the main application is deleted, or its sharing is revoked.",
+                    applicationResourceID), thrownException.getMessage());
+        } else {
+            boolean result = fragmentApplicationMgtListener
+                    .doPreDeleteApplication(applicationName, tenantDomain, userName);
+            assertTrue(result);
         }
     }
 


### PR DESCRIPTION
## Purpose
$subject

Fixes: https://github.com/wso2-enterprise/asgardeo-product/issues/29230

Instead of the server error, this error is now thrown:

<img width="1259" alt="Screenshot 2025-02-25 at 09 45 25" src="https://github.com/user-attachments/assets/a3776538-faa3-41dc-a8bc-9469e103ef79" />
