### PR TITLE
Make Role Audience Type Comparison Case-Insensitive in User Sharing API

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImpl.java
@@ -1210,10 +1210,10 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
         }
 
         try {
-            if (StringUtils.equals(ORGANIZATION, role.getAudienceType())) {
+            if (StringUtils.equalsIgnoreCase(ORGANIZATION, role.getAudienceType())) {
                 return originalOrgId;
             }
-            if (StringUtils.equals(APPLICATION, role.getAudienceType())) {
+            if (StringUtils.equalsIgnoreCase(APPLICATION, role.getAudienceType())) {
                 return getApplicationResourceId(role.getAudienceName(), tenantDomain);
             }
             LOG.warn(String.format(ERROR_CODE_INVALID_AUDIENCE_TYPE.getDescription(), role.getAudienceType()));


### PR DESCRIPTION
## Purpose
Currently, in the User Sharing API, while the API accepts any case format for the `audience.type` field, the backend performs a case-sensitive comparison. This results in roles not being assigned if the audience type is not provided in lowercase.

This PR resolves this issue by ensuring that the backend performs a case-insensitive comparison, allowing roles to be assigned correctly regardless of how the `audience.type` value is formatted.

## Goals
- Ensure that role assignments work correctly irrespective of the capitalization of `audience.type`.
- Improve API usability by aligning backend behavior with the API's flexibility in accepting any case format.

## Approach
- Updated the backend logic to compare the `audience.type` field in a case-insensitive manner.

---

## Related Issue
[User Sharing API Should Support Case-Insensitive Role Audience Type #23309](https://github.com/wso2/product-is/issues/23309)