### PR TITLE
Add overloaded method to include authentication context during organization discovery

### DIFF
--- a/components/org.wso2.carbon.identity.organization.discovery.service/src/main/java/org/wso2/carbon/identity/organization/discovery/service/AttributeBasedOrganizationDiscoveryHandler.java
+++ b/components/org.wso2.carbon.identity.organization.discovery.service/src/main/java/org/wso2/carbon/identity/organization/discovery/service/AttributeBasedOrganizationDiscoveryHandler.java
@@ -18,6 +18,8 @@
 
 package org.wso2.carbon.identity.organization.discovery.service;
 
+import org.apache.commons.lang.NotImplementedException;
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 
 import java.util.List;
@@ -52,6 +54,18 @@ public interface AttributeBasedOrganizationDiscoveryHandler {
      * @return The extracted attribute value.
      */
     String extractAttributeValue(String discoveryInput);
+
+    /**
+     * Extract the attribute value from the given organization discovery input.
+     *
+     * @param discoveryInput The discovery input provided by the user.
+     * @param context        The authentication context.
+     * @return The extracted attribute value.
+     */
+    default String extractAttributeValue(String discoveryInput, AuthenticationContext context) {
+
+        throw new NotImplementedException("extractAttributeValue method is not implemented");
+    }
 
     /**
      * Get the list of validations that are required for events triggered during organization discovery related

--- a/components/org.wso2.carbon.identity.organization.discovery.service/src/main/java/org/wso2/carbon/identity/organization/discovery/service/OrganizationDiscoveryManager.java
+++ b/components/org.wso2.carbon.identity.organization.discovery.service/src/main/java/org/wso2/carbon/identity/organization/discovery/service/OrganizationDiscoveryManager.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.organization.discovery.service;
 
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.organization.discovery.service.model.DiscoveryOrganizationsResult;
 import org.wso2.carbon.identity.organization.discovery.service.model.OrgDiscoveryAttribute;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
@@ -134,4 +135,21 @@ public interface OrganizationDiscoveryManager {
      */
     String getOrganizationIdByDiscoveryAttribute(String attributeType, String discoveryInput, String rootOrganizationId)
             throws OrganizationManagementException;
+
+    /**
+     * Get the organization ID by discovery attribute in the hierarchy.
+     *
+     * @param attributeType      The organization discovery attribute type.
+     * @param discoveryInput     The organization discovery input.
+     * @param rootOrganizationId The root organization ID.
+     * @param context            The authentication context.
+     * @return The organization ID.
+     * @throws OrganizationManagementException The server exception thrown when fetching the organization ID.
+     */
+    default String getOrganizationIdByDiscoveryAttribute(String attributeType, String discoveryInput,
+                                                         String rootOrganizationId, AuthenticationContext context)
+            throws OrganizationManagementException {
+
+        return getOrganizationIdByDiscoveryAttribute(attributeType, discoveryInput, rootOrganizationId);
+    }
 }

--- a/components/org.wso2.carbon.identity.organization.discovery.service/src/test/java/org.wso2.carbon.identity.organization.discovery.service/OrganizationDiscoveryManagerImplTest.java
+++ b/components/org.wso2.carbon.identity.organization.discovery.service/src/test/java/org.wso2.carbon.identity.organization.discovery.service/OrganizationDiscoveryManagerImplTest.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.organization.discovery.service;
 
+import org.apache.commons.lang.NotImplementedException;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -26,6 +27,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.organization.config.service.OrganizationConfigManager;
 import org.wso2.carbon.identity.organization.discovery.service.dao.OrganizationDiscoveryDAO;
 import org.wso2.carbon.identity.organization.discovery.service.dao.OrganizationDiscoveryDAOImpl;
@@ -41,6 +43,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
@@ -379,6 +382,9 @@ public class OrganizationDiscoveryManagerImplTest {
         when(attributeBasedOrganizationDiscoveryHandler.getType()).thenReturn(DISCOVERY_ATTRIBUTE_TYPE);
         when(attributeBasedOrganizationDiscoveryHandler.areAttributeValuesInValidFormat(anyList())).thenReturn(true);
         when(attributeBasedOrganizationDiscoveryHandler.extractAttributeValue(anyString())).thenReturn("wso2.lk");
+        when(attributeBasedOrganizationDiscoveryHandler.extractAttributeValue(anyString(),
+                any(AuthenticationContext.class)))
+                .thenThrow(new NotImplementedException("extractAttributeValue method is not implemented"));
 
         String organizationId =
                 organizationDiscoveryManager.getOrganizationIdByDiscoveryAttribute(DISCOVERY_ATTRIBUTE_TYPE,


### PR DESCRIPTION
## Purpose

Adds an overloaded method to the OrganizationDiscoveryManager and AttributeBasedOrganizationDiscoveryHandler interfaces to include the authentication context during organization discovery.

## Related Issues

- https://github.com/wso2/product-is/issues/23390

## Related PRs

- https://github.com/wso2-extensions/identity-auth-organization-login/pull/55