### PR TITLE
Improve the app retrieval logic when adding shared apps to organization during org creation

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/OrganizationCreationHandler.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/OrganizationCreationHandler.java
@@ -115,6 +115,7 @@ public class OrganizationCreationHandler extends AbstractEventHandler {
         }
 
         ApplicationBasicInfo[] applicationBasicInfos;
+        // Retrieve all the applications which are to be shared to the new organization.
         applicationBasicInfos = getApplicationManagementService().getApplicationBasicInfoBySPProperty(
                 getOrganizationManager().resolveTenantDomain(primaryOrganizationId), getAuthenticatedUsername(),
                 SHARE_WITH_ALL_CHILDREN, "true");

--- a/pom.xml
+++ b/pom.xml
@@ -602,7 +602,7 @@
         <carbon.multitenancy.package.import.version.range>[4.7.0,5.0.0)
         </carbon.multitenancy.package.import.version.range>
 
-        <carbon.identity.framework.version>7.8.150</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.234</carbon.identity.framework.version>
         <carbon.identity.package.import.version.range>[5.20.0, 8.0.0)
         </carbon.identity.package.import.version.range>
 


### PR DESCRIPTION
## Purpose
Currently, the addSharedApplicationsToOrganization method in the sub organization creation flow retrieves all the applications of the parent organization regardless of whether they are marked to be shared. When there are a large number of applications, this leads to a large number of DB calls which leads to a significant increase in the time taken.

The objective of the above logic is to share the applications which have the "shareWithAllChildren" property with the newly created sub organization. In order to do that, we are retrieving all the applications and then checking which of them has the above property set to true. This causes an unnecessary overhead as it is not required to retrieve all applications and iterate through them.

## Issue

- https://github.com/wso2/product-is/issues/24339

## Goals
This improvement is to improve the logic to ONLY retrieve applications which have the "shareWithAllChildren" property set to true of the PRIMARY organization, instead of retrieving ALL the applications of the IMMEDIATE PARENT organization.

## Approach

The fix incorporates three changes in the logic.

1. Retrieve only applications with the shareWithAllChildren attribute set to true, rather than retrieving all applications.
   -  In the existing implementation, all the apps were retrieved and then iterated to find apps with “shareWithAllChildren” attribute. The entire app was retrieved for all the apps before checking whether the attribute is true.
   - With the improvement, ONLY the apps with “shareWithAllChildren” attribute are retrieved.


2. Retrieve shared applications from the PRIMARY organization, rather than the IMMEDIATE PARENT.
   - In the existing implementation, all the apps of the "IMMEDIATE PARENT" org were retrieved.
   - With the improvement, only apps of the “PRIMARY” org are retrieved.
   - This flow is hit during primary org (tenant) creation as well if primary orgs are created with the super tenant as the parent. It does not get hit in the normal root organization creation flow in the IS. Earlier, for “primary” orgs, the parent (Super tenant) apps were retrieved and iterated to check for any apps with the “shareWithAllChildren” attribute.  But since there is no usecase where the super tenant apps are shared to the primary orgs, it was decided to skip the app sharing if the org is a primary org

3. Remove the previous fragment application handling logic as we are now only considering Primary organizations.

Test Plan - https://github.com/wso2/product-is/issues/24339#issuecomment-2982679135

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.