### PR TITLE
Extend sub organization user sessions While using Session Extension API for root organization

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.handler/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.handler/pom.xml
@@ -194,7 +194,7 @@
                             version="${identity.outbound.auth.oidc.import.version.range}",
                             org.wso2.carbon.identity.oauth.common;
                             version="${identity.inbound.auth.oauth.import.version.range}",
-                            com.nimbusds.jose.*; version="${nimbusds.osgi.version.range}",
+                            com.nimbusds.jwt; version="${nimbusds.osgi.version.range}",
                             net.minidev.json; version="${net.minidev.json.imp.pkg.version.range}",
                         </Import-Package>
                     </instructions>

--- a/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/OrganizationSessionHandler.java
+++ b/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/OrganizationSessionHandler.java
@@ -18,13 +18,16 @@
 
 package org.wso2.carbon.identity.organization.management.handler;
 
-import com.nimbusds.jose.util.JSONObjectUtils;
+import com.nimbusds.jwt.SignedJWT;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.application.authentication.framework.AuthenticatorStateInfo;
 import org.wso2.carbon.identity.application.authentication.framework.UserSessionManagementService;
+import org.wso2.carbon.identity.application.authentication.framework.cache.SessionContextCache;
+import org.wso2.carbon.identity.application.authentication.framework.cache.SessionContextCacheEntry;
+import org.wso2.carbon.identity.application.authentication.framework.cache.SessionContextCacheKey;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.AuthenticatorConfig;
 import org.wso2.carbon.identity.application.authentication.framework.context.SessionContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
@@ -32,19 +35,19 @@ import org.wso2.carbon.identity.application.authentication.framework.exception.s
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedIdPData;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.authenticator.oidc.model.OIDCStateInfo;
 import org.wso2.carbon.identity.event.IdentityEventConstants;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.event.Event;
 import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
 import org.wso2.carbon.identity.organization.management.handler.internal.OrganizationManagementHandlerDataHolder;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 
-import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
-import java.util.Base64;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCClaims.IDP_SESSION_KEY;
 
@@ -54,6 +57,8 @@ import static org.wso2.carbon.identity.oauth.common.OAuthConstants.OIDCClaims.ID
 public class OrganizationSessionHandler extends AbstractEventHandler {
 
     private static final Log LOG = LogFactory.getLog(OrganizationSessionHandler.class);
+    private static final String AUTHORIZED_ORGANIZATION_ID_ATTRIBUTE = "org_id";
+
 
     @Override
     public void handleEvent(Event event) throws IdentityEventException {
@@ -62,6 +67,8 @@ public class OrganizationSessionHandler extends AbstractEventHandler {
         Map<String, Object> eventProperties = event.getEventProperties();
         if (IdentityEventConstants.EventName.SESSION_TERMINATE.name().equals(eventName)) {
             handleOrgSessionTerminate(eventProperties);
+        } else if (IdentityEventConstants.Event.SESSION_EXTENSION.equals(eventName)) {
+            handleOrgSessionExtend(eventProperties);
         }
     }
 
@@ -92,7 +99,7 @@ public class OrganizationSessionHandler extends AbstractEventHandler {
                         OIDCStateInfo oidcStateInfo = (OIDCStateInfo) authenticatorStateInfo;
                         String idTokenHint = oidcStateInfo.getIdTokenHint();
                         // Resolve session ID by `isk` claim in ID token hint.
-                        sessionId = getSessionId(idTokenHint);
+                        sessionId = getClaimFromJWT(idTokenHint, IDP_SESSION_KEY);
                         break;
                     }
                 }
@@ -116,23 +123,109 @@ public class OrganizationSessionHandler extends AbstractEventHandler {
         }
     }
 
