### PR TITLE
Improve the condition to skip adding SSO authenticator for application being shared

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManagerImpl.java
@@ -187,8 +187,9 @@ public class OrgApplicationManagerImpl implements OrgApplicationManager {
             }
         }
 
-        // Skip adding the SSO if there are no sub orgs.
-        if (childOrganizations.isEmpty()) {
+        // Skip adding the SSO if there are no sub orgs except for console and my account.
+        if (childOrganizations.isEmpty() &&
+                !ApplicationMgtUtil.isConsoleOrMyAccount(rootApplication.getApplicationName())) {
             return;
         }
 


### PR DESCRIPTION
In IS-7.0.0, when an application is shared with the sub organizations, the application replica created will be created with the useMappedLocalSubject property as true. But from IS-7.1.0, this behavior has changed because of an improvement done regarding skipping the creation of SSO authenticator during the shared application creation. 

Even though this is an expected change, for Console and MyAccount applications, in order for a federated user to act as an administrator, the useMappedLocalSubject should be true. Hence, we have improved the condition to skip the SSO authenticator creation by additionally checking for the application as neither Console nor MyAccount.

Related issue:
- https://github.com/wso2/product-is/issues/23720