### PR TITLE
Fix NPE when Unsharing a User with Invalid User ID or Organization ID

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/OrganizationUserSharingServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/OrganizationUserSharingServiceImpl.java
@@ -215,15 +215,17 @@ public class OrganizationUserSharingServiceImpl implements OrganizationUserShari
 
     private void removeSharedUser(UserAssociation userAssociation) throws OrganizationManagementException {
 
-        String userId = userAssociation.getUserId();
-        String organizationId = userAssociation.getOrganizationId();
-        String tenantDomain = getOrganizationManager().resolveTenantDomain(organizationId);
-        int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
-        try {
-            AbstractUserStoreManager sharedOrgUserStoreManager = getAbstractUserStoreManager(tenantId);
-            deleteUserInTenantFlow(sharedOrgUserStoreManager, userId, tenantDomain, organizationId);
-        } catch (UserStoreException e) {
-            throw handleServerException(ERROR_CODE_ERROR_DELETE_SHARED_USER, e, userId, organizationId);
+        if (userAssociation != null) {
+            String userId = userAssociation.getUserId();
+            String organizationId = userAssociation.getOrganizationId();
+            String tenantDomain = getOrganizationManager().resolveTenantDomain(organizationId);
+            int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
+            try {
+                AbstractUserStoreManager sharedOrgUserStoreManager = getAbstractUserStoreManager(tenantId);
+                deleteUserInTenantFlow(sharedOrgUserStoreManager, userId, tenantDomain, organizationId);
+            } catch (UserStoreException e) {
+                throw handleServerException(ERROR_CODE_ERROR_DELETE_SHARED_USER, e, userId, organizationId);
+            }
         }
     }
 

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/OrganizationUserSharingServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/OrganizationUserSharingServiceImpl.java
@@ -18,8 +18,6 @@
 
 package org.wso2.carbon.identity.organization.management.organization.user.sharing;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
@@ -58,7 +56,6 @@ import static org.wso2.carbon.identity.organization.management.service.util.Util
  */
 public class OrganizationUserSharingServiceImpl implements OrganizationUserSharingService {
 
-    private static final Log LOG = LogFactory.getLog(OrganizationUserSharingServiceImpl.class);
     private final OrganizationUserSharingDAO organizationUserSharingDAO = new OrganizationUserSharingDAOImpl();
 
     @Override


### PR DESCRIPTION
## Purpose
Currently, when unsharing a user from a selective organization or a set of organizations, if the provided `userId` or `organizationId` is invalid (i.e., the user or organization does not exist), the server throws a `NullPointerException`.
**Expected behavior:** The API should skip invalid IDs and proceed with valid ones.

## Goals
- Prevent the API from failing with an NPE when encountering an invalid `userId` or `organizationId`.
- Ensure the API skips invalid entries and processes only valid user-organization mappings.

## Approach
- Added a null check for userAssociation before attempting to access its properties (`userId`, `organizationId`).
- This prevents potential NullPointerExceptions when the method is called with a `null` value.
- The rest of the logic remains unchanged, ensuring the method continues to delete the shared user when valid input is provided.

## Related Issues

[NullPointerException when Unsharing a User Selectively with Invalid User ID or Organization ID #23290](https://github.com/wso2/product-is/issues/23290)