-    private String getSessionId(String idToken) {
+    private void handleOrgSessionExtend(Map<String, Object> eventProperties) throws IdentityEventException {
 
-        String base64Body = idToken.split("\\.")[1];
-        byte[] decoded = Base64.getDecoder().decode(base64Body);
-        try {
-            Set<Map.Entry<String, Object>> jwtAttributeSet =
-                    JSONObjectUtils.parse(new String(decoded, StandardCharsets.UTF_8)).entrySet();
-            for (Map.Entry<String, Object> entry : jwtAttributeSet) {
-                if (StringUtils.equals(IDP_SESSION_KEY, entry.getKey())) {
-                    return String.valueOf(entry.getValue());
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Extending associated sub organization session for root organization session: " +
+                    eventProperties.get(
+                            IdentityEventConstants.EventProperty.SESSION_CONTEXT_ID));
+        }
+        SessionContext sessionContext = (SessionContext) eventProperties.get(
+                IdentityEventConstants.EventProperty.SESSION_CONTEXT);
+        Map<String, AuthenticatedIdPData> authenticatedIdPs = sessionContext.getAuthenticatedIdPs();
+        if (authenticatedIdPs == null) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Authenticated IdPs not found in the session context." +
+                        " Hence, sub org session extension is not applicable.");
+            }
+            return;
+        }
+        String sessionId = null;
+        String orgId = null;
+        authenticatedIdPsLoop:
+        for (Map.Entry<String, AuthenticatedIdPData> entry : authenticatedIdPs.entrySet()) {
+            if (entry.getValue() == null) {
+                continue;
+            }
+            List<AuthenticatorConfig> authenticators = entry.getValue().getAuthenticators();
+            if (CollectionUtils.isEmpty(authenticators)) {
+                continue;
+            }
+            for (AuthenticatorConfig authenticator : authenticators) {
+                if (FrameworkConstants.ORGANIZATION_AUTHENTICATOR.equals(authenticator.getName())) {
+                    AuthenticatorStateInfo authenticatorStateInfo = authenticator.getAuthenticatorStateInfo();
+                    if (authenticatorStateInfo instanceof OIDCStateInfo) {
+                        OIDCStateInfo oidcStateInfo = (OIDCStateInfo) authenticatorStateInfo;
+                        String idTokenHint = oidcStateInfo.getIdTokenHint();
+                        // Resolve session ID by `isk` claim in ID token hint.
+                        sessionId = getClaimFromJWT(idTokenHint, IDP_SESSION_KEY);
+                        // Resolve org ID by `org_id` claim in ID token hint.
+                        orgId = getClaimFromJWT(idTokenHint, AUTHORIZED_ORGANIZATION_ID_ATTRIBUTE);
+                        break authenticatedIdPsLoop;
+                    }
                 }
             }
+        }
+        if (StringUtils.isBlank(sessionId) || StringUtils.isBlank(orgId)) {
+            LOG.debug("Organization authenticator not found in the authenticators list or " +
+                    "Session ID / org ID not found in the ID token.");
+            return;
+        }
+        String tenantDomain;
+        try {
+            tenantDomain = getOrganizationManager().resolveTenantDomain(orgId);
+            if (StringUtils.isBlank(tenantDomain)) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Tenant ID not found for the organization ID: " + orgId);
+                }
+                return;
+            }
+        } catch (OrganizationManagementException e) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Error while resolving the tenant ID for the organization ID: " + orgId, e);
+            }
+            throw new IdentityEventException("Error while extending session for session ID: " + sessionId, e);
+        }
+
+        SessionContextCacheKey sessionContextCacheKey = new SessionContextCacheKey(sessionId);
+        SessionContextCacheEntry sessionContextCacheEntry = SessionContextCache.getInstance()
+                .getSessionContextCacheEntry(sessionContextCacheKey, tenantDomain);
+
+        if (sessionContextCacheEntry == null) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("No session available for requested session identifier: " + sessionId);
+            }
+            return;
+        }
+
+        SessionContext orgSessionContext = sessionContextCacheEntry.getContext();
+        boolean isSessionExpired = SessionContextCache.getInstance().
+                isSessionExpired(sessionContextCacheKey, sessionContextCacheEntry);
+        if (isSessionExpired) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Session already expired for provided session cache entry with session ID: " + sessionId);
+            }
+            return;
+        }
+        long currentTime = System.currentTimeMillis();
+        FrameworkUtils.updateSessionLastAccessTimeMetadata(sessionId, currentTime);
+        FrameworkUtils.addSessionContextToCache(sessionId, orgSessionContext, tenantDomain, tenantDomain);
+    }
+
+    private String getClaimFromJWT(String idToken, String claimname) {
+
+        try {
+            return String.valueOf(SignedJWT.parse(idToken).getJWTClaimsSet().getClaim(claimname));
         } catch (ParseException e) {
             if (LOG.isDebugEnabled()) {
                 LOG.debug("Error while parsing the ID token.", e);
             }
         }
         return null;
+    }
+
+    private static OrganizationManager getOrganizationManager() {
+
+        return OrganizationManagementHandlerDataHolder.getInstance().getOrganizationManager();
     }
 }

