### PR TITLE
Add Unit Tests for User Sharing Component

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/test/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/test/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImplTest.java
@@ -57,6 +57,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.APPLICATION_AUDIENCE;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.APP_1_NAME;
@@ -190,7 +191,7 @@ public class UserSharingPolicyHandlerServiceImplTest {
         }
     }
 
-    @Test(expectedExceptions = UserSharingMgtClientException.class)
+    @Test
     public void testGetSharedOrganizationsOfUserWithClientException() throws Exception {
 
         utilsMockedStatic.when(Utils::getOrganizationId).thenReturn(ORG_SUPER_ID);
@@ -203,8 +204,10 @@ public class UserSharingPolicyHandlerServiceImplTest {
         when(mockOrgUserSharingService.getUserAssociationsOfGivenUser(anyString(), anyString())).thenThrow(
                 new OrganizationManagementException(VALIDATE_MSG_EXCEPTION));
 
-        // Invoke the method (expected to throw an exception).
-        userSharingPolicyHandlerService.getSharedOrganizationsOfUser(USER_1_ID, null, null, null, null, false);
+        // Assert that the expected exception is thrown
+        assertThrows(UserSharingMgtClientException.class,
+                () -> userSharingPolicyHandlerService.getSharedOrganizationsOfUser(USER_1_ID, null, null, null, null,
+                        false));
     }
 
     @DataProvider(name = "roleSharingDataProvider")
@@ -317,7 +320,7 @@ public class UserSharingPolicyHandlerServiceImplTest {
         assertEquals(response.getSharedRoles().size(), expectedRoles.size(), VALIDATE_MSG_RESPONSE_SHARED_ROLES_COUNT);
     }
 
-    @Test(expectedExceptions = UserSharingMgtClientException.class)
+    @Test
     public void testGetRolesSharedWithUserInOrganizationWithClientException() throws Exception {
 
         OrganizationUserSharingDataHolder dataHolder = mock(OrganizationUserSharingDataHolder.class);
@@ -336,9 +339,10 @@ public class UserSharingPolicyHandlerServiceImplTest {
         when(mockOrgManager.resolveTenantDomain(anyString())).thenThrow(
                 new OrganizationManagementException(VALIDATE_MSG_EXCEPTION));
 
-        // Invoke the method (expected to throw an exception).
-        userSharingPolicyHandlerService.getRolesSharedWithUserInOrganization(USER_1_ID, ORG_1_ID, null, null, null,
-                null, false);
+        // Assert that the expected exception is thrown
+        assertThrows(UserSharingMgtClientException.class,
+                () -> userSharingPolicyHandlerService.getRolesSharedWithUserInOrganization(USER_1_ID, ORG_1_ID, null,
+                        null, null, null, false));
     }
 
     // Test case Builders.

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/test/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/test/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImplTest.java
@@ -38,7 +38,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/test/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/test/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImplTest.java
@@ -1,0 +1,5 @@
+package org.wso2.carbon.identity.organization.management.organization.user.sharing;
+
+public class UserSharingPolicyHandlerServiceImplTest {
+
+}

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/test/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/test/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImplTest.java
@@ -1,5 +1,199 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.carbon.identity.organization.management.organization.user.sharing;
+
+import org.mockito.InjectMocks;
+import org.mockito.MockedStatic;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.SharedType;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.exception.UserSharingMgtClientException;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.internal.OrganizationUserSharingDataHolder;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.models.UserAssociation;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.models.dos.ResponseSharedOrgsDO;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.identity.organization.management.service.util.Utils;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.openMocks;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.ORG_1_ID;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.ORG_1_NAME;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.ORG_2_ID;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.ORG_2_NAME;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.ORG_3_ID;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.ORG_3_NAME;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.ORG_SUPER_ID;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.USER_1_ID;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.USER_2_ID;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.USER_3_ID;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.VALIDATE_MESSAGE_RESPONSE;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.VALIDATE_MESSAGE_RESPONSE_SHARED_ORGS;
 
 public class UserSharingPolicyHandlerServiceImplTest {
 
+    @InjectMocks
+    private UserSharingPolicyHandlerServiceImpl userSharingPolicyHandlerService;
+
+    private MockedStatic<UserSharingPolicyHandlerServiceImpl> userSharingPolicyHandlerServiceMock;
+
+    @BeforeMethod
+    public void setUp() {
+
+        openMocks(this);
+        userSharingPolicyHandlerServiceMock = mockStatic(UserSharingPolicyHandlerServiceImpl.class);
+    }
+
+    @AfterMethod
+    public void tearDown() {
+
+        userSharingPolicyHandlerServiceMock.close();
+    }
+
+    @DataProvider(name = "getSharedOrgsDataProvider")
+    public Object[][] getSharedOrgsDataProvider() {
+
+        return new Object[][]{
+                {USER_1_ID, setExpectedResultsForGetSharedOrgsTestCase1()},
+                {USER_2_ID, setExpectedResultsForGetSharedOrgsTestCase2()},
+                {USER_3_ID, setExpectedResultsForGetSharedOrgsTestCase3()}
+        };
+    }
+
+    @Test(dataProvider = "getSharedOrgsDataProvider")
+    public void testGetSharedOrganizationsOfUser(String associatedUserId, Map<String, UserAssociation> expectedResults)
+            throws Exception {
+
+        try (MockedStatic<Utils> utilsMockedStatic = mockStatic(Utils.class);
+             MockedStatic<OrganizationUserSharingDataHolder> dataHolderMock = mockStatic(
+                     OrganizationUserSharingDataHolder.class)) {
+
+            // Mock getOrganizationId() from the Utils class
+            utilsMockedStatic.when(Utils::getOrganizationId).thenReturn(ORG_SUPER_ID);
+
+            // Mock the data holder and return the mock service
+            OrganizationUserSharingDataHolder dataHolder = mock(OrganizationUserSharingDataHolder.class);
+            when(OrganizationUserSharingDataHolder.getInstance()).thenReturn(dataHolder);
+            OrganizationUserSharingService mockOrgUserSharingService = mock(OrganizationUserSharingService.class);
+            when(dataHolder.getOrganizationUserSharingService()).thenReturn(mockOrgUserSharingService);
+            OrganizationManager mockOrgManager = mock(OrganizationManager.class);
+            when(dataHolder.getOrganizationManager()).thenReturn(mockOrgManager);
+
+            // Mock organization names dynamically
+            List<UserAssociation> mockUserAssociations = new ArrayList<>();
+            for (Map.Entry<String, UserAssociation> entry : expectedResults.entrySet()) {
+                String orgName = entry.getKey();
+                UserAssociation userAssociation = entry.getValue();
+                when(mockOrgManager.getOrganizationNameById(userAssociation.getOrganizationId())).thenReturn(orgName);
+                mockUserAssociations.add(userAssociation);
+            }
+
+            when(mockOrgUserSharingService.getUserAssociationsOfGivenUser(associatedUserId, ORG_SUPER_ID))
+                    .thenReturn(mockUserAssociations);
+
+            // Call the method
+            ResponseSharedOrgsDO response =
+                    userSharingPolicyHandlerService.getSharedOrganizationsOfUser(associatedUserId, null, null, null,
+                            null, false);
+
+            // Validate response
+            assertNotNull(response, VALIDATE_MESSAGE_RESPONSE);
+            assertEquals(response.getSharedOrgs().size(), mockUserAssociations.size(),
+                    VALIDATE_MESSAGE_RESPONSE_SHARED_ORGS);
+
+            for (int i = 0; i < mockUserAssociations.size(); i++) {
+                UserAssociation expectedAssociation = mockUserAssociations.get(i);
+                assertEquals(response.getSharedOrgs().get(i).getOrganizationId(),
+                        expectedAssociation.getOrganizationId());
+                assertEquals(response.getSharedOrgs().get(i).getSharedUserId(), expectedAssociation.getUserId());
+                assertEquals(response.getSharedOrgs().get(i).getSharedType(), SharedType.SHARED);
+                assertTrue(expectedResults.containsKey(response.getSharedOrgs().get(i).getOrganizationName()));
+            }
+        }
+    }
+
+    @Test(expectedExceptions = UserSharingMgtClientException.class)
+    public void testGetSharedOrganizationsOfUser_ExceptionHandling() throws Exception {
+
+        try (MockedStatic<Utils> utilsMockedStatic = mockStatic(Utils.class);
+             MockedStatic<OrganizationUserSharingDataHolder> dataHolderMock = mockStatic(
+                     OrganizationUserSharingDataHolder.class)) {
+
+            // Mock getOrganizationId() from the Utils class
+            utilsMockedStatic.when(Utils::getOrganizationId).thenReturn(ORG_SUPER_ID);
+
+            // Mock the data holder and return the mock service
+            OrganizationUserSharingDataHolder dataHolder = mock(OrganizationUserSharingDataHolder.class);
+            when(OrganizationUserSharingDataHolder.getInstance()).thenReturn(dataHolder);
+            OrganizationUserSharingService mockOrgUserSharingService = mock(OrganizationUserSharingService.class);
+            when(dataHolder.getOrganizationUserSharingService()).thenReturn(mockOrgUserSharingService);
+
+            // Force an exception when calling getUserAssociationsOfGivenUser
+            when(mockOrgUserSharingService.getUserAssociationsOfGivenUser(anyString(), anyString()))
+                    .thenThrow(new OrganizationManagementException("Simulated Exception"));
+
+            // Invoke the method (expected to throw an exception)
+            userSharingPolicyHandlerService.getSharedOrganizationsOfUser(USER_1_ID, null, null, null, null, false);
+        }
+    }
+
+    // Test case Builders.
+
+    private Map<String, UserAssociation> setExpectedResultsForGetSharedOrgsTestCase1() {
+
+        Map<String, UserAssociation> expectedResults = new HashMap<>();
+        expectedResults.put(ORG_1_NAME, createUserAssociation(USER_1_ID, ORG_1_ID));
+        expectedResults.put(ORG_2_NAME, createUserAssociation(USER_1_ID, ORG_2_ID));
+        expectedResults.put(ORG_3_NAME, createUserAssociation(USER_1_ID, ORG_3_ID));
+        return expectedResults;
+    }
+
+    private Map<String, UserAssociation> setExpectedResultsForGetSharedOrgsTestCase2() {
+
+        return new HashMap<>();
+    }
+
+    private Map<String, UserAssociation> setExpectedResultsForGetSharedOrgsTestCase3() {
+
+        Map<String, UserAssociation> expectedResults = new HashMap<>();
+        expectedResults.put(ORG_1_NAME, createUserAssociation(USER_3_ID, ORG_1_ID));
+        return expectedResults;
+    }
+
+    // Helper Methods.
+
+    private UserAssociation createUserAssociation(String userId, String organizationId) {
+
+        UserAssociation userAssociation = new UserAssociation();
+        userAssociation.setUserId(userId);
+        userAssociation.setOrganizationId(organizationId);
+        userAssociation.setSharedType(SharedType.SHARED);
+        return userAssociation;
+    }
 }

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/test/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/test/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImplTest.java
@@ -100,6 +100,9 @@ import static org.wso2.carbon.identity.organization.management.organization.user
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.VALIDATE_MSG_SHARED_TYPE;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.VALIDATE_MSG_SHARED_USER_ID;
 
+/**
+ * Unit tests for UserSharingPolicyHandlerServiceImpl.
+ */
 public class UserSharingPolicyHandlerServiceImplTest {
 
     @InjectMocks

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/test/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/test/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImplTest.java
@@ -24,20 +24,32 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.SharedType;
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.exception.UserSharingMgtClientException;
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.internal.OrganizationUserSharingDataHolder;
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.models.UserAssociation;
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.models.dos.ResponseSharedOrgsDO;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.models.dos.ResponseSharedRolesDO;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 import org.wso2.carbon.identity.organization.management.service.util.Utils;
+import org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService;
+import org.wso2.carbon.identity.role.v2.mgt.core.model.Role;
+import org.wso2.carbon.identity.role.v2.mgt.core.util.UserIDResolver;
+import org.wso2.carbon.user.core.util.UserCoreUtil;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -46,18 +58,47 @@ import static org.mockito.MockitoAnnotations.openMocks;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.APPLICATION_AUDIENCE;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.APP_1_NAME;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.APP_2_NAME;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.APP_ROLE_1_ID;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.APP_ROLE_1_NAME;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.APP_ROLE_2_ID;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.APP_ROLE_2_NAME;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.FIELD_USER_ID_RESOLVER;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.ORGANIZATION_AUDIENCE;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.ORG_1_ID;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.ORG_1_NAME;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.ORG_2_ID;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.ORG_2_NAME;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.ORG_3_ID;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.ORG_3_NAME;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.ORG_ROLE_1_ID;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.ORG_ROLE_1_NAME;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.ORG_ROLE_2_ID;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.ORG_ROLE_2_NAME;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.ORG_SUPER_ID;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.PATH_SEPARATOR;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.TENANT_DOMAIN;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.TENANT_ID;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.USER_1_ID;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.USER_2_ID;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.USER_3_ID;
-import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.VALIDATE_MESSAGE_RESPONSE;
-import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.VALIDATE_MESSAGE_RESPONSE_SHARED_ORGS;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.USER_4_ID;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.USER_5_ID;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.USER_DOMAIN_PRIMARY;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.USER_NAME_PREFIX;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.VALIDATE_MSG_EXCEPTION;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.VALIDATE_MSG_RESPONSE;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.VALIDATE_MSG_RESPONSE_SHARED_ORGS_COUNT;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.VALIDATE_MSG_RESPONSE_SHARED_ROLES_COUNT;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.VALIDATE_MSG_SHARED_ORG_ID;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.VALIDATE_MSG_SHARED_ORG_NAME;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.VALIDATE_MSG_SHARED_ROLE_AUDIENCE_NAME;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.VALIDATE_MSG_SHARED_ROLE_AUDIENCE_TYPE;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.VALIDATE_MSG_SHARED_ROLE_NAME;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.VALIDATE_MSG_SHARED_TYPE;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.TestUserSharingConstants.VALIDATE_MSG_SHARED_USER_ID;
 
 public class UserSharingPolicyHandlerServiceImplTest {
 
@@ -65,19 +106,27 @@ public class UserSharingPolicyHandlerServiceImplTest {
     private UserSharingPolicyHandlerServiceImpl userSharingPolicyHandlerService;
 
     private MockedStatic<UserSharingPolicyHandlerServiceImpl> userSharingPolicyHandlerServiceMock;
+    private MockedStatic<OrganizationUserSharingDataHolder> dataHolderMock;
+    private MockedStatic<Utils> utilsMockedStatic;
 
     @BeforeMethod
     public void setUp() {
 
         openMocks(this);
         userSharingPolicyHandlerServiceMock = mockStatic(UserSharingPolicyHandlerServiceImpl.class);
+        dataHolderMock = mockStatic(OrganizationUserSharingDataHolder.class);
+        utilsMockedStatic = mockStatic(Utils.class);
     }
 
     @AfterMethod
     public void tearDown() {
 
         userSharingPolicyHandlerServiceMock.close();
+        dataHolderMock.close();
+        utilsMockedStatic.close();
     }
+
+    // Tests for GET Shared Orgs.
 
     @DataProvider(name = "getSharedOrgsDataProvider")
     public Object[][] getSharedOrgsDataProvider() {
@@ -93,77 +142,217 @@ public class UserSharingPolicyHandlerServiceImplTest {
     public void testGetSharedOrganizationsOfUser(String associatedUserId, Map<String, UserAssociation> expectedResults)
             throws Exception {
 
-        try (MockedStatic<Utils> utilsMockedStatic = mockStatic(Utils.class);
-             MockedStatic<OrganizationUserSharingDataHolder> dataHolderMock = mockStatic(
-                     OrganizationUserSharingDataHolder.class)) {
+        // Mock getOrganizationId() from the Utils class.
+        utilsMockedStatic.when(Utils::getOrganizationId).thenReturn(ORG_SUPER_ID);
 
-            // Mock getOrganizationId() from the Utils class
-            utilsMockedStatic.when(Utils::getOrganizationId).thenReturn(ORG_SUPER_ID);
+        // Mock the data holder and return the mock service.
+        OrganizationUserSharingDataHolder dataHolder = mock(OrganizationUserSharingDataHolder.class);
+        when(OrganizationUserSharingDataHolder.getInstance()).thenReturn(dataHolder);
+        OrganizationUserSharingService mockOrgUserSharingService = mock(OrganizationUserSharingService.class);
+        when(dataHolder.getOrganizationUserSharingService()).thenReturn(mockOrgUserSharingService);
+        OrganizationManager mockOrgManager = mock(OrganizationManager.class);
+        when(dataHolder.getOrganizationManager()).thenReturn(mockOrgManager);
 
-            // Mock the data holder and return the mock service
-            OrganizationUserSharingDataHolder dataHolder = mock(OrganizationUserSharingDataHolder.class);
-            when(OrganizationUserSharingDataHolder.getInstance()).thenReturn(dataHolder);
-            OrganizationUserSharingService mockOrgUserSharingService = mock(OrganizationUserSharingService.class);
-            when(dataHolder.getOrganizationUserSharingService()).thenReturn(mockOrgUserSharingService);
-            OrganizationManager mockOrgManager = mock(OrganizationManager.class);
-            when(dataHolder.getOrganizationManager()).thenReturn(mockOrgManager);
+        // Mock organization names dynamically.
+        List<UserAssociation> mockUserAssociations = new ArrayList<>();
+        for (Map.Entry<String, UserAssociation> entry : expectedResults.entrySet()) {
+            String orgName = entry.getKey();
+            UserAssociation userAssociation = entry.getValue();
+            when(mockOrgManager.getOrganizationNameById(userAssociation.getOrganizationId())).thenReturn(orgName);
+            mockUserAssociations.add(userAssociation);
+        }
 
-            // Mock organization names dynamically
-            List<UserAssociation> mockUserAssociations = new ArrayList<>();
-            for (Map.Entry<String, UserAssociation> entry : expectedResults.entrySet()) {
-                String orgName = entry.getKey();
-                UserAssociation userAssociation = entry.getValue();
-                when(mockOrgManager.getOrganizationNameById(userAssociation.getOrganizationId())).thenReturn(orgName);
-                mockUserAssociations.add(userAssociation);
-            }
+        when(mockOrgUserSharingService.getUserAssociationsOfGivenUser(associatedUserId, ORG_SUPER_ID)).thenReturn(
+                mockUserAssociations);
 
-            when(mockOrgUserSharingService.getUserAssociationsOfGivenUser(associatedUserId, ORG_SUPER_ID))
-                    .thenReturn(mockUserAssociations);
+        // Call the method.
+        ResponseSharedOrgsDO response =
+                userSharingPolicyHandlerService.getSharedOrganizationsOfUser(associatedUserId, null, null, null, null,
+                        false);
 
-            // Call the method
-            ResponseSharedOrgsDO response =
-                    userSharingPolicyHandlerService.getSharedOrganizationsOfUser(associatedUserId, null, null, null,
-                            null, false);
-
-            // Validate response
-            assertNotNull(response, VALIDATE_MESSAGE_RESPONSE);
-            assertEquals(response.getSharedOrgs().size(), mockUserAssociations.size(),
-                    VALIDATE_MESSAGE_RESPONSE_SHARED_ORGS);
-
-            for (int i = 0; i < mockUserAssociations.size(); i++) {
-                UserAssociation expectedAssociation = mockUserAssociations.get(i);
-                assertEquals(response.getSharedOrgs().get(i).getOrganizationId(),
-                        expectedAssociation.getOrganizationId());
-                assertEquals(response.getSharedOrgs().get(i).getSharedUserId(), expectedAssociation.getUserId());
-                assertEquals(response.getSharedOrgs().get(i).getSharedType(), SharedType.SHARED);
-                assertTrue(expectedResults.containsKey(response.getSharedOrgs().get(i).getOrganizationName()));
-            }
+        // Validate response.
+        assertNotNull(response, VALIDATE_MSG_RESPONSE);
+        assertEquals(response.getSharedOrgs().size(), mockUserAssociations.size(),
+                VALIDATE_MSG_RESPONSE_SHARED_ORGS_COUNT);
+        for (int i = 0; i < mockUserAssociations.size(); i++) {
+            UserAssociation expectedAssociation = mockUserAssociations.get(i);
+            assertEquals(response.getSharedOrgs().get(i).getOrganizationId(), expectedAssociation.getOrganizationId(),
+                    VALIDATE_MSG_SHARED_ORG_ID);
+            assertEquals(response.getSharedOrgs().get(i).getSharedUserId(), expectedAssociation.getUserId(),
+                    VALIDATE_MSG_SHARED_USER_ID);
+            assertEquals(response.getSharedOrgs().get(i).getSharedType(), SharedType.SHARED, VALIDATE_MSG_SHARED_TYPE);
+            assertTrue(expectedResults.containsKey(response.getSharedOrgs().get(i).getOrganizationName()),
+                    VALIDATE_MSG_SHARED_ORG_NAME);
         }
     }
 
     @Test(expectedExceptions = UserSharingMgtClientException.class)
     public void testGetSharedOrganizationsOfUser_ExceptionHandling() throws Exception {
 
-        try (MockedStatic<Utils> utilsMockedStatic = mockStatic(Utils.class);
-             MockedStatic<OrganizationUserSharingDataHolder> dataHolderMock = mockStatic(
-                     OrganizationUserSharingDataHolder.class)) {
+        // Mock getOrganizationId() from the Utils class.
+        utilsMockedStatic.when(Utils::getOrganizationId).thenReturn(ORG_SUPER_ID);
 
-            // Mock getOrganizationId() from the Utils class
-            utilsMockedStatic.when(Utils::getOrganizationId).thenReturn(ORG_SUPER_ID);
+        // Mock the data holder and return the mock service.
+        OrganizationUserSharingDataHolder dataHolder = mock(OrganizationUserSharingDataHolder.class);
+        when(OrganizationUserSharingDataHolder.getInstance()).thenReturn(dataHolder);
+        OrganizationUserSharingService mockOrgUserSharingService = mock(OrganizationUserSharingService.class);
+        when(dataHolder.getOrganizationUserSharingService()).thenReturn(mockOrgUserSharingService);
 
-            // Mock the data holder and return the mock service
+        // Force an exception when calling getUserAssociationsOfGivenUser.
+        when(mockOrgUserSharingService.getUserAssociationsOfGivenUser(anyString(), anyString())).thenThrow(
+                new OrganizationManagementException(VALIDATE_MSG_EXCEPTION));
+
+        // Invoke the method (expected to throw an exception).
+        userSharingPolicyHandlerService.getSharedOrganizationsOfUser(USER_1_ID, null, null, null, null, false);
+    }
+
+    // Tests for GET Shared Roles.
+
+    @DataProvider(name = "roleSharingDataProvider")
+    public Object[][] roleSharingDataProvider() {
+
+        return new Object[][]{
+                {USER_1_ID, ORG_1_ID, setExpectedResultsForGetSharedRolesTestCase1()},
+                {USER_2_ID, ORG_2_ID, setExpectedResultsForGetSharedRolesTestCase2()},
+                {USER_3_ID, ORG_3_ID, setExpectedResultsForGetSharedRolesTestCase3()},
+                {USER_1_ID, ORG_1_ID, setExpectedResultsForGetSharedRolesTestCase4()},
+                {USER_1_ID, ORG_1_ID, setExpectedResultsForGetSharedRolesTestCase5()},
+                {USER_1_ID, ORG_1_ID, setExpectedResultsForGetSharedRolesTestCase6()}
+        };
+    }
+
+    @Test(dataProvider = "roleSharingDataProvider")
+    public void testGetRolesSharedWithUserInOrganization(String userId, String orgId,
+                                                         List<Role> expectedRoles) throws Exception {
+
+        try (MockedStatic<IdentityTenantUtil> identityTenantUtilMockedStatic = mockStatic(IdentityTenantUtil.class);
+             MockedStatic<UserCoreUtil> mockUserCoreUtil = mockStatic(UserCoreUtil.class)) {
+
+            // Extract shared role IDs dynamically from expected roles.
+            List<String> sharedRoleIds = expectedRoles.stream().map(Role::getId).collect(Collectors.toList());
+
+            // Mock the data holder and dependencies.
             OrganizationUserSharingDataHolder dataHolder = mock(OrganizationUserSharingDataHolder.class);
             when(OrganizationUserSharingDataHolder.getInstance()).thenReturn(dataHolder);
             OrganizationUserSharingService mockOrgUserSharingService = mock(OrganizationUserSharingService.class);
             when(dataHolder.getOrganizationUserSharingService()).thenReturn(mockOrgUserSharingService);
+            RoleManagementService mockRoleMgtService = mock(RoleManagementService.class);
+            when(dataHolder.getRoleManagementService()).thenReturn(mockRoleMgtService);
+            OrganizationManager mockOrgManager = mock(OrganizationManager.class);
+            when(dataHolder.getOrganizationManager()).thenReturn(mockOrgManager);
 
-            // Force an exception when calling getUserAssociationsOfGivenUser
-            when(mockOrgUserSharingService.getUserAssociationsOfGivenUser(anyString(), anyString()))
-                    .thenThrow(new OrganizationManagementException("Simulated Exception"));
+            UserIDResolver mockUserIDResolver = mock(UserIDResolver.class);
+            Field field = UserSharingPolicyHandlerServiceImpl.class.getDeclaredField(FIELD_USER_ID_RESOLVER);
+            field.setAccessible(true);
+            field.set(userSharingPolicyHandlerService, mockUserIDResolver);
 
-            // Invoke the method (expected to throw an exception)
-            userSharingPolicyHandlerService.getSharedOrganizationsOfUser(USER_1_ID, null, null, null, null, false);
+            // Mock user association.
+            UserAssociation userAssociation = createUserAssociation(userId, orgId);
+            when(mockOrgUserSharingService.getUserAssociationOfAssociatedUserByOrgId(userId, orgId)).thenReturn(
+                    userAssociation);
+
+            when(mockOrgManager.resolveTenantDomain(anyString())).thenReturn(TENANT_DOMAIN);
+            identityTenantUtilMockedStatic.when(() -> IdentityTenantUtil.getTenantId(TENANT_DOMAIN))
+                    .thenReturn(TENANT_ID);
+
+            String domainQualifiedUserName = getDomainQualifiedUserName(userId);
+            String userName = getUserName(userId);
+            when(mockUserIDResolver.getNameByID(userId, TENANT_DOMAIN)).thenReturn(domainQualifiedUserName);
+            mockUserCoreUtil.when(() -> UserCoreUtil.removeDomainFromName(domainQualifiedUserName))
+                    .thenReturn(userName);
+            mockUserCoreUtil.when(() -> UserCoreUtil.extractDomainFromName(domainQualifiedUserName))
+                    .thenReturn(USER_DOMAIN_PRIMARY);
+
+            when(mockOrgUserSharingService.getRolesSharedWithUserInOrganization(any(), anyInt(), any())).thenReturn(
+                    sharedRoleIds);
+
+            for (Role role : expectedRoles) {
+                when(mockRoleMgtService.getRole(role.getId(), TENANT_DOMAIN)).thenReturn(role);
+            }
+
+            // Call the method.
+            ResponseSharedRolesDO response =
+                    userSharingPolicyHandlerService.getRolesSharedWithUserInOrganization(userId, orgId, null, null,
+                            null, null, false);
+
+            // Validate response.
+            assertNotNull(response, VALIDATE_MSG_RESPONSE);
+            assertEquals(response.getSharedRoles().size(), expectedRoles.size(),
+                    VALIDATE_MSG_RESPONSE_SHARED_ROLES_COUNT);
+            for (int i = 0; i < expectedRoles.size(); i++) {
+                assertEquals(response.getSharedRoles().get(i).getRoleName(), expectedRoles.get(i).getName(),
+                        VALIDATE_MSG_SHARED_ROLE_NAME);
+                assertEquals(response.getSharedRoles().get(i).getAudienceName(), expectedRoles.get(i).getAudienceName(),
+                        VALIDATE_MSG_SHARED_ROLE_AUDIENCE_NAME);
+                assertEquals(response.getSharedRoles().get(i).getAudienceType(), expectedRoles.get(i).getAudience(),
+                        VALIDATE_MSG_SHARED_ROLE_AUDIENCE_TYPE);
+            }
         }
+    }
+
+    @DataProvider(name = "roleSharingForUnSharedUserDataProvider")
+    public Object[][] roleSharingForUnSharedUserDataProvider() {
+
+        return new Object[][]{
+                {USER_4_ID, ORG_1_ID, setExpectedResultsForGetSharedRolesTestCase6()},
+                {USER_5_ID, ORG_2_ID, setExpectedResultsForGetSharedRolesTestCase6()}
+        };
+    }
+
+    @Test(dataProvider = "roleSharingForUnSharedUserDataProvider")
+    public void testGetRolesSharedWithUserForUnSharedUserInOrganization(String userId, String orgId,
+                                                                        List<Role> expectedRoles) throws Exception {
+
+        // Mock the data holder and dependencies.
+        OrganizationUserSharingDataHolder dataHolder = mock(OrganizationUserSharingDataHolder.class);
+        when(OrganizationUserSharingDataHolder.getInstance()).thenReturn(dataHolder);
+        OrganizationUserSharingService mockOrgUserSharingService = mock(OrganizationUserSharingService.class);
+        when(dataHolder.getOrganizationUserSharingService()).thenReturn(mockOrgUserSharingService);
+        RoleManagementService mockRoleMgtService = mock(RoleManagementService.class);
+        when(dataHolder.getRoleManagementService()).thenReturn(mockRoleMgtService);
+        OrganizationManager mockOrgManager = mock(OrganizationManager.class);
+        when(dataHolder.getOrganizationManager()).thenReturn(mockOrgManager);
+
+        UserIDResolver mockUserIDResolver = mock(UserIDResolver.class);
+        Field field = UserSharingPolicyHandlerServiceImpl.class.getDeclaredField(FIELD_USER_ID_RESOLVER);
+        field.setAccessible(true);
+        field.set(userSharingPolicyHandlerService, mockUserIDResolver);
+
+        // Call the method.
+        ResponseSharedRolesDO response =
+                userSharingPolicyHandlerService.getRolesSharedWithUserInOrganization(userId, orgId, null, null, null,
+                        null, false);
+
+        // Validate response.
+        assertNotNull(response, VALIDATE_MSG_RESPONSE);
+        assertEquals(response.getSharedRoles().size(), expectedRoles.size(), VALIDATE_MSG_RESPONSE_SHARED_ROLES_COUNT);
+    }
+
+    @Test(expectedExceptions = UserSharingMgtClientException.class)
+    public void testGetRolesSharedWithUserInOrganization_OrgException() throws Exception {
+
+        // Mock the data holder and dependencies.
+        OrganizationUserSharingDataHolder dataHolder = mock(OrganizationUserSharingDataHolder.class);
+        when(OrganizationUserSharingDataHolder.getInstance()).thenReturn(dataHolder);
+
+        OrganizationUserSharingService mockOrgUserSharingService = mock(OrganizationUserSharingService.class);
+        when(dataHolder.getOrganizationUserSharingService()).thenReturn(mockOrgUserSharingService);
+
+        OrganizationManager mockOrgManager = mock(OrganizationManager.class);
+        when(dataHolder.getOrganizationManager()).thenReturn(mockOrgManager);
+
+        // Mock user association.
+        UserAssociation userAssociation = createUserAssociation(USER_1_ID, ORG_1_ID);
+        when(mockOrgUserSharingService.getUserAssociationOfAssociatedUserByOrgId(USER_1_ID, ORG_1_ID)).thenReturn(
+                userAssociation);
+
+        // Force OrganizationManagementException.
+        when(mockOrgManager.resolveTenantDomain(anyString())).thenThrow(
+                new OrganizationManagementException(VALIDATE_MSG_EXCEPTION));
+
+        // Invoke the method (expected to throw an exception).
+        userSharingPolicyHandlerService.getRolesSharedWithUserInOrganization(USER_1_ID, ORG_1_ID, null, null, null,
+                null, false);
     }
 
     // Test case Builders.
@@ -179,14 +368,92 @@ public class UserSharingPolicyHandlerServiceImplTest {
 
     private Map<String, UserAssociation> setExpectedResultsForGetSharedOrgsTestCase2() {
 
-        return new HashMap<>();
+        Map<String, UserAssociation> expectedResults = new HashMap<>();
+        expectedResults.put(ORG_1_NAME, createUserAssociation(USER_3_ID, ORG_1_ID));
+        return expectedResults;
     }
 
     private Map<String, UserAssociation> setExpectedResultsForGetSharedOrgsTestCase3() {
 
-        Map<String, UserAssociation> expectedResults = new HashMap<>();
-        expectedResults.put(ORG_1_NAME, createUserAssociation(USER_3_ID, ORG_1_ID));
-        return expectedResults;
+        return new HashMap<>(); // No shared orgs for this test case.
+    }
+
+    private static List<Role> setExpectedResultsForGetSharedRolesTestCase1() {
+
+        Role role1 = new Role();
+        role1.setId(APP_ROLE_1_ID);
+        role1.setName(APP_ROLE_1_NAME);
+        role1.setAudienceName(APP_1_NAME);
+        role1.setAudience(APPLICATION_AUDIENCE);
+
+        Role role2 = new Role();
+        role2.setId(APP_ROLE_2_ID);
+        role2.setName(APP_ROLE_2_NAME);
+        role2.setAudienceName(APP_1_NAME);
+        role2.setAudience(APPLICATION_AUDIENCE);
+
+        return Arrays.asList(role1, role2);
+    }
+
+    private static List<Role> setExpectedResultsForGetSharedRolesTestCase2() {
+
+        Role role = new Role();
+        role.setId(APP_ROLE_2_ID);
+        role.setName(APP_ROLE_2_NAME);
+        role.setAudienceName(APP_1_NAME);
+        role.setAudience(APPLICATION_AUDIENCE);
+
+        return Collections.singletonList(role);
+    }
+
+    private static List<Role> setExpectedResultsForGetSharedRolesTestCase3() {
+
+        Role role1 = new Role();
+        role1.setId(ORG_ROLE_1_ID);
+        role1.setName(ORG_ROLE_1_NAME);
+        role1.setAudienceName(APP_2_NAME);
+        role1.setAudience(ORGANIZATION_AUDIENCE);
+
+        Role role2 = new Role();
+        role2.setId(ORG_ROLE_2_ID);
+        role2.setName(ORG_ROLE_2_NAME);
+        role2.setAudienceName(APP_2_NAME);
+        role2.setAudience(ORGANIZATION_AUDIENCE);
+
+        return Arrays.asList(role1, role2);
+    }
+
+    private static List<Role> setExpectedResultsForGetSharedRolesTestCase4() {
+
+        Role role = new Role();
+        role.setId(ORG_ROLE_2_ID);
+        role.setName(ORG_ROLE_2_NAME);
+        role.setAudienceName(APP_2_NAME);
+        role.setAudience(ORGANIZATION_AUDIENCE);
+
+        return Collections.singletonList(role);
+    }
+
+    private static List<Role> setExpectedResultsForGetSharedRolesTestCase5() {
+
+        Role role1 = new Role();
+        role1.setId(ORG_ROLE_2_ID);
+        role1.setName(ORG_ROLE_2_NAME);
+        role1.setAudienceName(APP_2_NAME);
+        role1.setAudience(ORGANIZATION_AUDIENCE);
+
+        Role role2 = new Role();
+        role2.setId(APP_ROLE_1_ID);
+        role2.setName(APP_ROLE_1_NAME);
+        role2.setAudienceName(APP_1_NAME);
+        role2.setAudience(APPLICATION_AUDIENCE);
+
+        return Arrays.asList(role1, role2);
+    }
+
+    private static List<Role> setExpectedResultsForGetSharedRolesTestCase6() {
+
+        return Collections.emptyList(); // No roles shared for this test case.
     }
 
     // Helper Methods.
@@ -198,5 +465,15 @@ public class UserSharingPolicyHandlerServiceImplTest {
         userAssociation.setOrganizationId(organizationId);
         userAssociation.setSharedType(SharedType.SHARED);
         return userAssociation;
+    }
+
+    private String getDomainQualifiedUserName(String userId) {
+
+        return USER_NAME_PREFIX + USER_DOMAIN_PRIMARY + PATH_SEPARATOR + userId;
+    }
+
+    private String getUserName(String userId) {
+
+        return USER_NAME_PREFIX + userId;
     }
 }

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/test/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/test/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImplTest.java
@@ -139,9 +139,9 @@ public class UserSharingPolicyHandlerServiceImplTest {
     public Object[][] getSharedOrgsDataProvider() {
 
         return new Object[][]{
-                {USER_1_ID, setExpectedResultsForGetSharedOrgsTestCase1()},
-                {USER_2_ID, setExpectedResultsForGetSharedOrgsTestCase2()},
-                {USER_3_ID, Collections.emptyMap()}
+                {USER_1_ID, setExpectedResultsForGetSharedOrgsTestCase1()}, // Having many shared orgs.
+                {USER_2_ID, setExpectedResultsForGetSharedOrgsTestCase2()}, // Having a single shared org.
+                {USER_3_ID, Collections.emptyMap()} // Having no shared orgs.
         };
     }
 
@@ -211,12 +211,12 @@ public class UserSharingPolicyHandlerServiceImplTest {
     public Object[][] roleSharingDataProvider() {
 
         return new Object[][]{
-                {USER_1_ID, ORG_1_ID, setExpectedResultsForGetSharedRolesTestCase1()},
-                {USER_2_ID, ORG_2_ID, setExpectedResultsForGetSharedRolesTestCase2()},
-                {USER_3_ID, ORG_3_ID, setExpectedResultsForGetSharedRolesTestCase3()},
-                {USER_1_ID, ORG_1_ID, setExpectedResultsForGetSharedRolesTestCase4()},
-                {USER_1_ID, ORG_1_ID, setExpectedResultsForGetSharedRolesTestCase5()},
-                {USER_1_ID, ORG_1_ID, Collections.emptyList()}
+                {USER_1_ID, ORG_1_ID, setExpectedResultsForGetSharedRolesTestCase1()}, // Having many shared App Roles.
+                {USER_2_ID, ORG_2_ID, setExpectedResultsForGetSharedRolesTestCase2()}, // Having one shared App Role.
+                {USER_3_ID, ORG_3_ID, setExpectedResultsForGetSharedRolesTestCase3()}, // Having many shared Org Roles.
+                {USER_1_ID, ORG_1_ID, setExpectedResultsForGetSharedRolesTestCase4()}, // Having one shared Org Role.
+                {USER_1_ID, ORG_1_ID, setExpectedResultsForGetSharedRolesTestCase5()}, // Having many App and Org Roles.
+                {USER_1_ID, ORG_1_ID, Collections.emptyList()} // Having no shared roles.
         };
     }
 
@@ -284,8 +284,8 @@ public class UserSharingPolicyHandlerServiceImplTest {
     public Object[][] roleSharingForUnSharedUserDataProvider() {
 
         return new Object[][]{
-                {USER_4_ID, ORG_1_ID, Collections.emptyList()},
-                {USER_5_ID, ORG_2_ID, Collections.emptyList()}
+                {USER_4_ID, ORG_1_ID, Collections.emptyList()}, // Having no shared user association in Org 1.
+                {USER_5_ID, ORG_2_ID, Collections.emptyList()} // Having no shared user association in Org 2.
         };
     }
 

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/test/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/test/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImplTest.java
@@ -145,10 +145,8 @@ public class UserSharingPolicyHandlerServiceImplTest {
     public void testGetSharedOrganizationsOfUser(String associatedUserId, Map<String, UserAssociation> expectedResults)
             throws Exception {
 
-        // Mock getOrganizationId() from the Utils class.
         utilsMockedStatic.when(Utils::getOrganizationId).thenReturn(ORG_SUPER_ID);
 
-        // Mock the data holder and return the mock service.
         OrganizationUserSharingDataHolder dataHolder = mock(OrganizationUserSharingDataHolder.class);
         when(OrganizationUserSharingDataHolder.getInstance()).thenReturn(dataHolder);
         OrganizationUserSharingService mockOrgUserSharingService = mock(OrganizationUserSharingService.class);
@@ -156,7 +154,6 @@ public class UserSharingPolicyHandlerServiceImplTest {
         OrganizationManager mockOrgManager = mock(OrganizationManager.class);
         when(dataHolder.getOrganizationManager()).thenReturn(mockOrgManager);
 
-        // Mock organization names dynamically.
         List<UserAssociation> mockUserAssociations = new ArrayList<>();
         for (Map.Entry<String, UserAssociation> entry : expectedResults.entrySet()) {
             String orgName = entry.getKey();
@@ -192,16 +189,13 @@ public class UserSharingPolicyHandlerServiceImplTest {
     @Test(expectedExceptions = UserSharingMgtClientException.class)
     public void testGetSharedOrganizationsOfUser_ExceptionHandling() throws Exception {
 
-        // Mock getOrganizationId() from the Utils class.
         utilsMockedStatic.when(Utils::getOrganizationId).thenReturn(ORG_SUPER_ID);
 
-        // Mock the data holder and return the mock service.
         OrganizationUserSharingDataHolder dataHolder = mock(OrganizationUserSharingDataHolder.class);
         when(OrganizationUserSharingDataHolder.getInstance()).thenReturn(dataHolder);
         OrganizationUserSharingService mockOrgUserSharingService = mock(OrganizationUserSharingService.class);
         when(dataHolder.getOrganizationUserSharingService()).thenReturn(mockOrgUserSharingService);
 
-        // Force an exception when calling getUserAssociationsOfGivenUser.
         when(mockOrgUserSharingService.getUserAssociationsOfGivenUser(anyString(), anyString())).thenThrow(
                 new OrganizationManagementException(VALIDATE_MSG_EXCEPTION));
 
@@ -231,10 +225,8 @@ public class UserSharingPolicyHandlerServiceImplTest {
         try (MockedStatic<IdentityTenantUtil> identityTenantUtilMockedStatic = mockStatic(IdentityTenantUtil.class);
              MockedStatic<UserCoreUtil> mockUserCoreUtil = mockStatic(UserCoreUtil.class)) {
 
-            // Extract shared role IDs dynamically from expected roles.
             List<String> sharedRoleIds = expectedRoles.stream().map(Role::getId).collect(Collectors.toList());
 
-            // Mock the data holder and dependencies.
             OrganizationUserSharingDataHolder dataHolder = mock(OrganizationUserSharingDataHolder.class);
             when(OrganizationUserSharingDataHolder.getInstance()).thenReturn(dataHolder);
             OrganizationUserSharingService mockOrgUserSharingService = mock(OrganizationUserSharingService.class);
@@ -249,7 +241,6 @@ public class UserSharingPolicyHandlerServiceImplTest {
             field.setAccessible(true);
             field.set(userSharingPolicyHandlerService, mockUserIDResolver);
 
-            // Mock user association.
             UserAssociation userAssociation = createUserAssociation(userId, orgId);
             when(mockOrgUserSharingService.getUserAssociationOfAssociatedUserByOrgId(userId, orgId)).thenReturn(
                     userAssociation);
@@ -306,7 +297,6 @@ public class UserSharingPolicyHandlerServiceImplTest {
     public void testGetRolesSharedWithUserForUnSharedUserInOrganization(String userId, String orgId,
                                                                         List<Role> expectedRoles) throws Exception {
 
-        // Mock the data holder and dependencies.
         OrganizationUserSharingDataHolder dataHolder = mock(OrganizationUserSharingDataHolder.class);
         when(OrganizationUserSharingDataHolder.getInstance()).thenReturn(dataHolder);
         OrganizationUserSharingService mockOrgUserSharingService = mock(OrganizationUserSharingService.class);
@@ -334,7 +324,6 @@ public class UserSharingPolicyHandlerServiceImplTest {
     @Test(expectedExceptions = UserSharingMgtClientException.class)
     public void testGetRolesSharedWithUserInOrganization_OrgException() throws Exception {
 
-        // Mock the data holder and dependencies.
         OrganizationUserSharingDataHolder dataHolder = mock(OrganizationUserSharingDataHolder.class);
         when(OrganizationUserSharingDataHolder.getInstance()).thenReturn(dataHolder);
 
@@ -344,12 +333,10 @@ public class UserSharingPolicyHandlerServiceImplTest {
         OrganizationManager mockOrgManager = mock(OrganizationManager.class);
         when(dataHolder.getOrganizationManager()).thenReturn(mockOrgManager);
 
-        // Mock user association.
         UserAssociation userAssociation = createUserAssociation(USER_1_ID, ORG_1_ID);
         when(mockOrgUserSharingService.getUserAssociationOfAssociatedUserByOrgId(USER_1_ID, ORG_1_ID)).thenReturn(
                 userAssociation);
 
-        // Force OrganizationManagementException.
         when(mockOrgManager.resolveTenantDomain(anyString())).thenThrow(
                 new OrganizationManagementException(VALIDATE_MSG_EXCEPTION));
 

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/test/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/constant/TestUserSharingConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/test/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/constant/TestUserSharingConstants.java
@@ -31,10 +31,6 @@ public class TestUserSharingConstants {
     public static final String USER_NAME_PREFIX = "username-of-";
     public static final String PATH_SEPARATOR = "/";
 
-    // Mocks.
-    public static final String MOCKED_DATA_ACCESS_EXCEPTION = "Mocked DataAccessException";
-    public static final String MOCKED_TRANSACTION_EXCEPTION = "Mocked TransactionException";
-
     // Organizations.
     public static final String ORG_SUPER_ID = "10084a8d-113f-4211-a0d5-efe36b082211";
     public static final String ORG_1_ID = "c524c30a-cbd4-4169-ac9d-1ee3edf1bf16";

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/test/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/constant/TestUserSharingConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/test/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/constant/TestUserSharingConstants.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.management.organization.user.sharing.constant;
+
+/**
+ * Constants related to the test cases of User Sharing Policy Handler service.
+ */
+public class TestUserSharingConstants {
+
+    // Organizations.
+    public static final String ORG_SUPER_ID = "10084a8d-113f-4211-a0d5-efe36b082211";
+    public static final String ORG_1_ID = "c524c30a-cbd4-4169-ac9d-1ee3edf1bf16";
+    public static final String ORG_2_ID = "cd5a1dcb-fff2-4c14-a073-c07b3caf1757";
+    public static final String ORG_3_ID = "7cb4ab7e-9a25-44bd-a9e0-cf4e07d804dc";
+
+    public static final String ORG_1_NAME = "org1";
+    public static final String ORG_2_NAME = "org2";
+    public static final String ORG_3_NAME = "org3";
+
+    // Users.
+    public static final String USER_1_ID = "448e57e7-ff6b-4c31-a1eb-2a0e2d635b2a";
+    public static final String USER_2_ID = "558e57e7-ff6b-4c31-a1eb-2a0e2d635b2a";
+    public static final String USER_3_ID = "668e57e7-ff6b-4c31-a1eb-2a0e2d635b2b";
+
+    // Mocks.
+    public static final String MOCKED_DATA_ACCESS_EXCEPTION = "Mocked DataAccessException";
+    public static final String MOCKED_TRANSACTION_EXCEPTION = "Mocked TransactionException";
+
+    // Validate Messages.
+    public static final String VALIDATE_MESSAGE_RESPONSE = "Response should not be null.";
+    public static final String VALIDATE_MESSAGE_RESPONSE_SHARED_ORGS = "Mismatch in shared organizations count";
+}

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/test/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/constant/TestUserSharingConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/test/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/constant/TestUserSharingConstants.java
@@ -23,6 +23,18 @@ package org.wso2.carbon.identity.organization.management.organization.user.shari
  */
 public class TestUserSharingConstants {
 
+    // Fields.
+    public static final String FIELD_USER_ID_RESOLVER = "userIDResolver";
+    public static final String TENANT_DOMAIN = "tenantDomain";
+    public static final int TENANT_ID = -1234;
+    public static final String USER_DOMAIN_PRIMARY = "PRIMARY";
+    public static final String USER_NAME_PREFIX = "username-of-";
+    public static final String PATH_SEPARATOR = "/";
+
+    // Mocks.
+    public static final String MOCKED_DATA_ACCESS_EXCEPTION = "Mocked DataAccessException";
+    public static final String MOCKED_TRANSACTION_EXCEPTION = "Mocked TransactionException";
+
     // Organizations.
     public static final String ORG_SUPER_ID = "10084a8d-113f-4211-a0d5-efe36b082211";
     public static final String ORG_1_ID = "c524c30a-cbd4-4169-ac9d-1ee3edf1bf16";
@@ -33,16 +45,41 @@ public class TestUserSharingConstants {
     public static final String ORG_2_NAME = "org2";
     public static final String ORG_3_NAME = "org3";
 
+    // Applications.
+    public static final String APP_1_NAME = "App1";
+    public static final String APP_2_NAME = "App2";
+
+    public static final String APPLICATION_AUDIENCE = "APPLICATION";
+    public static final String ORGANIZATION_AUDIENCE = "ORGANIZATION";
+
+    // Roles.
+    public static final String APP_ROLE_1_ID = "3f2a1d7e-89c6-4e3f-9c1b-8a4f6b3e5d91";
+    public static final String APP_ROLE_1_NAME = "app-role-1";
+    public static final String APP_ROLE_2_ID = "b7e9f3d2-6c45-4128-928c-5f91e3a8d7b2";
+    public static final String APP_ROLE_2_NAME = "app-role-2";
+
+    public static final String ORG_ROLE_1_ID = "e5c1a7f8-4d92-44b1-bc3e-8d2f6a9e1b74";
+    public static final String ORG_ROLE_1_NAME = "org-role-1";
+    public static final String ORG_ROLE_2_ID = "a3d6f2c8-9b71-482e-91c5-7e4d8b2a3f69";
+    public static final String ORG_ROLE_2_NAME = "org-role-2";
+
     // Users.
     public static final String USER_1_ID = "448e57e7-ff6b-4c31-a1eb-2a0e2d635b2a";
     public static final String USER_2_ID = "558e57e7-ff6b-4c31-a1eb-2a0e2d635b2a";
     public static final String USER_3_ID = "668e57e7-ff6b-4c31-a1eb-2a0e2d635b2b";
-
-    // Mocks.
-    public static final String MOCKED_DATA_ACCESS_EXCEPTION = "Mocked DataAccessException";
-    public static final String MOCKED_TRANSACTION_EXCEPTION = "Mocked TransactionException";
+    public static final String USER_4_ID = "a35cd594-8408-4692-a061-56730b62ba27";
+    public static final String USER_5_ID = "c1f7d4a8-92b3-47e1-8c5d-6e9a3f2b7d64";
 
     // Validate Messages.
-    public static final String VALIDATE_MESSAGE_RESPONSE = "Response should not be null.";
-    public static final String VALIDATE_MESSAGE_RESPONSE_SHARED_ORGS = "Mismatch in shared organizations count";
+    public static final String VALIDATE_MSG_RESPONSE = "Response should not be null.";
+    public static final String VALIDATE_MSG_RESPONSE_SHARED_ORGS_COUNT = "Mismatch in shared organizations count.";
+    public static final String VALIDATE_MSG_SHARED_ORG_ID = "Mismatched in shared org id.";
+    public static final String VALIDATE_MSG_SHARED_USER_ID = "Mismatched in shared user id.";
+    public static final String VALIDATE_MSG_SHARED_TYPE = "Mismatched in shared type.";
+    public static final String VALIDATE_MSG_SHARED_ORG_NAME = "Mismatched in shared org name.";
+    public static final String VALIDATE_MSG_RESPONSE_SHARED_ROLES_COUNT = "Role count mismatch";
+    public static final String VALIDATE_MSG_SHARED_ROLE_NAME = "Mismatch in shared role name.";
+    public static final String VALIDATE_MSG_SHARED_ROLE_AUDIENCE_NAME = "Mismatch in shared role audience name.";
+    public static final String VALIDATE_MSG_SHARED_ROLE_AUDIENCE_TYPE = "Mismatch in shared role audience type.";
+    public static final String VALIDATE_MSG_EXCEPTION = "Simulated Exception";
 }

--- a/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/test/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/ResourceSharingPolicyHandlerServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/src/test/java/org/wso2/carbon/identity/organization/resource/sharing/policy/management/ResourceSharingPolicyHandlerServiceImplTest.java
@@ -78,6 +78,9 @@ import static org.wso2.carbon.identity.organization.resource.sharing.policy.mana
 import static org.wso2.carbon.identity.organization.resource.sharing.policy.management.constants.TestResourceSharingConstants.UM_ID_RESOURCE_ATTRIBUTE_2;
 import static org.wso2.carbon.identity.organization.resource.sharing.policy.management.util.TestUtils.closeH2Base;
 
+/**
+ * Unit tests for ResourceSharingPolicyHandlerServiceImpl.
+ */
 public class ResourceSharingPolicyHandlerServiceImplTest {
 
     private ResourceSharingPolicyHandlerServiceImpl resourceSharingPolicyHandlerService;


### PR DESCRIPTION
## Purpose
The User Sharing Component currently lacks unit test coverage, which affects its reliability and maintainability. This PR introduces unit tests to validate key functionalities and ensure expected behavior under different conditions.

## Goals
- Improve test coverage for the User Sharing Component.
- Ensure correctness by validating core functionalities.
- Enhance maintainability and prevent regressions in future updates.

## Approach
- Add unit tests covering various use cases, including validation logic and business rules.
- Ensure test cases handle both expected and edge cases.
- Follow best practices for structuring unit tests to maintain readability and maintainability.