### PR TITLE
Add organization handle to JWT access tokens and id tokens

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.claim.provider/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.claim.provider/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+  ~ Copyright (c) 2023-2025, WSO2 LLC. (http://www.wso2.com).
   ~
   ~ WSO2 LLC. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except
@@ -47,6 +47,14 @@
         <dependency>
             <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
             <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
         </dependency>
     </dependencies>
 

--- a/components/org.wso2.carbon.identity.organization.management.claim.provider/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.claim.provider/pom.xml
@@ -51,10 +51,12 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -101,28 +103,15 @@
                 <version>${jacoco.version}</version>
                 <executions>
                     <execution>
-                        <id>default-instrument</id>
                         <goals>
-                            <goal>instrument</goal>
+                            <goal>prepare-agent</goal>
                         </goals>
                     </execution>
                     <execution>
-                        <id>default-restore-instrumented-classes</id>
-                        <goals>
-                            <goal>restore-instrumented-classes</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-report</id>
-                        <phase>prepare-package</phase>
+                        <id>report</id>
+                        <phase>test</phase>
                         <goals>
                             <goal>report</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>default-report-integration</id>
-                        <goals>
-                            <goal>report-integration</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/components/org.wso2.carbon.identity.organization.management.claim.provider/src/main/java/org/wso2/carbon/identity/organization/management/claim/provider/OrganizationClaimProvider.java
+++ b/components/org.wso2.carbon.identity.organization.management.claim.provider/src/main/java/org/wso2/carbon/identity/organization/management/claim/provider/OrganizationClaimProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023-2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -43,6 +43,7 @@ public class OrganizationClaimProvider implements ClaimProvider, JWTAccessTokenC
 
     private static final String AUTHORIZED_ORGANIZATION_ID_ATTRIBUTE = "org_id";
     private static final String AUTHORIZED_ORGANIZATION_NAME_ATTRIBUTE = "org_name";
+    private static final String AUTHORIZED_ORGANIZATION_HANDLE_ATTRIBUTE = "org_handle";
     private static final String USER_RESIDENT_ORGANIZATION_NAME_ATTRIBUTE = "user_org";
 
     @Override
@@ -100,9 +101,11 @@ public class OrganizationClaimProvider implements ClaimProvider, JWTAccessTokenC
         try {
             if (StringUtils.isNotBlank(authorizedOrgId)) {
                 String authorizedOrgName = getOrganizationManager().getOrganizationNameById(authorizedOrgId);
+                String authorizedOrgHandle = getOrganizationManager().resolveTenantDomain(authorizedOrgId);
                 additionalClaims.put(USER_RESIDENT_ORGANIZATION_NAME_ATTRIBUTE, userResideOrgId);
                 additionalClaims.put(AUTHORIZED_ORGANIZATION_ID_ATTRIBUTE, authorizedOrgId);
                 additionalClaims.put(AUTHORIZED_ORGANIZATION_NAME_ATTRIBUTE, authorizedOrgName);
+                additionalClaims.put(AUTHORIZED_ORGANIZATION_HANDLE_ATTRIBUTE, authorizedOrgHandle);
             }
         } catch (OrganizationManagementException e) {
             throw new IdentityOAuth2Exception("Error while resolving organization name by ID.", e);

--- a/components/org.wso2.carbon.identity.organization.management.claim.provider/src/test/java/org/wso2/carbon/identity/organization/management/claim/provider/OrganizationClaimProviderTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.claim.provider/src/test/java/org/wso2/carbon/identity/organization/management/claim/provider/OrganizationClaimProviderTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.management.claim.provider;
+
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
+import org.wso2.carbon.identity.organization.management.claim.provider.internal.OrganizationClaimProviderServiceComponentHolder;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManagementInitialize;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+
+import java.util.Map;
+
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class OrganizationClaimProviderTest {
+
+    private static final String USER_ORG_ID = "userOrgId";
+    private static final String AUTH_ORG_ID = "authOrgId";
+    private static final String AUTHORIZED_ORG_NAME = "AuthorizedOrgName";
+    private static final String AUTHORIZED_ORG_HANDLE = "AuthorizedOrgHandle";
+    private static final String ORG_ID_CLAIM = "org_id";
+    private static final String ORG_NAME_CLAIM = "org_name";
+    private static final String ORG_HANDLE_CLAIM = "org_handle";
+
+    private OrganizationClaimProvider organizationClaimProvider;
+
+    @Mock
+    private OAuthTokenReqMessageContext oAuthTokenReqMessageContext;
+
+    @Mock
+    private AuthenticatedUser authenticatedUser;
+
+    @Mock
+    private OrganizationManager organizationManager;
+
+    @Mock
+    private OrganizationManagementInitialize organizationManagementInitializeService;
+
+    @BeforeMethod
+    public void setUp() {
+
+        MockitoAnnotations.openMocks(this);
+        organizationClaimProvider = new OrganizationClaimProvider();
+        OrganizationClaimProviderServiceComponentHolder.getInstance().setOrganizationManager(organizationManager);
+    }
+
+    @Test
+    public void testGetAdditionalClaims() throws IdentityOAuth2Exception, OrganizationManagementException {
+
+        when(organizationManagementInitializeService.isOrganizationManagementEnabled()).thenReturn(true);
+        OrganizationClaimProviderServiceComponentHolder.getInstance()
+                .setOrganizationManagementEnable(organizationManagementInitializeService);
+
+        when(oAuthTokenReqMessageContext.getAuthorizedUser()).thenReturn(authenticatedUser);
+        when(authenticatedUser.getUserResidentOrganization()).thenReturn(USER_ORG_ID);
+        when(authenticatedUser.getAccessingOrganization()).thenReturn(AUTH_ORG_ID);
+
+        when(organizationManager.getOrganizationNameById(AUTH_ORG_ID)).thenReturn(AUTHORIZED_ORG_NAME);
+        when(organizationManager.resolveTenantDomain(AUTH_ORG_ID)).thenReturn(AUTHORIZED_ORG_HANDLE);
+
+        Map<String, Object>
+                additionalClaims = organizationClaimProvider.getAdditionalClaims(oAuthTokenReqMessageContext);
+
+        assertTrue(additionalClaims.containsKey(ORG_ID_CLAIM));
+        assertTrue(additionalClaims.containsKey(ORG_NAME_CLAIM));
+        assertTrue(additionalClaims.containsKey(ORG_HANDLE_CLAIM));
+        assertEquals(AUTH_ORG_ID, additionalClaims.get(ORG_ID_CLAIM));
+        assertEquals(AUTHORIZED_ORG_NAME, additionalClaims.get(ORG_NAME_CLAIM));
+        assertEquals(AUTHORIZED_ORG_HANDLE, additionalClaims.get(ORG_HANDLE_CLAIM));
+    }
+}

--- a/components/org.wso2.carbon.identity.organization.management.claim.provider/src/test/java/org/wso2/carbon/identity/organization/management/claim/provider/OrganizationClaimProviderTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.claim.provider/src/test/java/org/wso2/carbon/identity/organization/management/claim/provider/OrganizationClaimProviderTest.java
@@ -36,6 +36,9 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
+/**
+ * Unit test class for OrganizationClaimProvider.
+ */
 public class OrganizationClaimProviderTest {
 
     private static final String USER_ORG_ID = "userOrgId";

--- a/components/org.wso2.carbon.identity.organization.management.claim.provider/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.organization.management.claim.provider/src/test/resources/testng.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="org.wso2.carbon.identity.organization.management.claim.provider">
+    <test name="organization-claim-provider-tests" preserve-order="true" parallel="false">
+        <classes>
+            <class name="org.wso2.carbon.identity.organization.management.claim.provider.OrganizationClaimProviderTest"/>
+        </classes>
+    </test>
+</suite>


### PR DESCRIPTION
## Purpose
$subject

## Goals
This update will add organization handle to JWT access tokens and id tokens

## Approach
Send as an additional claim along with _org_name_ and _org_id_

**Access tokens**

- Super ORG
   <img width="667" alt="Screenshot 2025-04-08 at 11 46 30" src="https://github.com/user-attachments/assets/9c26c93c-788a-44e8-8718-72a7b902f734" />

- Sub Org with handle
   <img width="667" alt="Screenshot 2025-04-08 at 11 48 18" src="https://github.com/user-attachments/assets/958bd77f-1136-4db9-afda-9646f54242ca" />

- Sub Org without handle (only ID)
   <img width="667" alt="Screenshot 2025-04-08 at 11 47 31" src="https://github.com/user-attachments/assets/d1db1719-ed17-4946-b5b6-86b4a2979e15" />

**ID tokens**
- Super ORG
   <img width="667" alt="Screenshot 2025-04-08 at 11 56 52" src="https://github.com/user-attachments/assets/da0894f3-0158-4a3a-995d-952f8be6ed97" />

- Sub Org with handle
   <img width="667" alt="Screenshot 2025-04-08 at 11 58 25" src="https://github.com/user-attachments/assets/c763928a-ea5a-4c8d-a083-3a210b03c2ae" />

- Sub Org without handle (only ID)
   <img width="658" alt="Screenshot 2025-04-08 at 12 07 58" src="https://github.com/user-attachments/assets/79b20b4d-151b-4a1e-b442-03431bc150cd" />

## Related Issues: 

- https://github.com/wso2/product-is/issues/23526