### PR TITLE
Handle remember me option of root org session to align with sub org session

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/OrganizationSessionHandler.java
+++ b/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/OrganizationSessionHandler.java
@@ -29,6 +29,7 @@ import org.wso2.carbon.identity.application.authentication.framework.cache.Sessi
 import org.wso2.carbon.identity.application.authentication.framework.cache.SessionContextCacheEntry;
 import org.wso2.carbon.identity.application.authentication.framework.cache.SessionContextCacheKey;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.AuthenticatorConfig;
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.context.SessionContext;
 import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
 import org.wso2.carbon.identity.application.authentication.framework.exception.session.mgt.SessionManagementException;
@@ -68,6 +69,8 @@ public class OrganizationSessionHandler extends AbstractEventHandler {
             handleOrgSessionTerminate(eventProperties);
         } else if (IdentityEventConstants.Event.SESSION_EXTENSION.equals(eventName)) {
             handleOrgSessionExtend(eventProperties);
+        } else if (IdentityEventConstants.EventName.SESSION_CREATE.name().equals(eventName)) {
+            handleOrgSessionCreation(eventProperties);
         }
     }
 
@@ -209,6 +212,104 @@ public class OrganizationSessionHandler extends AbstractEventHandler {
         long currentTime = System.currentTimeMillis();
         FrameworkUtils.updateSessionLastAccessTimeMetadata(sessionId, currentTime);
         FrameworkUtils.addSessionContextToCache(sessionId, orgSessionContext, tenantDomain, tenantDomain);
+    }
+
+    private void handleOrgSessionCreation(Map<String, Object> eventProperties) {
+
+        SessionContext sessionContext = (SessionContext) eventProperties.get(
+                IdentityEventConstants.EventProperty.SESSION_CONTEXT);
+        AuthenticationContext context = (AuthenticationContext) eventProperties.get(
+                IdentityEventConstants.EventProperty.CONTEXT);
+        Map<String, Object> params = (Map<String, Object>) eventProperties.get(
+                IdentityEventConstants.EventProperty.PARAMS);
+
+        String rootOrgSessionId;
+        if (params.containsKey(FrameworkConstants.AnalyticsAttributes.SESSION_ID)) {
+            rootOrgSessionId = (String) params.get(FrameworkConstants.AnalyticsAttributes.SESSION_ID);
+        } else {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Root organization session ID not found in the event properties.");
+            }
+            return;
+        }
+
+        Map<String, AuthenticatedIdPData> authenticatedIdPs = sessionContext.getAuthenticatedIdPs();
+        if (authenticatedIdPs == null) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Authenticated IdPs not found in the session context." +
+                        " Hence, handling root org session remember me option is not needed.");
+            }
+            return;
+        }
+
+        String subOrgSessionId = null;
+        String subOrgId = null;
+        authenticatedIdPsLoop:
+        for (Map.Entry<String, AuthenticatedIdPData> entry : authenticatedIdPs.entrySet()) {
+            if (entry.getValue() == null) {
+                continue;
+            }
+            List<AuthenticatorConfig> authenticators = entry.getValue().getAuthenticators();
+            if (CollectionUtils.isEmpty(authenticators)) {
+                continue;
+            }
+            for (AuthenticatorConfig authenticator : authenticators) {
+                if (FrameworkConstants.ORGANIZATION_AUTHENTICATOR.equals(authenticator.getName())) {
+                    AuthenticatorStateInfo authenticatorStateInfo = authenticator.getAuthenticatorStateInfo();
+                    if (authenticatorStateInfo instanceof OIDCStateInfo) {
+                        OIDCStateInfo oidcStateInfo = (OIDCStateInfo) authenticatorStateInfo;
+                        String idTokenHint = oidcStateInfo.getIdTokenHint();
+                        // Resolve session ID by `isk` claim in ID token hint.
+                        subOrgSessionId = getClaimFromJWT(idTokenHint, IDP_SESSION_KEY);
+                        // Resolve org ID by `org_id` claim in ID token hint.
+                        subOrgId = getClaimFromJWT(idTokenHint, AUTHORIZED_ORGANIZATION_ID_ATTRIBUTE);
+                        break authenticatedIdPsLoop;
+                    }
+                }
+            }
+        }
+
+        if (StringUtils.isBlank(subOrgSessionId) || StringUtils.isBlank(subOrgId)) {
+            LOG.debug("Organization authenticator not found in the authenticators list or " +
+                    "Session ID / org ID not found in the ID token.");
+            return;
+        }
+        String subOrgTenantDomain;
+        try {
+            subOrgTenantDomain = getOrganizationManager().resolveTenantDomain(subOrgId);
+            if (StringUtils.isBlank(subOrgTenantDomain)) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Tenant domain not found for the organization ID: " + subOrgId);
+                }
+                return;
+            }
+        } catch (OrganizationManagementException e) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Error while handling root org session remember me option for sub org session: " +
+                        subOrgId, e);
+            }
+            return;
+        }
+
+        SessionContextCacheKey sessionContextCacheKey = new SessionContextCacheKey(subOrgSessionId);
+        SessionContextCacheEntry sessionContextCacheEntry = SessionContextCache.getInstance()
+                .getSessionContextCacheEntry(sessionContextCacheKey, subOrgTenantDomain);
+        if (sessionContextCacheEntry == null) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("No session available for requested session identifier: " + subOrgSessionId);
+            }
+            return;
+        }
+
+        // Get the sub organization session context.
+        SessionContext orgSessionContext = sessionContextCacheEntry.getContext();
+
+        // Set the remember me option of the sub organization session to the root organization session.
+        sessionContext.setRememberMe(orgSessionContext.isRememberMe());
+
+        // Add the root organization session context to the cache.
+        FrameworkUtils.addSessionContextToCache(rootOrgSessionId, sessionContext, subOrgTenantDomain,
+                context.getLoginTenantDomain());
     }
 
     private String getClaimFromJWT(String idToken, String claimname) {

--- a/components/org.wso2.carbon.identity.organization.management.handler/src/test/java/org/wso2/carbon/identity/organization/management/handler/OrganizationSessionHandlerTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.handler/src/test/java/org/wso2/carbon/identity/organization/management/handler/OrganizationSessionHandlerTest.java
@@ -66,6 +66,19 @@ public class OrganizationSessionHandlerTest {
     private final String testTenant = "dummyTenant1";
     private final String testSessionId = "dummySessionId";
     private final String testOrgTenant = "dummyOrgTenant";
+    private final String testIdTokenHint =
+            "eyJhbGciOiJSUzI1NiIsImtpZCI6ImRlbW8ta2lkLTEyMzQ1IiwidHlwIjoiSldUIiwieDV0IjoiZGVtby14NXQtNjc4OTAifQ" +
+                    ".eyJpc2siOiI4M2I0ZTY0NGE3MmM4MmEzNDkwNTljZTNmY2FhMDc2YzZkODc4MWE0ZWZhNWJlZjBmZTA2ZmMxY2Y5M" +
+                    "2IwMDliIiwic3ViIjoiNTUwM2VkNmYtNTA3Yi00ZTA1LTk0MTUtZDZlMjE5MGY5YWQyIiwiaXNzIjoiaHR0cHM6Ly9" +
+                    "sb2NhbGhvc3Q6OTQ0My9vL2ZhY2RlYWIxLWNjMGEtNDU5MC04MGVjLTYxMDViMzgyNjgwMi9vYXV0aDIvdG9rZW4iL" +
+                    "CJhdWQiOiJjZGJmZGM5OS1iN2M2LTQ0MjMtOGJkYy1lNWFiMzcwMThlMWQiLCJjbGllbnRfaWQiOiJjZGJmZGM5OS1" +
+                    "iN2M2LTQ0MjMtOGJkYy1lNWFiMzcwMThlMWQiLCJleHAiOjE3NDMzNDQ4MjgsImlhdCI6MTc0MzM0MTIyOCwianRpI" +
+                    "joiMDVmZmM2MDgtMjQyNy00M2U5LTkxYzEtNjI0OTIwY2M5YzY1Iiwib3JnX25hbWUiOiJkdW1teW9yZzEiLCJvcmd" +
+                    "faWQiOiJmYWNkZWFiMS1jYzBhLTQ1OTAtODBlYy02MTA1YjM4MjY4MDIiLCJ1c2VybmFtZSI6ImR1bW15dXNlciJ9." +
+                    "ODglE3IUFsKpZqGGj2nLCLDqjS52lv4hcA8cFkMtmgI6Se0_b857fx4xuqNTEaDyCkY_9uy4UGt_yngl11Rnx_0PqO" +
+                    "LZG5Fysw7Zktg4cBchywWLfIeyn1zovBN5Q6t5JxkwJG6XvTnt_BUXRdHH5wFo_ErEn74fNoFIKhDneS-IiVUnwxGz" +
+                    "hZKpPnhJZllmlJlZenqSRRaMK_mLsmb218zEj_zAn8bbaI1eG9TqNXZwmjmftxhrqGqMyLhyZrTCXXLtO893n4qpA0" +
+                    "lPgM23X1HeTPN_59SUwqhI7clnDRb6eZ-RDIgWAoixdR4I9r-UJfvNfqAEv4xwTf3zaNTt4g";
     private AutoCloseable closeable;
 
     @Mock
@@ -164,19 +177,7 @@ public class OrganizationSessionHandlerTest {
 
         SessionContext sessionContext = new SessionContext();
         OIDCStateInfo oidcStateInfo = new OIDCStateInfo();
-        oidcStateInfo.setIdTokenHint(
-                "eyJhbGciOiJSUzI1NiIsImtpZCI6ImRlbW8ta2lkLTEyMzQ1IiwidHlwIjoiSldUIiwieDV0IjoiZGVtby14NXQtNjc4OTAifQ" +
-                        ".eyJpc2siOiI4M2I0ZTY0NGE3MmM4MmEzNDkwNTljZTNmY2FhMDc2YzZkODc4MWE0ZWZhNWJlZjBmZTA2ZmMxY2Y5M" +
-                        "2IwMDliIiwic3ViIjoiNTUwM2VkNmYtNTA3Yi00ZTA1LTk0MTUtZDZlMjE5MGY5YWQyIiwiaXNzIjoiaHR0cHM6Ly9" +
-                        "sb2NhbGhvc3Q6OTQ0My9vL2ZhY2RlYWIxLWNjMGEtNDU5MC04MGVjLTYxMDViMzgyNjgwMi9vYXV0aDIvdG9rZW4iL" +
-                        "CJhdWQiOiJjZGJmZGM5OS1iN2M2LTQ0MjMtOGJkYy1lNWFiMzcwMThlMWQiLCJjbGllbnRfaWQiOiJjZGJmZGM5OS1" +
-                        "iN2M2LTQ0MjMtOGJkYy1lNWFiMzcwMThlMWQiLCJleHAiOjE3NDMzNDQ4MjgsImlhdCI6MTc0MzM0MTIyOCwianRpI" +
-                        "joiMDVmZmM2MDgtMjQyNy00M2U5LTkxYzEtNjI0OTIwY2M5YzY1Iiwib3JnX25hbWUiOiJkdW1teW9yZzEiLCJvcmd" +
-                        "faWQiOiJmYWNkZWFiMS1jYzBhLTQ1OTAtODBlYy02MTA1YjM4MjY4MDIiLCJ1c2VybmFtZSI6ImR1bW15dXNlciJ9." +
-                        "ODglE3IUFsKpZqGGj2nLCLDqjS52lv4hcA8cFkMtmgI6Se0_b857fx4xuqNTEaDyCkY_9uy4UGt_yngl11Rnx_0PqO" +
-                        "LZG5Fysw7Zktg4cBchywWLfIeyn1zovBN5Q6t5JxkwJG6XvTnt_BUXRdHH5wFo_ErEn74fNoFIKhDneS-IiVUnwxGz" +
-                        "hZKpPnhJZllmlJlZenqSRRaMK_mLsmb218zEj_zAn8bbaI1eG9TqNXZwmjmftxhrqGqMyLhyZrTCXXLtO893n4qpA0" +
-                        "lPgM23X1HeTPN_59SUwqhI7clnDRb6eZ-RDIgWAoixdR4I9r-UJfvNfqAEv4xwTf3zaNTt4g");
+        oidcStateInfo.setIdTokenHint(testIdTokenHint);
         // Initialize authenticator config.
         AuthenticatorConfig authenticatorConfig = new AuthenticatorConfig();
         authenticatorConfig.setName(ORGANIZATION_AUTHENTICATOR);
@@ -229,6 +230,58 @@ public class OrganizationSessionHandlerTest {
 
     @Test
     public void testHandleOrgSessionCreationForNonRememberMeSession() throws Exception {
+
+        SessionContext sessionContext = new SessionContext();
+        OIDCStateInfo oidcStateInfo = new OIDCStateInfo();
+        oidcStateInfo.setIdTokenHint(testIdTokenHint);
+        // Initialize authenticator config.
+        AuthenticatorConfig authenticatorConfig = new AuthenticatorConfig();
+        authenticatorConfig.setName(ORGANIZATION_AUTHENTICATOR);
+        authenticatorConfig.setAuthenticatorStateInfo(oidcStateInfo);
+        // Initialize authenticated IdPs.
+        Map<String, AuthenticatedIdPData> authenticatedIdPs = new HashMap<>();
+        AuthenticatedIdPData authenticatedIdPData = new AuthenticatedIdPData();
+        authenticatedIdPData.setIdpName(ORGANIZATION_LOGIN_IDP_NAME);
+        authenticatedIdPs.put(ORGANIZATION_LOGIN_IDP_NAME, authenticatedIdPData);
+        authenticatedIdPData.setAuthenticators(List.of(authenticatorConfig));
+        sessionContext.setAuthenticatedIdPs(authenticatedIdPs);
+
+        sessionContext.setRememberMe(false);
+
+        AuthenticationContext authenticationContext = new AuthenticationContext();
+        authenticationContext.setTenantDomain(testTenant);
+
+        Map<String, Object> eventProperties = new HashMap<>();
+        eventProperties.put(SESSION_CONTEXT, sessionContext);
+        eventProperties.put(CONTEXT, authenticationContext);
+        Map<String, Object> params = new HashMap<>();
+        params.put(FrameworkConstants.AnalyticsAttributes.SESSION_ID, testSessionId);
+        params.put(FrameworkConstants.AnalyticsAttributes.USER, "dummyuser");
+        eventProperties.put(PARAMS, params);
+        Event event = new Event(SESSION_CREATE.name(), eventProperties);
+
+        when(organizationManager.resolveTenantDomain(anyString())).thenReturn(testOrgTenant);
+        sessionContextCacheMockedStatic.when(SessionContextCache::getInstance).thenReturn(sessionContextCache);
+
+        SessionContextCacheEntry sessionContextCacheEntry = new SessionContextCacheEntry();
+        SessionContext orgSessionContext = new SessionContext();
+        orgSessionContext.setRememberMe(false);
+        sessionContextCacheEntry.setContext(orgSessionContext);
+        when(sessionContextCache.getSessionContextCacheEntry(any(), anyString())).thenReturn(sessionContextCacheEntry);
+
+        frameworkUtilsMockedStatic.when(() -> FrameworkUtils.addSessionContextToCache(anyString(), any(), anyString(),
+                anyString())).thenAnswer(invocation -> null);
+
+        OrganizationSessionHandler organizationSessionHandler = new OrganizationSessionHandler();
+        // Execute the method.
+        organizationSessionHandler.handleEvent(event);
+
+        frameworkUtilsMockedStatic.verify(() ->
+                FrameworkUtils.addSessionContextToCache(anyString(), any(), anyString(), anyString()), times(0));
+    }
+
+    @Test
+    public void testHandleOrgSessionCreationForNonOrganizationSSOScenario() throws Exception {
 
         SessionContext sessionContext = new SessionContext();
         // Initialize authenticator config.

--- a/components/org.wso2.carbon.identity.organization.management.handler/src/test/java/org/wso2/carbon/identity/organization/management/handler/OrganizationSessionHandlerTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.handler/src/test/java/org/wso2/carbon/identity/organization/management/handler/OrganizationSessionHandlerTest.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.organization.management.handler;
 
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.testng.annotations.AfterClass;
@@ -27,8 +28,10 @@ import org.testng.annotations.Test;
 import org.wso2.carbon.identity.application.authentication.framework.cache.SessionContextCache;
 import org.wso2.carbon.identity.application.authentication.framework.cache.SessionContextCacheEntry;
 import org.wso2.carbon.identity.application.authentication.framework.config.model.AuthenticatorConfig;
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
 import org.wso2.carbon.identity.application.authentication.framework.context.SessionContext;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedIdPData;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
 import org.wso2.carbon.identity.application.authenticator.oidc.model.OIDCStateInfo;
 import org.wso2.carbon.identity.event.event.Event;
@@ -42,17 +45,28 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.ORGANIZATION_AUTHENTICATOR;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.ORGANIZATION_LOGIN_IDP_NAME;
 import static org.wso2.carbon.identity.event.IdentityEventConstants.Event.SESSION_EXTENSION;
+import static org.wso2.carbon.identity.event.IdentityEventConstants.EventName.SESSION_CREATE;
+import static org.wso2.carbon.identity.event.IdentityEventConstants.EventProperty.CONTEXT;
+import static org.wso2.carbon.identity.event.IdentityEventConstants.EventProperty.PARAMS;
 import static org.wso2.carbon.identity.event.IdentityEventConstants.EventProperty.SESSION_CONTEXT;
 import static org.wso2.carbon.identity.event.IdentityEventConstants.EventProperty.SESSION_CONTEXT_ID;
 
 public class OrganizationSessionHandlerTest {
+
+    private final String testTenant = "dummyTenant1";
+    private final String testSessionId = "dummySessionId";
+    private final String testOrgTenant = "dummyOrgTenant";
+    private AutoCloseable closeable;
 
     @Mock
     private OrganizationManager organizationManager;
@@ -64,16 +78,18 @@ public class OrganizationSessionHandlerTest {
     @BeforeClass
     public void setUp() {
 
-        openMocks(this);
+        closeable = openMocks(this);
         OrganizationManagementHandlerDataHolder.getInstance().setOrganizationManager(organizationManager);
         sessionContextCacheMockedStatic = mockStatic(SessionContextCache.class);
         frameworkUtilsMockedStatic = mockStatic(FrameworkUtils.class);
     }
 
     @AfterClass
-    public void tearDown() {
+    public void tearDown() throws Exception {
 
         sessionContextCacheMockedStatic.close();
+        frameworkUtilsMockedStatic.close();
+        closeable.close();
     }
 
     @Test(dataProvider = "sessionTypeDataProvider")
@@ -141,6 +157,114 @@ public class OrganizationSessionHandlerTest {
         OrganizationSessionHandler organizationSessionHandler = new OrganizationSessionHandler();
         organizationSessionHandler.handleEvent(event);
         assertEquals(sessionUpdated.get(), isSessionUpdated);
+    }
+
+    @Test
+    public void testHandleOrgSessionCreationForRememberMeSession() throws Exception {
+
+        SessionContext sessionContext = new SessionContext();
+        OIDCStateInfo oidcStateInfo = new OIDCStateInfo();
+        oidcStateInfo.setIdTokenHint(
+                "eyJhbGciOiJSUzI1NiIsImtpZCI6ImRlbW8ta2lkLTEyMzQ1IiwidHlwIjoiSldUIiwieDV0IjoiZGVtby14NXQtNjc4OTAifQ" +
+                        ".eyJpc2siOiI4M2I0ZTY0NGE3MmM4MmEzNDkwNTljZTNmY2FhMDc2YzZkODc4MWE0ZWZhNWJlZjBmZTA2ZmMxY2Y5M" +
+                        "2IwMDliIiwic3ViIjoiNTUwM2VkNmYtNTA3Yi00ZTA1LTk0MTUtZDZlMjE5MGY5YWQyIiwiaXNzIjoiaHR0cHM6Ly9" +
+                        "sb2NhbGhvc3Q6OTQ0My9vL2ZhY2RlYWIxLWNjMGEtNDU5MC04MGVjLTYxMDViMzgyNjgwMi9vYXV0aDIvdG9rZW4iL" +
+                        "CJhdWQiOiJjZGJmZGM5OS1iN2M2LTQ0MjMtOGJkYy1lNWFiMzcwMThlMWQiLCJjbGllbnRfaWQiOiJjZGJmZGM5OS1" +
+                        "iN2M2LTQ0MjMtOGJkYy1lNWFiMzcwMThlMWQiLCJleHAiOjE3NDMzNDQ4MjgsImlhdCI6MTc0MzM0MTIyOCwianRpI" +
+                        "joiMDVmZmM2MDgtMjQyNy00M2U5LTkxYzEtNjI0OTIwY2M5YzY1Iiwib3JnX25hbWUiOiJkdW1teW9yZzEiLCJvcmd" +
+                        "faWQiOiJmYWNkZWFiMS1jYzBhLTQ1OTAtODBlYy02MTA1YjM4MjY4MDIiLCJ1c2VybmFtZSI6ImR1bW15dXNlciJ9." +
+                        "ODglE3IUFsKpZqGGj2nLCLDqjS52lv4hcA8cFkMtmgI6Se0_b857fx4xuqNTEaDyCkY_9uy4UGt_yngl11Rnx_0PqO" +
+                        "LZG5Fysw7Zktg4cBchywWLfIeyn1zovBN5Q6t5JxkwJG6XvTnt_BUXRdHH5wFo_ErEn74fNoFIKhDneS-IiVUnwxGz" +
+                        "hZKpPnhJZllmlJlZenqSRRaMK_mLsmb218zEj_zAn8bbaI1eG9TqNXZwmjmftxhrqGqMyLhyZrTCXXLtO893n4qpA0" +
+                        "lPgM23X1HeTPN_59SUwqhI7clnDRb6eZ-RDIgWAoixdR4I9r-UJfvNfqAEv4xwTf3zaNTt4g");
+        // Initialize authenticator config.
+        AuthenticatorConfig authenticatorConfig = new AuthenticatorConfig();
+        authenticatorConfig.setName(ORGANIZATION_AUTHENTICATOR);
+        authenticatorConfig.setAuthenticatorStateInfo(oidcStateInfo);
+        // Initialize authenticated IdPs.
+        Map<String, AuthenticatedIdPData> authenticatedIdPs = new HashMap<>();
+        AuthenticatedIdPData authenticatedIdPData = new AuthenticatedIdPData();
+        authenticatedIdPData.setIdpName(ORGANIZATION_LOGIN_IDP_NAME);
+        authenticatedIdPs.put(ORGANIZATION_LOGIN_IDP_NAME, authenticatedIdPData);
+        authenticatedIdPData.setAuthenticators(List.of(authenticatorConfig));
+        sessionContext.setAuthenticatedIdPs(authenticatedIdPs);
+
+        sessionContext.setRememberMe(false);
+
+        AuthenticationContext authenticationContext = new AuthenticationContext();
+        authenticationContext.setTenantDomain(testTenant);
+
+        Map<String, Object> eventProperties = new HashMap<>();
+        eventProperties.put(SESSION_CONTEXT, sessionContext);
+        eventProperties.put(CONTEXT, authenticationContext);
+        Map<String, Object> params = new HashMap<>();
+        params.put(FrameworkConstants.AnalyticsAttributes.SESSION_ID, testSessionId);
+        params.put(FrameworkConstants.AnalyticsAttributes.USER, "dummyuser");
+        eventProperties.put(PARAMS, params);
+        Event event = new Event(SESSION_CREATE.name(), eventProperties);
+
+        when(organizationManager.resolveTenantDomain(anyString())).thenReturn(testOrgTenant);
+        sessionContextCacheMockedStatic.when(SessionContextCache::getInstance).thenReturn(sessionContextCache);
+
+        SessionContextCacheEntry sessionContextCacheEntry = new SessionContextCacheEntry();
+        SessionContext orgSessionContext = new SessionContext();
+        orgSessionContext.setRememberMe(true);
+        sessionContextCacheEntry.setContext(orgSessionContext);
+        when(sessionContextCache.getSessionContextCacheEntry(any(), anyString())).thenReturn(sessionContextCacheEntry);
+
+        frameworkUtilsMockedStatic.when(() -> FrameworkUtils.addSessionContextToCache(anyString(), any(), anyString(),
+                anyString())).thenAnswer(invocation -> null);
+
+        OrganizationSessionHandler organizationSessionHandler = new OrganizationSessionHandler();
+        // Execute the method.
+        organizationSessionHandler.handleEvent(event);
+
+        ArgumentCaptor<SessionContext> sessionContextCaptor = ArgumentCaptor.forClass(SessionContext.class);
+        frameworkUtilsMockedStatic.verify(() ->
+                        FrameworkUtils.addSessionContextToCache(eq(testSessionId), sessionContextCaptor.capture(),
+                                eq(testOrgTenant), eq(testTenant)), times(1));
+        SessionContext sessionContextValue = sessionContextCaptor.getValue();
+        assertTrue(sessionContextValue.isRememberMe());
+    }
+
+    @Test
+    public void testHandleOrgSessionCreationForNonRememberMeSession() throws Exception {
+
+        SessionContext sessionContext = new SessionContext();
+        // Initialize authenticator config.
+        AuthenticatorConfig authenticatorConfig = new AuthenticatorConfig();
+        authenticatorConfig.setName("dummyAuthenticator");
+        // Initialize authenticated IdPs.
+        Map<String, AuthenticatedIdPData> authenticatedIdPs = new HashMap<>();
+        AuthenticatedIdPData authenticatedIdPData = new AuthenticatedIdPData();
+        authenticatedIdPData.setIdpName("dummyIdp");
+        authenticatedIdPs.put("dummyIdp", authenticatedIdPData);
+        authenticatedIdPData.setAuthenticators(List.of(authenticatorConfig));
+        sessionContext.setAuthenticatedIdPs(authenticatedIdPs);
+
+        sessionContext.setRememberMe(false);
+
+        AuthenticationContext authenticationContext = new AuthenticationContext();
+        authenticationContext.setTenantDomain(testTenant);
+
+        Map<String, Object> eventProperties = new HashMap<>();
+        eventProperties.put(SESSION_CONTEXT, sessionContext);
+        eventProperties.put(CONTEXT, authenticationContext);
+        Map<String, Object> params = new HashMap<>();
+        params.put(FrameworkConstants.AnalyticsAttributes.SESSION_ID, testSessionId);
+        params.put(FrameworkConstants.AnalyticsAttributes.USER, "dummyuser");
+        eventProperties.put(PARAMS, params);
+        Event event = new Event(SESSION_CREATE.name(), eventProperties);
+
+        frameworkUtilsMockedStatic.when(() -> FrameworkUtils.addSessionContextToCache(anyString(), any(), anyString(),
+                anyString())).thenAnswer(invocation -> null);
+
+        OrganizationSessionHandler organizationSessionHandler = new OrganizationSessionHandler();
+        // Execute the method.
+        organizationSessionHandler.handleEvent(event);
+
+        frameworkUtilsMockedStatic.verify(() ->
+                FrameworkUtils.addSessionContextToCache(anyString(), any(), anyString(), anyString()), times(0));
     }
 
     @DataProvider(name = "sessionTypeDataProvider")


### PR DESCRIPTION
## Purpose
> Currently when the sub org user selects remember me option, only sub org session is set as remember me true. We need to update the root org session similarly to avoid idle session timeouts.

Issue - https://github.com/wso2/product-is/issues/23550