### PR TITLE
Refactor organization resource resolver service

### DIFF
--- a/components/org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.organization.management</groupId>
         <artifactId>identity-organization-management</artifactId>
-        <version>1.4.132</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service/pom.xml
@@ -1,6 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+  ~ Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
   ~
   ~ WSO2 LLC. licenses this file to you under the Apache License,
   ~ Version 2.0 (the "License"); you may not use this file except
@@ -17,25 +17,23 @@
   ~ under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <parent>
         <groupId>org.wso2.carbon.identity.organization.management</groupId>
         <artifactId>identity-organization-management</artifactId>
-        <version>1.4.136-SNAPSHOT</version>
+        <version>1.4.132</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
-    <artifactId>org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service</artifactId>
-    <name>WSO2 - Organization Resource Hierarchy Traverse Service</name>
+    <artifactId>org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service</artifactId>
+    <name>WSO2 - Organization Application Resource Hierarchy Traverse Service</name>
     <packaging>bundle</packaging>
 
     <dependencies>
-        <dependency>
-            <groupId>org.wso2.carbon</groupId>
-            <artifactId>org.wso2.carbon.utils</artifactId>
-        </dependency>
         <dependency>
             <groupId>commons-collections.wso2</groupId>
             <artifactId>commons-collections</artifactId>
@@ -45,8 +43,16 @@
             <artifactId>pax-logging-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.mgt</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
             <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service</artifactId>
         </dependency>
 
         <!-- Test dependencies -->
@@ -72,11 +78,18 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.identity.framework</groupId>
-            <artifactId>org.wso2.carbon.identity.application.mgt</artifactId>
-            <scope>test</scope>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>20030203.000129</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
 
     <build>
         <plugins>
@@ -89,9 +102,7 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
                         <Private-Package>
-                            org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.constant,
-                            org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.internal,
-                            org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.util
+                            org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service.internal
                         </Private-Package>
                         <Import-Package>
                             org.apache.commons.lang; version="${org.apache.commons.lang.imp.pkg.version.range}",
@@ -101,20 +112,27 @@
                             org.osgi.framework; version="${osgi.framework.imp.pkg.version.range}",
                             org.osgi.service.component; version="${osgi.service.component.imp.pkg.version.range}",
 
+                            org.wso2.carbon.identity.application.mgt;
+                            version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.application.common;
+                            version="${carbon.identity.package.import.version.range}",
+
                             org.wso2.carbon.identity.organization.management.service;
                             version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
                             org.wso2.carbon.identity.organization.management.service.exception;
                             version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
                             org.wso2.carbon.identity.organization.management.service.util;
-                            version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}"
+                            version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
+
+                            org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service;
+                            version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.exception;
+                            version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.strategy;
+                            version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
                         </Import-Package>
                         <Export-Package>
-                            !org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.constant,
-                            !org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.internal,
-                            !org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.util,
-                            org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service,
-                            org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.exception,
-                            org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.strategy;
+                            org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service,
                             version="${project.version}"
                         </Export-Package>
                     </instructions>
@@ -146,12 +164,8 @@
                 <version>${jacoco.version}</version>
                 <configuration>
                     <excludes>
-                        <exclude>org/wso2/carbon/identity/organization/resource/hierarchy/traverse/service/constant/*.class</exclude>
-                        <exclude>org/wso2/carbon/identity/organization/resource/hierarchy/traverse/service/exception/*.class</exclude>
-                        <exclude>org/wso2/carbon/identity/organization/resource/hierarchy/traverse/service/internal/*.class</exclude>
-                        <exclude>org/wso2/carbon/identity/organization/resource/hierarchy/traverse/service/strategy/AggregationStrategy.class</exclude>
-                        <exclude>org/wso2/carbon/identity/organization/resource/hierarchy/traverse/service/strategy/MergeAllAggregationStrategy.class</exclude>
-                        <exclude>org/wso2/carbon/identity/organization/resource/hierarchy/traverse/service/OrgResourceResolverService.class</exclude>
+                        <exclude>org/wso2/carbon/identity/organization/application/resource/hierarchy/traverse/service/internal/*.class</exclude>
+                        <exclude>org/wso2/carbon/identity/organization/application/resource/hierarchy/traverse/service/OrgAppResourceResolverService.class</exclude>
                     </excludes>
                 </configuration>
                 <executions>

--- a/components/org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service/src/main/java/org/wso2/carbon/identity/organization/application/resource/hierarchy/traverse/service/OrgAppResourceResolverService.java
+++ b/components/org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service/src/main/java/org/wso2/carbon/identity/organization/application/resource/hierarchy/traverse/service/OrgAppResourceResolverService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -16,40 +16,40 @@
  * under the License.
  */
 
-package org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service;
+package org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service;
 
 import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.exception.OrgResourceHierarchyTraverseException;
 import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.strategy.AggregationStrategy;
 
 import java.util.Optional;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 
 /**
- * Provides a service interface to retrieve resources from an organization's hierarchy.
- * Supports traversal of both organization and application hierarchies using customizable
- * resource retrieval and aggregation strategies.
- * <p>
- * The service is designed for extensibility, allowing clients to define their own retrieval logic
- * and aggregation mechanisms via functional interfaces and strategy patterns.
+ * Service interface for resolving resources from the organization and application hierarchy.
+ * This interface provides methods to retrieve resources by traversing the hierarchy of a given
+ * organization and application.
  */