--- a/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/OrganizationSessionHandler.java
+++ b/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/OrganizationSessionHandler.java
@@ -59,7 +59,6 @@ public class OrganizationSessionHandler extends AbstractEventHandler {
     private static final Log LOG = LogFactory.getLog(OrganizationSessionHandler.class);
     private static final String AUTHORIZED_ORGANIZATION_ID_ATTRIBUTE = "org_id";
 
-
     @Override
     public void handleEvent(Event event) throws IdentityEventException {
 

--- a/components/org.wso2.carbon.identity.organization.management.handler/src/test/java/org/wso2/carbon/identity/organization/management/handler/OrganizationSessionHandlerTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.handler/src/test/java/org/wso2/carbon/identity/organization/management/handler/OrganizationSessionHandlerTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.management.handler;
+
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.authentication.framework.cache.SessionContextCache;
+import org.wso2.carbon.identity.application.authentication.framework.cache.SessionContextCacheEntry;
+import org.wso2.carbon.identity.application.authentication.framework.config.model.AuthenticatorConfig;
+import org.wso2.carbon.identity.application.authentication.framework.context.SessionContext;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedIdPData;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.application.authenticator.oidc.model.OIDCStateInfo;
+import org.wso2.carbon.identity.event.event.Event;
+import org.wso2.carbon.identity.organization.management.handler.internal.OrganizationManagementHandlerDataHolder;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+import static org.testng.Assert.assertEquals;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.ORGANIZATION_AUTHENTICATOR;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.ORGANIZATION_LOGIN_IDP_NAME;
+import static org.wso2.carbon.identity.event.IdentityEventConstants.Event.SESSION_EXTENSION;
+import static org.wso2.carbon.identity.event.IdentityEventConstants.EventProperty.SESSION_CONTEXT;
+import static org.wso2.carbon.identity.event.IdentityEventConstants.EventProperty.SESSION_CONTEXT_ID;
+
+public class OrganizationSessionHandlerTest {
+
+    @Mock
+    private OrganizationManager organizationManager;
+    @Mock
+    private SessionContextCache sessionContextCache;
+    private MockedStatic<SessionContextCache> sessionContextCacheMockedStatic;
+    private MockedStatic<FrameworkUtils> frameworkUtilsMockedStatic;
+
+    @BeforeClass
+    public void setUp() {
+
+        openMocks(this);
+        OrganizationManagementHandlerDataHolder.getInstance().setOrganizationManager(organizationManager);
+        sessionContextCacheMockedStatic = mockStatic(SessionContextCache.class);
+        frameworkUtilsMockedStatic = mockStatic(FrameworkUtils.class);
+    }
+
+    @AfterClass
+    public void tearDown() {
+
+        sessionContextCacheMockedStatic.close();
+    }
+
+    @Test(dataProvider = "sessionTypeDataProvider")
+    public void testHandleOrgSessionExtendMethod(String idpName, String authenticatorName, boolean isSessionExpired,
+                                                 boolean isSessionUpdated) throws Exception {
+
+        Map<String, Object> eventProperties = new HashMap<>();
+
+        SessionContext sessionContext = new SessionContext();
+
+        OIDCStateInfo oidcStateInfo = new OIDCStateInfo();
+        oidcStateInfo.setIdTokenHint(
+                "eyJ4NXQiOiJPV1JpTXpaaVlURXhZVEl4WkdGa05UVTJOVE0zTWpkaFltTmxNVFZrTnpRMU56a3pa"
+                        + "VGc1TVRrNE0yWmxOMkZoWkdaalpURmlNemxsTTJJM1l6ZzJNZyIsImtpZCI6Ik9XUmlNelppWVRFeFlU"
+                        + "SXhaR0ZrTlRVMk5UTTNNamRoWW1ObE1UVmtOelExTnprelpUZzVNVGs0TTJabE4yRmhaR1pqWlRGaU16"
+                        + "bGxNMkkzWXpnMk1nX1JTMjU2IiwiYWxnIjoiUlMyNTYifQ.eyJpc2siOiI1NmJkNTBmNDE3MzJkZDExN"
+                        + "jczMjRkYTM4NDAzZmMxYWE3YmI3ZDc2ZTUxYjAyNTcyMzUzMTEzNDAxZjM3OThhIiwiYXRfaGFzaCI6I"
+                        + "mh5dXJhb3lEdzBZTXJ3TTNVV2JIb1EiLCJzdWIiOiI5Zjg0ODhlZi1kNTIyLTQ0NWQtYTllMy05MWRkO"
+                        + "TA2OTc4YjEiLCJhbXIiOlsiQmFzaWNBdXRoZW50aWNhdG9yIl0sImlzcyI6Imh0dHBzOlwvXC9sb2Nhb"
+                        + "Ghvc3Q6OTQ0M1wvb2F1dGgyXC90b2tlbiIsInNpZCI6IjBmMjBjNWZlLTU3ZWItNDMzNi1iZGU4LTI4N"
+                        + "TRmMWE5MzFlMyIsImF1ZCI6InJVWTB3RU85d1N1M0l2SHpmem9vMEdmSE5Pb2EiLCJjX2hhc2giOiJBd"
+                        + "ndQTjFvT0Jla3RydHR2MkRoM09nIiwibmJmIjoxNzQyNTYwMTI2LCJhenAiOiJyVVkwd0VPOXdTdTNJd"
+                        + "k h6ZnpvbzBHZkhOT29hIiwib3JnX2lkIjoiMTAwODRhOGQtMTEzZi00MjExLWEwZDUtZWZlMzZiMDgyM"
+                        + "jExIiwiZXhwIjoxNzQyNTYzNzI2LCJvcmdfbmFtZSI6IlN1cGVyIiwiaWF0IjoxNzQyNTYwMTI2LCJqd"
+                        + "GkiOiIxMjA0MGYzMi01OGJkLTQ3ZjYtYjg4NS0wNTMyM2M0NzMxNDgifQ.BNDz2yftQOy_4kOC7iRz7H"
+                        + "Tb8znV-1IafR9ZQgF3kS8FU0uhcPZmbTQICn-cbpqsFY3V-p-do6y8bjEuJ1mgNrXVAqETbn2MIGiUYc"
+                        + "wmFOb2Va32SjqmcovqkoHSFCv9mn0yxNo-CugeCm6r71RPnDkHm7QvYoY2Pp2S83RgYgpSGdzdFloWAV"
+                        + "zkN0gtcfPQEIXKtzFJiR5wxcIH_VdfdMF_B2oc2rcrWH7bnDtsgtSsGr7k8_EFYv0515W4EYsz03rFDb"
+                        + "C0VNQGRkh3XYzI-sLUwq9qFIGgiLzcqEpjCf6wz1CCDDmt7_A1OL3JTNoiE4TBYg55sOx6YzW9DQUMLA");
+
+        AuthenticatorConfig authenticatorConfig = new AuthenticatorConfig();
+        authenticatorConfig.setName(authenticatorName);
+        authenticatorConfig.setAuthenticatorStateInfo(oidcStateInfo);
+
+        Map<String, AuthenticatedIdPData> authenticatedIdPs = new HashMap<>();
+        AuthenticatedIdPData authenticatedIdPData = new AuthenticatedIdPData();
+        authenticatedIdPData.setIdpName(idpName);
+        authenticatedIdPs.put(idpName, authenticatedIdPData);
+        authenticatedIdPData.setAuthenticators(List.of(authenticatorConfig));
+        sessionContext.setAuthenticatedIdPs(authenticatedIdPs);
+
+        eventProperties.put(SESSION_CONTEXT, sessionContext);
+        eventProperties.put(SESSION_CONTEXT_ID, "dummySessionContextId");
+        Event event = new Event(SESSION_EXTENSION, eventProperties);
+
+        when(organizationManager.resolveTenantDomain(anyString())).thenReturn("orgTenantDomain");
+        sessionContextCacheMockedStatic.when(SessionContextCache::getInstance).thenReturn(sessionContextCache);
+
+        SessionContextCacheEntry sessionContextCacheEntry = new SessionContextCacheEntry();
+        SessionContext orgSessionContext = new SessionContext();
+        sessionContextCacheEntry.setContext(orgSessionContext);
+        when(sessionContextCache.getSessionContextCacheEntry(any(), anyString())).thenReturn(sessionContextCacheEntry);
+        when(sessionContextCache.isSessionExpired(any(), any())).thenReturn(isSessionExpired);
+
+        AtomicBoolean sessionUpdated = new AtomicBoolean(false);
+        frameworkUtilsMockedStatic.when(() -> FrameworkUtils.updateSessionLastAccessTimeMetadata(anyString(), any()))
+                .thenAnswer(invocation -> null);
+        frameworkUtilsMockedStatic.when(
+                        () -> FrameworkUtils.addSessionContextToCache(anyString(), any(), anyString(), anyString()))
+                .thenAnswer(invocation -> {
+                    sessionUpdated.set(isSessionUpdated);
+                    return null;
+                });
+
+        OrganizationSessionHandler organizationSessionHandler = new OrganizationSessionHandler();
+        organizationSessionHandler.handleEvent(event);
+        assertEquals(sessionUpdated.get(), isSessionUpdated);
+    }
+
+    @DataProvider(name = "sessionTypeDataProvider")
+    public Object[][] sessionTypeDataProvider() {
+
+        return new Object[][]{{"dummyIdp", ORGANIZATION_AUTHENTICATOR, false, true},
+                {ORGANIZATION_LOGIN_IDP_NAME, "dummyAuthenticator", false, false},
+                {ORGANIZATION_LOGIN_IDP_NAME, ORGANIZATION_AUTHENTICATOR, true, false},
+                {ORGANIZATION_LOGIN_IDP_NAME, ORGANIZATION_AUTHENTICATOR, false, true}};
+    }
+}

--- a/components/org.wso2.carbon.identity.organization.management.handler/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.organization.management.handler/src/test/resources/testng.xml
@@ -25,6 +25,7 @@
             <class name="org.wso2.carbon.identity.organization.management.handler.GovernanceConfigUpdateHandlerTest"/>
             <class name="org.wso2.carbon.identity.organization.management.handler.SharedRoleMgtHandlerTest"/>
             <class name="org.wso2.carbon.identity.organization.management.handler.SharingPolicyCleanUpHandlerTest"/>
+            <class name="org.wso2.carbon.identity.organization.management.handler.OrganizationSessionHandlerTest"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
### Subject

- This PR adds supports to extend the underlying sub organization sessions when the root organization session is extended with the session extension API.

### Related Issue
- https://github.com/wso2/product-is/issues/23291