### PR TITLE
Fix RP initiated logout propagation for Sub Org IDPs

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/OrganizationSessionHandler.java
+++ b/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/OrganizationSessionHandler.java
@@ -82,6 +82,22 @@ public class OrganizationSessionHandler extends AbstractEventHandler {
 
             SessionContext sessionContext = (SessionContext) eventProperties.get(
                     IdentityEventConstants.EventProperty.SESSION_CONTEXT);
+            AuthenticationContext context = (AuthenticationContext) eventProperties.get(
+                    IdentityEventConstants.EventProperty.CONTEXT);
+
+            if (context != null && context.isLogoutRequest()) {
+                /*
+                This means that the event is triggered during the execution of logout handler. Since the logout handler
+                sends RP initiated logout request to the sub organization, sub org session termination is not needed to
+                handle with this handler.
+                 */
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Session termination event triggered during the execution of logout handler. " +
+                            "Hence, skipping the sub org session termination.");
+                }
+                return;
+            }
+
             Map<String, AuthenticatedIdPData> authenticatedIdPs = sessionContext.getAuthenticatedIdPs();
             if (authenticatedIdPs == null ||
                     !authenticatedIdPs.containsKey(FrameworkConstants.ORGANIZATION_LOGIN_IDP_NAME)) {


### PR DESCRIPTION
## Purpose
> Currently, when root organization session is terminated, sub org session is also terminated using a handler. But in the case of RP initiated logouts, it checks for the OIDC session before sending the logout request to logout handler. Due to this, sub organization logout flow does not pass through the framework. As a result, RP-initiated logout is not propagated to federated IDPs of the sub organization. This fix excludes the handling of sub org session termination using session handler for the logout requests.

Issue - https://github.com/wso2/product-is/issues/23924