-public interface OrgResourceResolverService {
+public interface OrgAppResourceResolverService {
 
     /**
-     * Retrieves resources by traversing the hierarchy of a given organization.
+     * Retrieves resources by traversing the hierarchy of a given organization and application.
      *
      * @param organizationId      The unique identifier of the organization.
-     * @param resourceRetriever   A function that defines how to fetch a resource for a given organization ID.
-     *                            The function must return an {@link Optional<T>} containing the resource if found,
+     * @param applicationId       The unique identifier of the application within the organization.
+     * @param resourceRetriever   A bi-function that defines how to fetch a resource based on the
+     *                            organization and application IDs. The function must return an
+     *                            {@link Optional <T>} containing the resource if found,
      *                            or an empty {@link Optional<T>} if not.
      * @param aggregationStrategy A strategy defining how to aggregate resources retrieved from
      *                            different levels of the hierarchy.
      * @param <T>                 The type of the resource being retrieved and aggregated.
-     * @return An aggregated resource of type <T> obtained from the organization hierarchy.
+     * @return An aggregated resource of type <T> obtained from the organization and application hierarchy.
      * @throws OrgResourceHierarchyTraverseException If any errors occur during resource retrieval
      *                                               or aggregation.
      */
-    <T> T getResourcesFromOrgHierarchy(String organizationId,
-                                       Function<String, Optional<T>> resourceRetriever,
+    <T> T getResourcesFromOrgHierarchy(String organizationId, String applicationId,
+                                       BiFunction<String, String, Optional<T>> resourceRetriever,
                                        AggregationStrategy<T> aggregationStrategy)
             throws OrgResourceHierarchyTraverseException;
+
 }

--- a/components/org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service/src/main/java/org/wso2/carbon/identity/organization/application/resource/hierarchy/traverse/service/OrgAppResourceResolverServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service/src/main/java/org/wso2/carbon/identity/organization/application/resource/hierarchy/traverse/service/OrgAppResourceResolverServiceImpl.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service.internal.OrgAppResourceHierarchyTraverseServiceDataHolder;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementServerException;
+import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.constant.OrgResourceHierarchyTraverseConstants;
+import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.exception.OrgResourceHierarchyTraverseException;
+import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.exception.OrgResourceHierarchyTraverseServerException;
+import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.strategy.AggregationStrategy;
+import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.util.OrgResourceHierarchyTraverseUtil;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+/**
+ * Implementation of the OrgAppResourceResolverService interface.
+ * This class provides methods to resolve resources from the organization and application hierarchy.
+ */
+public class OrgAppResourceResolverServiceImpl implements OrgAppResourceResolverService {
+
+    /**
+     * Retrieves resources by traversing the hierarchy of a given organization and application.
+     *
+     * @param organizationId      The unique identifier of the organization.
+     * @param applicationId       The unique identifier of the application within the organization.
+     * @param resourceRetriever   A bi-function that defines how to fetch a resource based on the
+     *                            organization and application IDs. The function must return an
+     *                            {@link Optional <T>} containing the resource if found,
+     *                            or an empty {@link Optional<T>} if not.
+     * @param aggregationStrategy A strategy defining how to aggregate resources retrieved from
+     *                            different levels of the hierarchy.
+     * @param <T>                 The type of the resource being retrieved and aggregated.
+     * @return An aggregated resource of type <T> obtained from the organization and application hierarchy.
+     * @throws OrgResourceHierarchyTraverseException If any errors occur during resource retrieval
+     *                                               or aggregation.
+     */
+    @Override
+    public <T> T getResourcesFromOrgHierarchy(String organizationId, String applicationId,
+                                              BiFunction<String, String, Optional<T>> resourceRetriever,
+                                              AggregationStrategy<T> aggregationStrategy)
+            throws OrgResourceHierarchyTraverseException {
+
+        try {
+            List<String> organizationIds = getAncestorOrganizationsIds(organizationId);
+
+            ApplicationManagementService applicationManagementService =
+                    OrgAppResourceHierarchyTraverseServiceDataHolder.getInstance().getApplicationManagementService();
+            Map<String, String> ancestorAppIds = Collections.emptyMap();
+            if (applicationId != null) {
+                ancestorAppIds = applicationManagementService.getAncestorAppIds(applicationId, organizationId);
+            }
+
+            return aggregationStrategy.aggregate(organizationIds, ancestorAppIds, resourceRetriever);
+        } catch (IdentityApplicationManagementException e) {
+            throw OrgResourceHierarchyTraverseUtil.handleServerException(
+                    OrgResourceHierarchyTraverseConstants.ErrorMessages
+                            .ERROR_CODE_SERVER_ERROR_WHILE_RESOLVING_ANCESTOR_APPLICATIONS,
+                    e, organizationId, applicationId);
+        }
+    }
+
+    private List<String> getAncestorOrganizationsIds(String organizationId)
+            throws OrgResourceHierarchyTraverseServerException {
+
+        if (StringUtils.isBlank(organizationId)) {
+            throw OrgResourceHierarchyTraverseUtil.handleServerException(
+                    OrgResourceHierarchyTraverseConstants.ErrorMessages.ERROR_CODE_EMPTY_ORGANIZATION_ID);
+        }
+
+        try {
+            OrganizationManager organizationManager = OrgAppResourceHierarchyTraverseServiceDataHolder.getInstance()
+                    .getOrganizationManager();
+            List<String> organizationIds = organizationManager.getAncestorOrganizationIds(organizationId);
+            if (CollectionUtils.isEmpty(organizationIds)) {
+                throw OrgResourceHierarchyTraverseUtil.handleServerException(OrgResourceHierarchyTraverseConstants
+                                .ErrorMessages.ERROR_CODE_INVALID_ANCESTOR_ORGANIZATION_ID_LIST,
+                        organizationId);
+            }
+            return organizationIds;
+        } catch (OrganizationManagementServerException e) {
+            throw OrgResourceHierarchyTraverseUtil.handleServerException(
+                    OrgResourceHierarchyTraverseConstants.ErrorMessages
+                            .ERROR_CODE_SERVER_ERROR_WHILE_RESOLVING_ANCESTOR_ORGANIZATIONS, e, organizationId);
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service/src/main/java/org/wso2/carbon/identity/organization/application/resource/hierarchy/traverse/service/internal/OrgAppResourceHierarchyTraverseServiceComponent.java
+++ b/components/org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service/src/main/java/org/wso2/carbon/identity/organization/application/resource/hierarchy/traverse/service/internal/OrgAppResourceHierarchyTraverseServiceComponent.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service.internal;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service.OrgAppResourceResolverService;
+import org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service.OrgAppResourceResolverServiceImpl;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+
+/**
+ * OSGi component responsible for managing the activation and deactivation of the organization application resource
+ * hierarchy traverse service.
+ * <p>
+ * It manages dynamic references to necessary services required by {@link OrgAppResourceResolverService} as well.
+ */
+@Component(
+        name = "org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service",
+        immediate = true)
+public class OrgAppResourceHierarchyTraverseServiceComponent {
+
+    private static final Log LOG = LogFactory.getLog(OrgAppResourceHierarchyTraverseServiceComponent.class);
+
+    /**
+     * Activates the OSGi component.
+     * This method is called when the component is activated in the OSGi environment.
+     */
+    @Activate
+    protected void activate(ComponentContext context) {
+
+        try {
+            BundleContext bundleContext = context.getBundleContext();
+            bundleContext.registerService(OrgAppResourceResolverService.class.getName(),
+                    new OrgAppResourceResolverServiceImpl(), null);
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("OrgAppResourceResolverService bundle is activated successfully.");
+            }
+        } catch (Exception e) {
+            LOG.error("Error while activating OrgAppResourceResolverService bundle.", e);
+        }
+    }
+
+    /**
+     * Deactivates the OSGi component.
+     * This method is called when the component is deactivated in the OSGi environment.
+     */
+    @Deactivate
+    protected void deactivate() {
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("OrgAppResourceResolverService bundle is deactivated successfully.");
+        }
+    }
+
+    /**
+     * Set the OrganizationManager service.
+     *
+     * @param organizationManager OrganizationManager instance.
+     */
+    @Reference(
+            name = "org.wso2.carbon.identity.organization.management.service",
+            service = OrganizationManager.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetOrganizationManager")
+    protected void setOrganizationManager(OrganizationManager organizationManager) {
+
+        OrgAppResourceHierarchyTraverseServiceDataHolder.getInstance()
+                .setOrganizationManager(organizationManager);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("OrganizationManager set in OrgAppResourceHierarchyTraverseServiceComponent bundle.");
+        }
+    }
+
+    /**
+     * Unset the OrganizationManager service.
+     *
+     * @param organizationManager OrganizationManager instance.
+     */
+    protected void unsetOrganizationManager(OrganizationManager organizationManager) {
+
+        OrgAppResourceHierarchyTraverseServiceDataHolder.getInstance()
+                .setOrganizationManager(null);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("OrganizationManager unset in OrgAppResourceHierarchyTraverseServiceComponent bundle.");
+        }
+    }
+
+    /**
+     * Set the ApplicationManagementService service.
+     *
+     * @param applicationManagementService ApplicationManagementService instance.
+     */
+    @Reference(
+            name = "org.wso2.carbon.identity.application.mgt",
+            service = ApplicationManagementService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetApplicationManagementService")
+    protected void setApplicationManagementService(ApplicationManagementService applicationManagementService) {
+
+        OrgAppResourceHierarchyTraverseServiceDataHolder.getInstance()
+                .setApplicationManagementService(applicationManagementService);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("ApplicationManagementService set in OrgAppResourceHierarchyTraverseServiceComponent bundle.");
+        }
+    }
+
+    /**
+     * Unset the ApplicationManagementService service.
+     *
+     * @param applicationManagementService ApplicationManagementService instance.
+     */
+    protected void unsetApplicationManagementService(ApplicationManagementService applicationManagementService) {
+
+        OrgAppResourceHierarchyTraverseServiceDataHolder.getInstance()
+                .setApplicationManagementService(null);
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("ApplicationManagementService unset in OrgAppResourceHierarchyTraverseServiceComponent bundle.");
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service/src/main/java/org/wso2/carbon/identity/organization/application/resource/hierarchy/traverse/service/internal/OrgAppResourceHierarchyTraverseServiceDataHolder.java
+++ b/components/org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service/src/main/java/org/wso2/carbon/identity/organization/application/resource/hierarchy/traverse/service/internal/OrgAppResourceHierarchyTraverseServiceDataHolder.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service.internal;
+
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+
+/**
+ * Singleton class that serves as a centralized data holder for key service instances used in the organization
+ * application resource hierarchy traversal process.
+ */
+public class OrgAppResourceHierarchyTraverseServiceDataHolder {
+
+    private static final OrgAppResourceHierarchyTraverseServiceDataHolder INSTANCE =
+            new OrgAppResourceHierarchyTraverseServiceDataHolder();
+
+    private ApplicationManagementService applicationManagementService;
+    private OrganizationManager organizationManager;
+
+    private OrgAppResourceHierarchyTraverseServiceDataHolder() {
+    }
+
+    /**
+     * Retrieves the singleton instance of the OrgAppResourceHierarchyTraverseServiceDataHolder class.
+     *
+     * @return The singleton instance of OrgAppResourceHierarchyTraverseServiceDataHolder.
+     */
+    public static OrgAppResourceHierarchyTraverseServiceDataHolder getInstance() {
+
+        return INSTANCE;
+    }
+
+    /**
+     * Retrieves the current instance of the ApplicationManagementService.
+     *
+     * @return The current ApplicationManagementService instance responsible for managing applications.
+     */
+    public ApplicationManagementService getApplicationManagementService() {
+
+        return applicationManagementService;
+    }
+
+    /**
+     * Sets the ApplicationManagementService instance.
+     *
+     * @param applicationManagementService The ApplicationManagementService instance to be assigned.
+     */
+    public void setApplicationManagementService(ApplicationManagementService applicationManagementService) {
+
+        this.applicationManagementService = applicationManagementService;
+    }
+
+    /**
+     * Retrieves the current instance of the OrganizationManager.
+     *
+     * @return The current OrganizationManager instance that manages organizational data.
+     */
+    public OrganizationManager getOrganizationManager() {
+
+        return organizationManager;
+    }
+
+    /**
+     * Sets the OrganizationManager instance.
+     *
+     * @param organizationManager The OrganizationManager instance to be assigned.
+     */
+    public void setOrganizationManager(OrganizationManager organizationManager) {
+
+        this.organizationManager = organizationManager;
+    }
+}

--- a/components/org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service/src/test/java/org/wso2/carbon/identity/organization/application/resource/hierarchy/traverse/service/OrgAppResourceResolverServiceTest.java
+++ b/components/org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service/src/test/java/org/wso2/carbon/identity/organization/application/resource/hierarchy/traverse/service/OrgAppResourceResolverServiceTest.java
@@ -1,0 +1,506 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service;
+
+import org.mockito.Mock;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service.internal.OrgAppResourceHierarchyTraverseServiceDataHolder;
+import org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service.mock.resource.impl.MockResourceManagementService;
+import org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service.mock.resource.impl.model.MockResource;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementServerException;
+import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.exception.OrgResourceHierarchyTraverseException;
+import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.exception.OrgResourceHierarchyTraverseServerException;
+import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.internal.OrgResourceHierarchyTraverseServiceDataHolder;
+import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.strategy.AggregationStrategy;
+import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.strategy.FirstFoundAggregationStrategy;
+import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.strategy.MergeAllAggregationStrategy;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertThrows;
+
+/**
+ * Unit tests for the OrgAppResourceResolverService.
+ */
+public class OrgAppResourceResolverServiceTest {
+
+    private static final String ROOT_ORG_ID = "10084a8d-113f-4211-a0d5-efe36b082211";
+    private static final String ROOT_APP_ID = "1ee981ab-64e7-435c-ab91-e8d1e0a13b2c";
+    private static final String L1_ORG_ID = "93d996f9-a5ba-4275-a52b-adaad9eba869";
+    private static final String L1_APP_ID = "619d2cb1-174d-4d38-af3b-99c532dddb00";
+    private static final String L2_ORG_ID = "30b701c6-e309-4241-b047-0c299c45d1a0";
+    private static final String L2_APP_ID = "d04d48db-8c5a-437a-9458-4352b84db621";
+    private static final String INVALID_ORG_ID = "invalid-org-id";
+    private static final String INVALID_APP_ID = "invalid-app-id";
+
+    private OrgAppResourceResolverService orgAppResourceResolverService;
+    private MockResourceManagementService mockResourceManagementService;
+    private AggregationStrategy<MockResource> firstFoundAggregationStrategy;
+    private AggregationStrategy<MockResource> mergeAllAggregationStrategy;
+
+    @Mock
+    OrganizationManager organizationManager;
+
+    @Mock
+    ApplicationManagementService applicationManagementService;
+
+    /**
+     * Initializes test data and mock services before the test class is run.
+     * This method sets up necessary services and aggregation strategies required for the tests.
+     */
+    @BeforeClass
+    public void init() {
+
+        // Open mock objects for the current test instance.
+        openMocks(this);
+
+        // Set the OrganizationManager and ApplicationManagementService to the data holder for use in tests
+        OrgResourceHierarchyTraverseServiceDataHolder.getInstance().setOrganizationManager(organizationManager);
+        OrgAppResourceHierarchyTraverseServiceDataHolder.getInstance().setOrganizationManager(organizationManager);
+        OrgAppResourceHierarchyTraverseServiceDataHolder.getInstance()
+                .setApplicationManagementService(applicationManagementService);
+
+        // Initialize the aggregation strategies with the appropriate strategy types.
+        firstFoundAggregationStrategy = new FirstFoundAggregationStrategy<>();
+        mergeAllAggregationStrategy = new MergeAllAggregationStrategy<>(this::resourceMerger);
+    }
+
+    /**
+     * Sets up mocks for individual test cases by initializing mock services and resource management.
+     * This method runs before each test method to ensure the environment is ready for testing specific scenarios.
+     */
+    @BeforeMethod
+    public void setUp() throws Exception {
+
+        // Mock responses for the organization manager with different ancestor organization chains.
+        mockAncestorOrganizationRetrieval(Arrays.asList(L2_ORG_ID, L1_ORG_ID, ROOT_ORG_ID));
+        mockAncestorOrganizationRetrieval(Arrays.asList(L1_ORG_ID, ROOT_ORG_ID));
+        mockAncestorOrganizationRetrieval(Collections.singletonList(ROOT_ORG_ID));
+
+        // Mock responses for the application management service with corresponding application ancestor data.
+        mockAncestorApplicationRetrieval(Arrays.asList(L2_ORG_ID, L1_ORG_ID, ROOT_ORG_ID),
+                Arrays.asList(L2_APP_ID, L1_APP_ID, ROOT_APP_ID));
+        mockAncestorApplicationRetrieval(Arrays.asList(L1_ORG_ID, ROOT_ORG_ID),
+                Arrays.asList(L1_APP_ID, ROOT_APP_ID));
+        mockAncestorApplicationRetrieval(Collections.singletonList(ROOT_ORG_ID),
+                Collections.singletonList(ROOT_APP_ID));
+
+        // Initialize the mock resource management service used in tests.
+        mockResourceManagementService = new MockResourceManagementService();
+
+        // Instantiate the OrgAppResourceResolverService for testing.
+        orgAppResourceResolverService = new OrgAppResourceResolverServiceImpl();
+    }
+
+    /**
+     * Resets mock services after each test method to ensure a clean state for subsequent tests.
+     */
+    @AfterMethod
+    public void tearDown() {
+
+        // Reset the mock services to their default state after each test.
+        reset(organizationManager);
+        reset(applicationManagementService);
+    }
+
+    @DataProvider(name = "AggregationStrategyDataProvider")
+    public Object[][] provideAggregationStrategies() {
+
+        return new Object[][]{
+                {firstFoundAggregationStrategy},
+                {mergeAllAggregationStrategy}
+        };
+    }
+
+    /**
+     * Tests the behavior of the OrgAppResourceResolverService when no application-level or organization-level resources
+     * are available in the hierarchy.
+     * <p>
+     * This test ensures that when no resources are available at the organization or application levels,
+     * the resolver correctly returns null.
+     *
+     * @param aggregationStrategy The aggregation strategy used to resolve resources.
+     */
+    @Test(dataProvider = "AggregationStrategyDataProvider")
+    public void testGetAppLevelResourcesFromOrgHierarchyWhenNoResourceAvailable(
+            AggregationStrategy<MockResource> aggregationStrategy) throws Exception {
+
+        MockResource resolvedRootAppResource =
+                invokeAppLevelResourceResolver(aggregationStrategy, ROOT_ORG_ID, ROOT_APP_ID);
+        assertNull(resolvedRootAppResource);
+
+        MockResource resolvedL1AppResource = invokeAppLevelResourceResolver(aggregationStrategy, L1_ORG_ID, L1_APP_ID);
+        assertNull(resolvedL1AppResource);
+
+        MockResource resolvedL2AppResource = invokeAppLevelResourceResolver(aggregationStrategy, L2_ORG_ID, L2_APP_ID);
+        assertNull(resolvedL2AppResource);
+    }
+
+    /**
+     * Tests the behavior of the OrgAppResourceResolverService when resources are available at both root organization
+     * and/ or root application levels in the organization hierarchy.
+     * <p>
+     * This test verifies that when resources are available for the root level, they are correctly resolved at the
+     * organization and application levels across all organization levels (root, L1, and L2).
+     *
+     * @param aggregationStrategy The aggregation strategy used to resolve resources at different levels.
+     */
+    @Test(dataProvider = "AggregationStrategyDataProvider")
+    public void testGetAppLevelResourcesFromOrgHierarchyWhenRootResourcesAvailable(
+            AggregationStrategy<MockResource> aggregationStrategy) throws Exception {
+
+        // Add org-level resource for root organization into the mock resource management service.
+        List<MockResource> createdOrgResource = addOrgResources(Collections.singletonList(ROOT_ORG_ID));
+
+        MockResource resolvedRootAppResource =
+                invokeAppLevelResourceResolver(aggregationStrategy, ROOT_ORG_ID, ROOT_APP_ID);
+        assertResolvedResponse(resolvedRootAppResource, createdOrgResource.get(0));
+
+        MockResource resolvedL1AppResource = invokeAppLevelResourceResolver(aggregationStrategy, L1_ORG_ID, L1_APP_ID);
+        assertResolvedResponse(resolvedL1AppResource, createdOrgResource.get(0));
+
+        MockResource resolvedL2AppResource = invokeAppLevelResourceResolver(aggregationStrategy, L2_ORG_ID, L2_APP_ID);
+        assertResolvedResponse(resolvedL2AppResource, createdOrgResource.get(0));
+
+        // Add app-level resource for root organization into the mock resource management service.
+        List<MockResource> createdAppResource = addAppResources(Collections.singletonList(ROOT_ORG_ID),
+                Collections.singletonList(ROOT_APP_ID));
+
+        resolvedRootAppResource =
+                invokeAppLevelResourceResolver(aggregationStrategy, ROOT_ORG_ID, ROOT_APP_ID);
+        assertResolvedResponse(resolvedRootAppResource, createdAppResource.get(0));
+
+        resolvedL1AppResource = invokeAppLevelResourceResolver(aggregationStrategy, L1_ORG_ID, L1_APP_ID);
+        assertResolvedResponse(resolvedL1AppResource, createdAppResource.get(0));
+
+        resolvedL2AppResource = invokeAppLevelResourceResolver(aggregationStrategy, L2_ORG_ID, L2_APP_ID);
+        assertResolvedResponse(resolvedL2AppResource, createdAppResource.get(0));
+    }
+
+    /**
+     * Tests the behavior of the OrgAppResourceResolverService when organization-level and/ or
+     * application-level resources
+     * are available for both root and L1 organizations in the hierarchy.
+     * <p>
+     * This test ensures when resources are available for the L1 level, they are correctly resolved at the
+     * organization and application levels across both organization levels, L1, and L2. At the root level,
+     * its own resource should be returned.
+     *
+     * @param aggregationStrategy The aggregation strategy used to resolve resources at different levels.
+     */
+    @Test(dataProvider = "AggregationStrategyDataProvider")
+    public void testGetAppLevelResourcesFromOrgHierarchyWhenL1ResourcesAvailable(
+            AggregationStrategy<MockResource> aggregationStrategy) throws Exception {
+
+        // Add org-level resources for L1 and root organizations into the mock resource management service.
+        List<MockResource> createdOrgResources = addOrgResources(Arrays.asList(ROOT_ORG_ID, L1_ORG_ID));
+        // Add app-level resources for root organization into the mock resource management service.
+        List<MockResource> createdAppResources = addAppResources(Collections.singletonList(ROOT_ORG_ID),
+                Collections.singletonList(ROOT_APP_ID));
+
+        MockResource resolvedRootAppResource =
+                invokeAppLevelResourceResolver(aggregationStrategy, ROOT_ORG_ID, ROOT_APP_ID);
+        assertResolvedResponse(resolvedRootAppResource, createdAppResources.get(0));
+
+        MockResource resolvedL1AppResource = invokeAppLevelResourceResolver(aggregationStrategy, L1_ORG_ID, L1_APP_ID);
+        assertResolvedResponse(resolvedL1AppResource, createdOrgResources.get(1));
+
+        MockResource resolvedL2AppResource = invokeAppLevelResourceResolver(aggregationStrategy, L2_ORG_ID, L2_APP_ID);
+        assertResolvedResponse(resolvedL2AppResource, createdOrgResources.get(1));
+
+        // Add app-level resources for L1 organization into the mock resource management service.
+        createdAppResources.addAll(addAppResources(Collections.singletonList(L1_ORG_ID),
+                Collections.singletonList(L1_APP_ID)));
+
+        resolvedRootAppResource =
+                invokeAppLevelResourceResolver(aggregationStrategy, ROOT_ORG_ID, ROOT_APP_ID);
+        assertResolvedResponse(resolvedRootAppResource, createdAppResources.get(0));
+
+        resolvedL1AppResource = invokeAppLevelResourceResolver(aggregationStrategy, L1_ORG_ID, L1_APP_ID);
+        assertResolvedResponse(resolvedL1AppResource, createdAppResources.get(1));
+
+        resolvedL2AppResource = invokeAppLevelResourceResolver(aggregationStrategy, L2_ORG_ID, L2_APP_ID);
+        assertResolvedResponse(resolvedL2AppResource, createdAppResources.get(1));
+    }
+
+    /**
+     * Tests the behavior of the OrgAppResourceResolverService when organization-level and/ or
+     * application-level resources
+     * are available for all organization levels in the hierarchy.
+     * <p>
+     * This test ensures that when a resource is available at the L2 level, it is correctly resolved for the
+     * L2 organization based on the provided aggregation strategy. At the root and L1 level, their own resources
+     * should be returned.
+     *
+     * @param aggregationStrategy The aggregation strategy used to resolve resources at different levels.
+     */
+    @Test(dataProvider = "AggregationStrategyDataProvider")
+    public void testGetAppLevelResourcesFromOrgHierarchyWhenL2ResourcesAvailable(
+            AggregationStrategy<MockResource> aggregationStrategy) throws Exception {
+
+        // Add org-level resources for L2, L1 and root organizations into the mock resource management service.
+        List<MockResource> createdOrgResources = addOrgResources(Arrays.asList(ROOT_ORG_ID, L1_ORG_ID, L2_ORG_ID));
+        // Add app-level resources for L1 and root organizations into the mock resource management service.
+        List<MockResource> createdAppResources = addAppResources(Arrays.asList(ROOT_ORG_ID, L1_ORG_ID),
+                Arrays.asList(ROOT_APP_ID, L1_APP_ID));
+
+        MockResource resolvedRootAppResource =
+                invokeAppLevelResourceResolver(aggregationStrategy, ROOT_ORG_ID, ROOT_APP_ID);
+        assertResolvedResponse(resolvedRootAppResource, createdAppResources.get(0));
+
+        MockResource resolvedL1AppResource = invokeAppLevelResourceResolver(aggregationStrategy, L1_ORG_ID, L1_APP_ID);
+        assertResolvedResponse(resolvedL1AppResource, createdAppResources.get(1));
+
+        MockResource resolvedL2AppResource = invokeAppLevelResourceResolver(aggregationStrategy, L2_ORG_ID, L2_APP_ID);
+        assertResolvedResponse(resolvedL2AppResource, createdOrgResources.get(2));
+
+        // Add app-level resources for L2 organization into the mock resource management service.
+        createdAppResources.addAll(addAppResources(Collections.singletonList(L2_ORG_ID),
+                Collections.singletonList(L2_APP_ID)));
+
+        resolvedRootAppResource =
+                invokeAppLevelResourceResolver(aggregationStrategy, ROOT_ORG_ID, ROOT_APP_ID);
+        assertResolvedResponse(resolvedRootAppResource, createdAppResources.get(0));
+
+        resolvedL1AppResource = invokeAppLevelResourceResolver(aggregationStrategy, L1_ORG_ID, L1_APP_ID);
+        assertResolvedResponse(resolvedL1AppResource, createdAppResources.get(1));
+
+        resolvedL2AppResource = invokeAppLevelResourceResolver(aggregationStrategy, L2_ORG_ID, L2_APP_ID);
+        assertResolvedResponse(resolvedL2AppResource, createdAppResources.get(2));
+    }
+
+    @DataProvider(name = "provideAggregationStrategiesForAppLevelResolverWithInvalidInput")
+    public Object[][] provideAggregationStrategiesForAppLevelResolverWithInvalidInput() {
+
+        List<String> invalidOrgIds = Arrays.asList(null, "", INVALID_ORG_ID);
+        List<String> invalidAppIds = Arrays.asList(null, "", INVALID_APP_ID);
+
+        return new Object[][]{
+                {firstFoundAggregationStrategy, invalidOrgIds, invalidAppIds},
+                {mergeAllAggregationStrategy, invalidOrgIds, invalidAppIds},
+        };
+    }
+
+    /**
+     * Tests the behavior of the OrgAppResourceResolverService when provided with invalid
+     * organization and application IDs.
+     * <p>
+     * This test verifies that the resolver correctly handles invalid input combinations by returning null,
+     * ensuring robustness and appropriate error handling in edge cases. The test covers scenarios where:
+     * - The organization ID is invalid.
+     * - The application ID is invalid.
+     * - Both the organization and application IDs are invalid.
+     *
+     * @param aggregationStrategy The aggregation strategy used to resolve resources across the hierarchy.
+     * @param invalidOrgIds       A list of invalid organization IDs to test the resolver's behavior.
+     * @param invalidAppIds       A list of invalid application IDs to test the resolver's behavior.
+     * @throws Exception If an error occurs during resolution.
+     */
+    @Test(dataProvider = "provideAggregationStrategiesForAppLevelResolverWithInvalidInput")
+    public void testGetAppLevelResourcesFromOrgHierarchyForInvalidInput(
+            AggregationStrategy<MockResource> aggregationStrategy, List<String> invalidOrgIds,
+            List<String> invalidAppIds) throws Exception {
+
+        for (String invalidOrgId : invalidOrgIds) {
+            for (String invalidAppId : invalidAppIds) {
+                assertThrows(OrgResourceHierarchyTraverseServerException.class,
+                        () -> invokeAppLevelResourceResolver(aggregationStrategy, invalidOrgId, invalidAppId));
+            }
+        }
+    }
+
+    /**
+     * Tests the behavior of the OrgAppResourceResolverService when server-side errors occur during
+     * application hierarchy traversal within an organization.
+     * <p>
+     * This test simulates server-side exceptions thrown by the following:
+     * - The `applicationManagementService` while retrieving ancestor application IDs.
+     * - The `organizationManager` while retrieving ancestor organization IDs.
+     *
+     * @param aggregationStrategy The aggregation strategy used for resolving resources.
+     * @throws Exception If an unexpected error occurs.
+     */
+    @Test(dataProvider = "AggregationStrategyDataProvider")
+    public void testGetAppLevelResourcesFromOrgHierarchyWhenServerErrorOccurs(
+            AggregationStrategy<MockResource> aggregationStrategy) throws Exception {
+
+        when(applicationManagementService.getAncestorAppIds(anyString(), anyString()))
+                .thenThrow(IdentityApplicationManagementException.class);
+
+        assertThrows(OrgResourceHierarchyTraverseServerException.class,
+                () -> invokeAppLevelResourceResolver(aggregationStrategy, ROOT_ORG_ID, ROOT_APP_ID));
+        assertThrows(OrgResourceHierarchyTraverseServerException.class,
+                () -> invokeAppLevelResourceResolver(aggregationStrategy, L1_ORG_ID, L1_APP_ID));
+        assertThrows(OrgResourceHierarchyTraverseServerException.class,
+                () -> invokeAppLevelResourceResolver(aggregationStrategy, L2_ORG_ID, L2_APP_ID));
+
+        when(organizationManager.getAncestorOrganizationIds(anyString()))
+                .thenThrow(OrganizationManagementServerException.class);
+
+        assertThrows(OrgResourceHierarchyTraverseServerException.class,
+                () -> invokeAppLevelResourceResolver(aggregationStrategy, ROOT_ORG_ID, ROOT_APP_ID));
+        assertThrows(OrgResourceHierarchyTraverseServerException.class,
+                () -> invokeAppLevelResourceResolver(aggregationStrategy, L1_ORG_ID, L1_APP_ID));
+        assertThrows(OrgResourceHierarchyTraverseServerException.class,
+                () -> invokeAppLevelResourceResolver(aggregationStrategy, L2_ORG_ID, L2_APP_ID));
+    }
+
+    /**
+     * Mock the retrieval of ancestor organization IDs.
+     *
+     * @param orgIds Organization IDs.
+     * @throws OrganizationManagementException If an error occurs while retrieving ancestor organization IDs.
+     */
+    private void mockAncestorOrganizationRetrieval(List<String> orgIds)
+            throws OrganizationManagementException {
+
+        List<String> ancestorOrganizationIds = new ArrayList<>(orgIds);
+        when(organizationManager.getAncestorOrganizationIds(orgIds.get(0))).thenReturn(ancestorOrganizationIds);
+    }
+
+    /**
+     * Mock the retrieval of ancestor application IDs.
+     *
+     * @param orgIds Organization IDs.
+     * @param appIds Application IDs.
+     * @throws IdentityApplicationManagementException If an error occurs while retrieving ancestor application IDs.
+     */
+    private void mockAncestorApplicationRetrieval(List<String> orgIds, List<String> appIds)
+            throws IdentityApplicationManagementException {
+
+        Map<String, String> ancestorAppIds = new HashMap<>();
+        for (String orgId : orgIds) {
+            ancestorAppIds.put(orgId, appIds.get(orgIds.indexOf(orgId)));
+        }
+
+        when(applicationManagementService.getAncestorAppIds(appIds.get(0), orgIds.get(0))).thenReturn(ancestorAppIds);
+    }
+
+    /**
+     * Add organization resources to the mock resource management service.
+     *
+     * @param orgIds Organization IDs.
+     * @return List of created organization resources.
+     */
+    private List<MockResource> addOrgResources(List<String> orgIds) {
+
+        List<MockResource> createdOrgResources = new ArrayList<>();
+        int resourceId = 1;
+        for (String orgId : orgIds) {
+            MockResource orgResource = new MockResource(resourceId++, orgId + "Org Resource", orgId);
+            mockResourceManagementService.addOrgResource(orgResource);
+            createdOrgResources.add(orgResource);
+        }
+        return createdOrgResources;
+    }
+
+    /**
+     * Add application resources to the mock resource management service.
+     *
+     * @param orgIds Organization IDs.
+     * @param appIds Application IDs.
+     * @return List of created application resources.
+     */
+    private List<MockResource> addAppResources(List<String> orgIds, List<String> appIds) {
+
+        List<MockResource> createdAppResources = new ArrayList<>();
+        int resourceId = 1;
+        for (String orgId : orgIds) {
+            MockResource appResource =
+                    new MockResource(resourceId++, orgId + "App Resource", orgId,
+                            appIds.get(orgIds.indexOf(orgId)));
+            mockResourceManagementService.addAppResource(appResource);
+            createdAppResources.add(appResource);
+        }
+        return createdAppResources;
+    }
+
+    /**
+     * Resource resolver function used for testing MergeAllAggregationStrategy.
+     *
+     * @param aggregatedResource Aggregated resource.
+     * @param newResource        New resource.
+     * @return Merged resource.
+     */
+    private MockResource resourceMerger(MockResource aggregatedResource, MockResource newResource) {
+
+        if (aggregatedResource == null) {
+            return newResource;
+        }
+        return aggregatedResource;
+    }
+
+    /**
+     * Invoke the application level resource resolver.
+     *
+     * @param aggregationStrategy Aggregation strategy.
+     * @param organizationId      Organization ID.
+     * @param applicationId       Application ID.
+     * @return Resolved resource.
+     * @throws OrgResourceHierarchyTraverseException If an error occurs while resolving the resource.
+     */
+    private MockResource invokeAppLevelResourceResolver(AggregationStrategy<MockResource> aggregationStrategy,
+                                                        String organizationId, String applicationId)
+            throws OrgResourceHierarchyTraverseException {
+
+        return orgAppResourceResolverService.getResourcesFromOrgHierarchy(
+                organizationId,
+                applicationId,
+                (orgId, appId) -> {
+                    MockResource resource = mockResourceManagementService.getAppResource(orgId, appId);
+                    return Optional.ofNullable(resource);
+                },
+                aggregationStrategy);
+    }
+
+    /**
+     * Assert the resolved resource with the actual resource.
+     *
+     * @param resolvedResource Resolved resource.
+     * @param actualResource   Actual resource.
+     */
+    private void assertResolvedResponse(MockResource resolvedResource, MockResource actualResource) {
+
+        assertNotNull(resolvedResource);
+        assertEquals(resolvedResource.getId(), actualResource.getId());
+        assertEquals(resolvedResource.getResourceName(), actualResource.getResourceName());
+        assertEquals(resolvedResource.getOrgId(), actualResource.getOrgId());
+    }
+}

--- a/components/org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service/src/test/java/org/wso2/carbon/identity/organization/application/resource/hierarchy/traverse/service/mock/resource/impl/MockResourceManagementService.java
+++ b/components/org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service/src/test/java/org/wso2/carbon/identity/organization/application/resource/hierarchy/traverse/service/mock/resource/impl/MockResourceManagementService.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service.mock.resource.impl;
+
+import org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service.mock.resource.impl.model.MockResource;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Service for managing mocked resources at application level.
+ * <p>
+ * This class maintains mappings for application-level
+ * resources, providing methods to add and retrieve resources. These mappings simulate a database,
+ * offering a simple in-memory representation for resource storage and retrieval operations.
+ * <p>
+ * This implementation is intended for testing or mocking purposes and simulates a resource management system.
+ */
+public class MockResourceManagementService {
+
+    private final Map<String, MockResource> orgResources;
+    private final Map<String, MockResource> appResources;
+
+    /**
+     * Initializes the mock resource management service with empty resource mappings
+     * for both organization-level and application-level resources.
+     */
+    public MockResourceManagementService() {
+
+        this.orgResources = new HashMap<>();
+        this.appResources = new HashMap<>();
+    }
+
+    /**
+     * Adds an organization-level resource to the management service.
+     *
+     * @param orgResource The resource to be added. The resource's organization ID
+     *                    ({@link MockResource#getOrgId}) is used as the key for storage.
+     */
+    public void addOrgResource(MockResource orgResource) {
+
+        orgResources.put(orgResource.getOrgId(), orgResource);
+    }
+
+    /**
+     * Retrieves an organization-level resource by its organization ID.
+     *
+     * @param orgId The unique identifier of the organization.
+     * @return The resource associated with the given organization ID, or {@code null}
+     * if no resource exists for the provided ID.
+     */
+    public MockResource getOrgResource(String orgId) {
+
+        return orgResources.get(orgId);
+    }
+
+    /**
+     * Adds an application-level resource to the management service.
+     *
+     * @param appResource The resource to be added. The key for storage is derived
+     *                    by concatenating the resource's organization ID and
+     *                    application ID ({@link MockResource#getAppId}), separated by a colon.
+     */
+    public void addAppResource(MockResource appResource) {
+
+        appResources.put(appResource.getOrgId() + ":" + appResource.getAppId(), appResource);
+    }
+
+    /**
+     * Retrieves an application-level resource by organization ID and application ID.
+     * <p>
+     * If no application-level resource is found for the given organization and application IDs,
+     * the method falls back to returning the corresponding organization-level resource, if available.
+     *
+     * @param orgId The unique identifier of the organization.
+     * @param appId The unique identifier of the application within the organization.
+     * @return The application-level resource if found; otherwise, the organization-level
+     * resource associated with the organization ID. Returns {@code null} if no matching
+     * resource is available at either level.
+     */
+    public MockResource getAppResource(String orgId, String appId) {
+
+        MockResource appResource = appResources.get(orgId + ":" + appId);
+        if (appResource == null) {
+            return orgResources.get(orgId);
+        }
+        return appResource;
+    }
+}

--- a/components/org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service/src/test/java/org/wso2/carbon/identity/organization/application/resource/hierarchy/traverse/service/mock/resource/impl/model/MockResource.java
+++ b/components/org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service/src/test/java/org/wso2/carbon/identity/organization/application/resource/hierarchy/traverse/service/mock/resource/impl/model/MockResource.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service.mock.resource.impl.model;
+
+/**
+ * Represents a mocked resource in an organization or application hierarchy.
+ * <p>
+ * This class models resources that are associated either at the organization level
+ * or at the application level within an organization. It includes identifiers and
+ * metadata such as resource ID, resource name, organization ID, and optionally,
+ * an application ID for application-specific resources.
+ */
+public class MockResource {
+
+    private int id;
+    private String resourceName;
+    private String orgId;
+    private String appId;
+
+    /**
+     * Constructs a mocked resource associated with an organization.
+     *
+     * @param id           Unique identifier of the resource.
+     * @param resourceName Descriptive name of the resource.
+     * @param orgId        Identifier of the organization the resource belongs to.
+     */
+    public MockResource(int id, String resourceName, String orgId) {
+
+        this.id = id;
+        this.resourceName = resourceName;
+        this.orgId = orgId;
+    }
+
+    /**
+     * Constructs a mocked resource associated with a specific application within an organization.
+     *
+     * @param id           Unique identifier of the resource.
+     * @param resourceName Descriptive name of the resource.
+     * @param orgId        Identifier of the organization the resource belongs to.
+     * @param appId        Identifier of the application the resource is associated with.
+     */
+    public MockResource(int id, String resourceName, String orgId, String appId) {
+
+        this(id, resourceName, orgId);
+        this.appId = appId;
+    }
+
+    /**
+     * Retrieves the unique identifier of the resource.
+     *
+     * @return The resource ID.
+     */
+    public int getId() {
+
+        return id;
+    }
+
+    /**
+     * Sets the unique identifier of the resource.
+     *
+     * @param id The resource ID to set.
+     */
+    public void setId(int id) {
+
+        this.id = id;
+    }
+
+    /**
+     * Retrieves the name of the resource.
+     *
+     * @return The resource name.
+     */
+    public String getResourceName() {
+
+        return resourceName;
+    }
+
+    /**
+     * Sets the name of the resource.
+     *
+     * @param resourceName The name to assign to the resource.
+     */
+    public void setResourceName(String resourceName) {
+
+        this.resourceName = resourceName;
+    }
+
+    /**
+     * Retrieves the organization ID associated with the resource.
+     *
+     * @return The organization ID.
+     */
+    public String getOrgId() {
+
+        return orgId;
+    }
+
+    /**
+     * Sets the organization ID associated with the resource.
+     *
+     * @param orgId The organization ID to set.
+     */
+    public void setOrgId(String orgId) {
+
+        this.orgId = orgId;
+    }
+
+    /**
+     * Retrieves the application ID associated with the resource.
+     *
+     * @return The application ID, or {@code null} if the resource is not associated with a specific application.
+     */
+    public String getAppId() {
+
+        return appId;
+    }
+
+    /**
+     * Sets the application ID associated with the resource.
+     *
+     * @param appId The application ID to set.
+     */
+    public void setAppId(String appId) {
+
+        this.appId = appId;
+    }
+}

--- a/components/org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service/src/test/resources/testng.xml
@@ -1,0 +1,27 @@
+<!--
+  ~ Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service.suite">
+    <test name="org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service.tests" preserve-order="true" parallel="false">
+        <classes>
+            <class name="org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service.OrgAppResourceResolverServiceTest"/>
+        </classes>
+    </test>
+</suite>

--- a/components/org.wso2.carbon.identity.organization.config.service/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.config.service/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.organization.management</groupId>
         <artifactId>identity-organization-management</artifactId>
-        <version>1.4.136-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.organization.discovery.service/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.discovery.service/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.organization.management</groupId>
         <artifactId>identity-organization-management</artifactId>
-        <version>1.4.136-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.organization.management.application/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.application/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.organization.management</groupId>
         <artifactId>identity-organization-management</artifactId>
-        <version>1.4.136-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.organization.management.authz.service/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.authz.service/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.organization.management</groupId>
         <artifactId>identity-organization-management</artifactId>
-        <version>1.4.136-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.organization.management.claim.provider/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.claim.provider/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.organization.management</groupId>
         <artifactId>identity-organization-management</artifactId>
-        <version>1.4.136-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.organization.management.ext/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.ext/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.organization.management</groupId>
         <artifactId>identity-organization-management</artifactId>
-        <version>1.4.136-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.organization.management.governance.connector/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.governance.connector/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.organization.management</groupId>
         <artifactId>identity-organization-management</artifactId>
-        <version>1.4.136-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.organization.management.handler/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.handler/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>identity-organization-management</artifactId>
         <groupId>org.wso2.carbon.identity.organization.management</groupId>
-        <version>1.4.136-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.organization.management</groupId>
         <artifactId>identity-organization-management</artifactId>
-        <version>1.4.136-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.organization.management.role.management.service/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.role.management.service/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>identity-organization-management</artifactId>
         <groupId>org.wso2.carbon.identity.organization.management</groupId>
-        <version>1.4.136-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.organization.management.tenant.association/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.tenant.association/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>identity-organization-management</artifactId>
         <groupId>org.wso2.carbon.identity.organization.management</groupId>
-        <version>1.4.136-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/org.wso2.carbon.identity.organization.management.tomcat.ext.tenant.resolver/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.tomcat.ext.tenant.resolver/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.organization.management</groupId>
         <artifactId>identity-organization-management</artifactId>
-        <version>1.4.136-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.organization.management</groupId>
         <artifactId>identity-organization-management</artifactId>
-        <version>1.4.136-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service/src/main/java/org/wso2/carbon/identity/organization/resource/hierarchy/traverse/service/OrgResourceResolverServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service/src/main/java/org/wso2/carbon/identity/organization/resource/hierarchy/traverse/service/OrgResourceResolverServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -19,23 +19,17 @@
 package org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service;
 
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang.StringUtils;
-import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
-import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.apache.commons.lang3.StringUtils;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementServerException;
 import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.constant.OrgResourceHierarchyTraverseConstants;
 import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.exception.OrgResourceHierarchyTraverseException;
 import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.exception.OrgResourceHierarchyTraverseServerException;
-import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.internal.OrgResourceHierarchyTraverseServiceDataHolder;
 import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.strategy.AggregationStrategy;
 import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.util.OrgResourceHierarchyTraverseUtil;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 
 /**
@@ -51,30 +45,6 @@ public class OrgResourceResolverServiceImpl implements OrgResourceResolverServic
 
         List<String> organizationIds = getAncestorOrganizationsIds(organizationId);
         return aggregationStrategy.aggregate(organizationIds, resourceRetriever);
-    }
-
-    @Override
-    public <T> T getResourcesFromOrgHierarchy(String organizationId, String applicationId,
-                                              BiFunction<String, String, Optional<T>> resourceRetriever,
-                                              AggregationStrategy<T> aggregationStrategy)
-            throws OrgResourceHierarchyTraverseException {
-
-        try {
-            List<String> organizationIds = getAncestorOrganizationsIds(organizationId);
-
-            ApplicationManagementService applicationManagementService = getApplicationManagementService();
-            Map<String, String> ancestorAppIds = Collections.emptyMap();
-            if (applicationId != null) {
-                ancestorAppIds = applicationManagementService.getAncestorAppIds(applicationId, organizationId);
-            }
-
-            return aggregationStrategy.aggregate(organizationIds, ancestorAppIds, resourceRetriever);
-        } catch (IdentityApplicationManagementException e) {
-            throw OrgResourceHierarchyTraverseUtil.handleServerException(
-                    OrgResourceHierarchyTraverseConstants.ErrorMessages
-                            .ERROR_CODE_SERVER_ERROR_WHILE_RESOLVING_ANCESTOR_APPLICATIONS,
-                    e, organizationId, applicationId);
-        }
     }
 
     private List<String> getAncestorOrganizationsIds(String organizationId)
@@ -99,10 +69,5 @@ public class OrgResourceResolverServiceImpl implements OrgResourceResolverServic
                     OrgResourceHierarchyTraverseConstants.ErrorMessages
                             .ERROR_CODE_SERVER_ERROR_WHILE_RESOLVING_ANCESTOR_ORGANIZATIONS, e, organizationId);
         }
-    }
-
-    private ApplicationManagementService getApplicationManagementService() {
-
-        return OrgResourceHierarchyTraverseServiceDataHolder.getInstance().getApplicationManagementService();
     }
 }

--- a/components/org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service/src/main/java/org/wso2/carbon/identity/organization/resource/hierarchy/traverse/service/internal/OrgResourceHierarchyTraverseServiceComponent.java
+++ b/components/org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service/src/main/java/org/wso2/carbon/identity/organization/resource/hierarchy/traverse/service/internal/OrgResourceHierarchyTraverseServiceComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -27,7 +27,6 @@ import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
-import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.OrgResourceResolverService;
 import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.OrgResourceResolverServiceImpl;
@@ -105,35 +104,6 @@ public class OrgResourceHierarchyTraverseServiceComponent {
 
         OrgResourceHierarchyTraverseServiceDataHolder.getInstance().setOrganizationManager(null);
         LOG.debug("OrganizationManager unset in OrgResourceManagementServiceComponent bundle.");
-    }
-
-    /**
-     * Sets the ApplicationManagementService instance in the OrgResourceHierarchyTraverseServiceDataHolder.
-     *
-     * @param applicationManagementService The ApplicationManagementService instance to be assigned.
-     */
-    @Reference(
-            name = "org.wso2.carbon.identity.application.mgt",
-            service = ApplicationManagementService.class,
-            cardinality = ReferenceCardinality.MANDATORY,
-            policy = ReferencePolicy.DYNAMIC,
-            unbind = "unsetApplicationManagementService")
-    protected void setApplicationManagementService(ApplicationManagementService applicationManagementService) {
-
-        OrgResourceHierarchyTraverseServiceDataHolder.getInstance()
-                .setApplicationManagementService(applicationManagementService);
-        LOG.debug("ApplicationManagementService set in OrgResourceManagementServiceComponent bundle.");
-    }
-
-    /**
-     * Unsets the ApplicationManagementService instance in the OrgResourceHierarchyTraverseServiceDataHolder.
-     *
-     * @param applicationManagementService The ApplicationManagementService instance to be removed.
-     */
-    protected void unsetApplicationManagementService(ApplicationManagementService applicationManagementService) {
-
-        OrgResourceHierarchyTraverseServiceDataHolder.getInstance().setApplicationManagementService(null);
-        LOG.debug("ApplicationManagementService unset in OrgResourceManagementServiceComponent bundle.");
     }
 }
 

--- a/components/org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service/src/main/java/org/wso2/carbon/identity/organization/resource/hierarchy/traverse/service/internal/OrgResourceHierarchyTraverseServiceDataHolder.java
+++ b/components/org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service/src/main/java/org/wso2/carbon/identity/organization/resource/hierarchy/traverse/service/internal/OrgResourceHierarchyTraverseServiceDataHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -18,7 +18,6 @@
 
 package org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.internal;
 
-import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 
 /**
@@ -31,7 +30,6 @@ public class OrgResourceHierarchyTraverseServiceDataHolder {
             new OrgResourceHierarchyTraverseServiceDataHolder();
 
     private OrganizationManager organizationManager;
-    private ApplicationManagementService applicationManagementService;
 
     private OrgResourceHierarchyTraverseServiceDataHolder() {
 
@@ -65,25 +63,5 @@ public class OrgResourceHierarchyTraverseServiceDataHolder {
     public void setOrganizationManager(OrganizationManager organizationManager) {
 
         this.organizationManager = organizationManager;
-    }
-
-    /**
-     * Retrieves the current instance of the ApplicationManagementService.
-     *
-     * @return The current ApplicationManagementService instance responsible for managing applications.
-     */
-    public ApplicationManagementService getApplicationManagementService() {
-
-        return applicationManagementService;
-    }
-
-    /**
-     * Sets the ApplicationManagementService instance.
-     *
-     * @param applicationManagementService The ApplicationManagementService instance to be set.
-     */
-    public void setApplicationManagementService(ApplicationManagementService applicationManagementService) {
-
-        this.applicationManagementService = applicationManagementService;
     }
 }

--- a/components/org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service/src/test/java/org/wso2/carbon/identity/organization/resource/hierarchy/traverse/service/OrgResourceResolverServiceTest.java
+++ b/components/org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service/src/test/java/org/wso2/carbon/identity/organization/resource/hierarchy/traverse/service/OrgResourceResolverServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2024-2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -24,8 +24,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
-import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementServerException;
@@ -41,9 +39,7 @@ import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.anyString;
@@ -61,11 +57,8 @@ import static org.testng.Assert.assertThrows;
 public class OrgResourceResolverServiceTest {
 
     private static final String ROOT_ORG_ID = "10084a8d-113f-4211-a0d5-efe36b082211";
-    private static final String ROOT_APP_ID = "1ee981ab-64e7-435c-ab91-e8d1e0a13b2c";
     private static final String L1_ORG_ID = "93d996f9-a5ba-4275-a52b-adaad9eba869";
-    private static final String L1_APP_ID = "619d2cb1-174d-4d38-af3b-99c532dddb00";
     private static final String L2_ORG_ID = "30b701c6-e309-4241-b047-0c299c45d1a0";
-    private static final String L2_APP_ID = "d04d48db-8c5a-437a-9458-4352b84db621";
     private static final String INVALID_ORG_ID = "invalid-org-id";
     private static final String INVALID_APP_ID = "invalid-app-id";
 
@@ -76,9 +69,6 @@ public class OrgResourceResolverServiceTest {
 
     @Mock
     OrganizationManager organizationManager;
-
-    @Mock
-    ApplicationManagementService applicationManagementService;
 
     /**
      * Initializes test data and mock services before the test class is run.
@@ -92,8 +82,6 @@ public class OrgResourceResolverServiceTest {
 
         // Set the OrganizationManager and ApplicationManagementService to the data holder for use in tests
         OrgResourceHierarchyTraverseServiceDataHolder.getInstance().setOrganizationManager(organizationManager);
-        OrgResourceHierarchyTraverseServiceDataHolder.getInstance()
-                .setApplicationManagementService(applicationManagementService);
 
         // Initialize the aggregation strategies with the appropriate strategy types.
         firstFoundAggregationStrategy = new FirstFoundAggregationStrategy<>();
@@ -112,14 +100,6 @@ public class OrgResourceResolverServiceTest {
         mockAncestorOrganizationRetrieval(Arrays.asList(L1_ORG_ID, ROOT_ORG_ID));
         mockAncestorOrganizationRetrieval(Collections.singletonList(ROOT_ORG_ID));
 
-        // Mock responses for the application management service with corresponding application ancestor data.
-        mockAncestorApplicationRetrieval(Arrays.asList(L2_ORG_ID, L1_ORG_ID, ROOT_ORG_ID),
-                Arrays.asList(L2_APP_ID, L1_APP_ID, ROOT_APP_ID));
-        mockAncestorApplicationRetrieval(Arrays.asList(L1_ORG_ID, ROOT_ORG_ID),
-                Arrays.asList(L1_APP_ID, ROOT_APP_ID));
-        mockAncestorApplicationRetrieval(Collections.singletonList(ROOT_ORG_ID),
-                Collections.singletonList(ROOT_APP_ID));
-
         // Initialize the mock resource management service used in tests.
         mockResourceManagementService = new MockResourceManagementService();
 
@@ -135,7 +115,6 @@ public class OrgResourceResolverServiceTest {
 
         // Reset the mock services to their default state after each test.
         reset(organizationManager);
-        reset(applicationManagementService);
     }
 
     @DataProvider(name = "AggregationStrategyDataProvider")
@@ -249,161 +228,6 @@ public class OrgResourceResolverServiceTest {
         assertResolvedResponse(resolvedL2Resource, createdOrgResources.get(2));
     }
 
-    /**
-     * Tests the behavior of the OrgResourceResolverService when no application-level or organization-level resources
-     * are available in the hierarchy.
-     * <p>
-     * This test ensures that when no resources are available at the organization or application levels,
-     * the resolver correctly returns null.
-     *
-     * @param aggregationStrategy The aggregation strategy used to resolve resources.
-     */
-    @Test(dataProvider = "AggregationStrategyDataProvider")
-    public void testGetAppLevelResourcesFromOrgHierarchyWhenNoResourceAvailable(
-            AggregationStrategy<MockResource> aggregationStrategy) throws Exception {
-
-        MockResource resolvedRootAppResource =
-                invokeAppLevelResourceResolver(aggregationStrategy, ROOT_ORG_ID, ROOT_APP_ID);
-        assertNull(resolvedRootAppResource);
-
-        MockResource resolvedL1AppResource = invokeAppLevelResourceResolver(aggregationStrategy, L1_ORG_ID, L1_APP_ID);
-        assertNull(resolvedL1AppResource);
-
-        MockResource resolvedL2AppResource = invokeAppLevelResourceResolver(aggregationStrategy, L2_ORG_ID, L2_APP_ID);
-        assertNull(resolvedL2AppResource);
-    }
-
-    /**
-     * Tests the behavior of the OrgResourceResolverService when resources are available at both root organization
-     * and/ or root application levels in the organization hierarchy.
-     * <p>
-     * This test verifies that when resources are available for the root level, they are correctly resolved at the
-     * organization and application levels across all organization levels (root, L1, and L2).
-     *
-     * @param aggregationStrategy The aggregation strategy used to resolve resources at different levels.
-     */
-    @Test(dataProvider = "AggregationStrategyDataProvider")
-    public void testGetAppLevelResourcesFromOrgHierarchyWhenRootResourcesAvailable(
-            AggregationStrategy<MockResource> aggregationStrategy) throws Exception {
-
-        // Add org-level resource for root organization into the mock resource management service.
-        List<MockResource> createdOrgResource = addOrgResources(Collections.singletonList(ROOT_ORG_ID));
-
-        MockResource resolvedRootAppResource =
-                invokeAppLevelResourceResolver(aggregationStrategy, ROOT_ORG_ID, ROOT_APP_ID);
-        assertResolvedResponse(resolvedRootAppResource, createdOrgResource.get(0));
-
-        MockResource resolvedL1AppResource = invokeAppLevelResourceResolver(aggregationStrategy, L1_ORG_ID, L1_APP_ID);
-        assertResolvedResponse(resolvedL1AppResource, createdOrgResource.get(0));
-
-        MockResource resolvedL2AppResource = invokeAppLevelResourceResolver(aggregationStrategy, L2_ORG_ID, L2_APP_ID);
-        assertResolvedResponse(resolvedL2AppResource, createdOrgResource.get(0));
-
-        // Add app-level resource for root organization into the mock resource management service.
-        List<MockResource> createdAppResource = addAppResources(Collections.singletonList(ROOT_ORG_ID),
-                Collections.singletonList(ROOT_APP_ID));
-
-        resolvedRootAppResource =
-                invokeAppLevelResourceResolver(aggregationStrategy, ROOT_ORG_ID, ROOT_APP_ID);
-        assertResolvedResponse(resolvedRootAppResource, createdAppResource.get(0));
-
-        resolvedL1AppResource = invokeAppLevelResourceResolver(aggregationStrategy, L1_ORG_ID, L1_APP_ID);
-        assertResolvedResponse(resolvedL1AppResource, createdAppResource.get(0));
-
-        resolvedL2AppResource = invokeAppLevelResourceResolver(aggregationStrategy, L2_ORG_ID, L2_APP_ID);
-        assertResolvedResponse(resolvedL2AppResource, createdAppResource.get(0));
-    }
-
-    /**
-     * Tests the behavior of the OrgResourceResolverService when organization-level and/ or application-level resources
-     * are available for both root and L1 organizations in the hierarchy.
-     * <p>
-     * This test ensures when resources are available for the L1 level, they are correctly resolved at the
-     * organization and application levels across both organization levels, L1, and L2. At the root level,
-     * its own resource should be returned.
-     *
-     * @param aggregationStrategy The aggregation strategy used to resolve resources at different levels.
-     */
-    @Test(dataProvider = "AggregationStrategyDataProvider")
-    public void testGetAppLevelResourcesFromOrgHierarchyWhenL1ResourcesAvailable(
-            AggregationStrategy<MockResource> aggregationStrategy) throws Exception {
-
-        // Add org-level resources for L1 and root organizations into the mock resource management service.
-        List<MockResource> createdOrgResources = addOrgResources(Arrays.asList(ROOT_ORG_ID, L1_ORG_ID));
-        // Add app-level resources for root organization into the mock resource management service.
-        List<MockResource> createdAppResources = addAppResources(Collections.singletonList(ROOT_ORG_ID),
-                Collections.singletonList(ROOT_APP_ID));
-
-        MockResource resolvedRootAppResource =
-                invokeAppLevelResourceResolver(aggregationStrategy, ROOT_ORG_ID, ROOT_APP_ID);
-        assertResolvedResponse(resolvedRootAppResource, createdAppResources.get(0));
-
-        MockResource resolvedL1AppResource = invokeAppLevelResourceResolver(aggregationStrategy, L1_ORG_ID, L1_APP_ID);
-        assertResolvedResponse(resolvedL1AppResource, createdOrgResources.get(1));
-
-        MockResource resolvedL2AppResource = invokeAppLevelResourceResolver(aggregationStrategy, L2_ORG_ID, L2_APP_ID);
-        assertResolvedResponse(resolvedL2AppResource, createdOrgResources.get(1));
-
-        // Add app-level resources for L1 organization into the mock resource management service.
-        createdAppResources.addAll(addAppResources(Collections.singletonList(L1_ORG_ID),
-                Collections.singletonList(L1_APP_ID)));
-
-        resolvedRootAppResource =
-                invokeAppLevelResourceResolver(aggregationStrategy, ROOT_ORG_ID, ROOT_APP_ID);
-        assertResolvedResponse(resolvedRootAppResource, createdAppResources.get(0));
-
-        resolvedL1AppResource = invokeAppLevelResourceResolver(aggregationStrategy, L1_ORG_ID, L1_APP_ID);
-        assertResolvedResponse(resolvedL1AppResource, createdAppResources.get(1));
-
-        resolvedL2AppResource = invokeAppLevelResourceResolver(aggregationStrategy, L2_ORG_ID, L2_APP_ID);
-        assertResolvedResponse(resolvedL2AppResource, createdAppResources.get(1));
-    }
-
-    /**
-     * Tests the behavior of the OrgResourceResolverService when organization-level and/ or application-level resources
-     * are available for all organization levels in the hierarchy.
-     * <p>
-     * This test ensures that when a resource is available at the L2 level, it is correctly resolved for the
-     * L2 organization based on the provided aggregation strategy. At the root and L1 level, their own resources
-     * should be returned.
-     *
-     * @param aggregationStrategy The aggregation strategy used to resolve resources at different levels.
-     */
-    @Test(dataProvider = "AggregationStrategyDataProvider")
-    public void testGetAppLevelResourcesFromOrgHierarchyWhenL2ResourcesAvailable(
-            AggregationStrategy<MockResource> aggregationStrategy) throws Exception {
-
-        // Add org-level resources for L2, L1 and root organizations into the mock resource management service.
-        List<MockResource> createdOrgResources = addOrgResources(Arrays.asList(ROOT_ORG_ID, L1_ORG_ID, L2_ORG_ID));
-        // Add app-level resources for L1 and root organizations into the mock resource management service.
-        List<MockResource> createdAppResources = addAppResources(Arrays.asList(ROOT_ORG_ID, L1_ORG_ID),
-                Arrays.asList(ROOT_APP_ID, L1_APP_ID));
-
-        MockResource resolvedRootAppResource =
-                invokeAppLevelResourceResolver(aggregationStrategy, ROOT_ORG_ID, ROOT_APP_ID);
-        assertResolvedResponse(resolvedRootAppResource, createdAppResources.get(0));
-
-        MockResource resolvedL1AppResource = invokeAppLevelResourceResolver(aggregationStrategy, L1_ORG_ID, L1_APP_ID);
-        assertResolvedResponse(resolvedL1AppResource, createdAppResources.get(1));
-
-        MockResource resolvedL2AppResource = invokeAppLevelResourceResolver(aggregationStrategy, L2_ORG_ID, L2_APP_ID);
-        assertResolvedResponse(resolvedL2AppResource, createdOrgResources.get(2));
-
-        // Add app-level resources for L2 organization into the mock resource management service.
-        createdAppResources.addAll(addAppResources(Collections.singletonList(L2_ORG_ID),
-                Collections.singletonList(L2_APP_ID)));
-
-        resolvedRootAppResource =
-                invokeAppLevelResourceResolver(aggregationStrategy, ROOT_ORG_ID, ROOT_APP_ID);
-        assertResolvedResponse(resolvedRootAppResource, createdAppResources.get(0));
-
-        resolvedL1AppResource = invokeAppLevelResourceResolver(aggregationStrategy, L1_ORG_ID, L1_APP_ID);
-        assertResolvedResponse(resolvedL1AppResource, createdAppResources.get(1));
-
-        resolvedL2AppResource = invokeAppLevelResourceResolver(aggregationStrategy, L2_ORG_ID, L2_APP_ID);
-        assertResolvedResponse(resolvedL2AppResource, createdAppResources.get(2));
-    }
-
     @DataProvider(name = "provideAggregationStrategiesForOrgLevelResolverWithInvalidInput")
     public Object[][] provideAggregationStrategiesForOrgLevelResolverWithInvalidInput() {
 
@@ -448,33 +272,6 @@ public class OrgResourceResolverServiceTest {
     }
 
     /**
-     * Tests the behavior of the OrgResourceResolverService when provided with invalid organization and application IDs.
-     * <p>
-     * This test verifies that the resolver correctly handles invalid input combinations by returning null,
-     * ensuring robustness and appropriate error handling in edge cases. The test covers scenarios where:
-     * - The organization ID is invalid.
-     * - The application ID is invalid.
-     * - Both the organization and application IDs are invalid.
-     *
-     * @param aggregationStrategy The aggregation strategy used to resolve resources across the hierarchy.
-     * @param invalidOrgIds       A list of invalid organization IDs to test the resolver's behavior.
-     * @param invalidAppIds       A list of invalid application IDs to test the resolver's behavior.
-     * @throws Exception If an error occurs during resolution.
-     */
-    @Test(dataProvider = "provideAggregationStrategiesForAppLevelResolverWithInvalidInput")
-    public void testGetAppLevelResourcesFromOrgHierarchyForInvalidInput(
-            AggregationStrategy<MockResource> aggregationStrategy, List<String> invalidOrgIds,
-            List<String> invalidAppIds) throws Exception {
-
-        for (String invalidOrgId : invalidOrgIds) {
-            for (String invalidAppId : invalidAppIds) {
-                assertThrows(OrgResourceHierarchyTraverseServerException.class,
-                        () -> invokeAppLevelResourceResolver(aggregationStrategy, invalidOrgId, invalidAppId));
-            }
-        }
-    }
-
-    /**
      * Tests the behavior of the OrgResourceResolverService when server-side errors occur during
      * organizational hierarchy traversal.
      * <p>
@@ -507,42 +304,6 @@ public class OrgResourceResolverServiceTest {
     }
 
     /**
-     * Tests the behavior of the OrgResourceResolverService when server-side errors occur during
-     * application hierarchy traversal within an organization.
-     * <p>
-     * This test simulates server-side exceptions thrown by the following:
-     * - The `applicationManagementService` while retrieving ancestor application IDs.
-     * - The `organizationManager` while retrieving ancestor organization IDs.
-     *
-     * @param aggregationStrategy The aggregation strategy used for resolving resources.
-     * @throws Exception If an unexpected error occurs.
-     */
-    @Test(dataProvider = "AggregationStrategyDataProvider")
-    public void testGetAppLevelResourcesFromOrgHierarchyWhenServerErrorOccurs(
-            AggregationStrategy<MockResource> aggregationStrategy) throws Exception {
-
-        when(applicationManagementService.getAncestorAppIds(anyString(), anyString()))
-                .thenThrow(IdentityApplicationManagementException.class);
-
-        assertThrows(OrgResourceHierarchyTraverseServerException.class,
-                () -> invokeAppLevelResourceResolver(aggregationStrategy, ROOT_ORG_ID, ROOT_APP_ID));
-        assertThrows(OrgResourceHierarchyTraverseServerException.class,
-                () -> invokeAppLevelResourceResolver(aggregationStrategy, L1_ORG_ID, L1_APP_ID));
-        assertThrows(OrgResourceHierarchyTraverseServerException.class,
-                () -> invokeAppLevelResourceResolver(aggregationStrategy, L2_ORG_ID, L2_APP_ID));
-
-        when(organizationManager.getAncestorOrganizationIds(anyString()))
-                .thenThrow(OrganizationManagementServerException.class);
-
-        assertThrows(OrgResourceHierarchyTraverseServerException.class,
-                () -> invokeAppLevelResourceResolver(aggregationStrategy, ROOT_ORG_ID, ROOT_APP_ID));
-        assertThrows(OrgResourceHierarchyTraverseServerException.class,
-                () -> invokeAppLevelResourceResolver(aggregationStrategy, L1_ORG_ID, L1_APP_ID));
-        assertThrows(OrgResourceHierarchyTraverseServerException.class,
-                () -> invokeAppLevelResourceResolver(aggregationStrategy, L2_ORG_ID, L2_APP_ID));
-    }
-
-    /**
      * Mock the retrieval of ancestor organization IDs.
      *
      * @param orgIds Organization IDs.
@@ -553,24 +314,6 @@ public class OrgResourceResolverServiceTest {
 
         List<String> ancestorOrganizationIds = new ArrayList<>(orgIds);
         when(organizationManager.getAncestorOrganizationIds(orgIds.get(0))).thenReturn(ancestorOrganizationIds);
-    }
-
-    /**
-     * Mock the retrieval of ancestor application IDs.
-     *
-     * @param orgIds Organization IDs.
-     * @param appIds Application IDs.
-     * @throws IdentityApplicationManagementException If an error occurs while retrieving ancestor application IDs.
-     */
-    private void mockAncestorApplicationRetrieval(List<String> orgIds, List<String> appIds)
-            throws IdentityApplicationManagementException {
-
-        Map<String, String> ancestorAppIds = new HashMap<>();
-        for (String orgId : orgIds) {
-            ancestorAppIds.put(orgId, appIds.get(orgIds.indexOf(orgId)));
-        }
-
-        when(applicationManagementService.getAncestorAppIds(appIds.get(0), orgIds.get(0))).thenReturn(ancestorAppIds);
     }
 
     /**
@@ -589,26 +332,6 @@ public class OrgResourceResolverServiceTest {
             createdOrgResources.add(orgResource);
         }
         return createdOrgResources;
-    }
-
-    /**
-     * Add application resources to the mock resource management service.
-     *
-     * @param orgIds Organization IDs.
-     * @param appIds Application IDs.
-     * @return List of created application resources.
-     */
-    private List<MockResource> addAppResources(List<String> orgIds, List<String> appIds) {
-
-        List<MockResource> createdAppResources = new ArrayList<>();
-        int resourceId = 1;
-        for (String orgId : orgIds) {
-            MockResource appResource =
-                    new MockResource(resourceId++, orgId + "App Resource", orgId, appIds.get(orgIds.indexOf(orgId)));
-            mockResourceManagementService.addAppResource(appResource);
-            createdAppResources.add(appResource);
-        }
-        return createdAppResources;
     }
 
     /**
@@ -642,29 +365,6 @@ public class OrgResourceResolverServiceTest {
                 organizationId,
                 orgId -> {
                     MockResource resource = mockResourceManagementService.getOrgResource(orgId);
-                    return Optional.ofNullable(resource);
-                },
-                aggregationStrategy);
-    }
-
-    /**
-     * Invoke the application level resource resolver.
-     *
-     * @param aggregationStrategy Aggregation strategy.
-     * @param organizationId      Organization ID.
-     * @param applicationId       Application ID.
-     * @return Resolved resource.
-     * @throws OrgResourceHierarchyTraverseException If an error occurs while resolving the resource.
-     */
-    private MockResource invokeAppLevelResourceResolver(AggregationStrategy<MockResource> aggregationStrategy,
-                                                        String organizationId, String applicationId)
-            throws OrgResourceHierarchyTraverseException {
-
-        return orgResourceResolverService.getResourcesFromOrgHierarchy(
-                organizationId,
-                applicationId,
-                (orgId, appId) -> {
-                    MockResource resource = mockResourceManagementService.getAppResource(orgId, appId);
                     return Optional.ofNullable(resource);
                 },
                 aggregationStrategy);

--- a/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.resource.sharing.policy.management/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.organization.management</groupId>
         <artifactId>identity-organization-management</artifactId>
-        <version>1.4.136-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.organization.management</groupId>
         <artifactId>identity-organization-management</artifactId>
-        <version>1.4.136-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.carbon.identity.organization.management.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.organization.management.server.feature/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.carbon.identity.organization.management</groupId>
         <artifactId>identity-organization-management</artifactId>
-        <version>1.4.136-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <module>components/org.wso2.carbon.identity.organization.management.organization.user.sharing</module>
         <module>components/org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service</module>
         <module>components/org.wso2.carbon.identity.organization.resource.sharing.policy.management</module>
+        <module>components/org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service</module>
     </modules>
 
     <dependencyManagement>
@@ -207,6 +208,12 @@
             <dependency>
                 <groupId>org.wso2.carbon.identity.organization.management</groupId>
                 <artifactId>org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service</artifactId>
+                <version>${project.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.organization.management</groupId>
+                <artifactId>org.wso2.carbon.identity.organization.application.resource.hierarchy.traverse.service</artifactId>
                 <version>${project.version}</version>
                 <scope>provided</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
     <groupId>org.wso2.carbon.identity.organization.management</groupId>
     <artifactId>identity-organization-management</artifactId>
-    <version>1.4.136-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
     <name>WSO2 Carbon - Organization Management</name>
@@ -586,7 +586,7 @@
 
         <identity.organization.management.exp.pkg.version>${project.version}
         </identity.organization.management.exp.pkg.version>
-        <org.wso2.identity.organization.mgt.imp.pkg.version.range>[1.0.0,2.0.0)
+        <org.wso2.identity.organization.mgt.imp.pkg.version.range>[1.0.0,3.0.0)
         </org.wso2.identity.organization.mgt.imp.pkg.version.range>
 
         <identity.organization.management.core.version>1.1.23</identity.organization.management.core.version>


### PR DESCRIPTION
## Purpose
The existing Organization Resource Resolver service provides two main capabilities:

- Retrieving resources by traversing the hierarchy of a given organization and application.
- Retrieving resources by traversing the hierarchy of a given organization.

This PR extracts the application-specific traversal logic into a separate service.
The goal is to prevent cyclic dependencies that can occur when the Organization Resource Resolver is invoked within the idp-mgt service (or any other service that app-mgt service depends on)

Since this PR introduces significant refactoring to the Organization Resource Resolver service, a major version bump will be performed to reflect the breaking changes.