### PR TITLE
Add organization version handler

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.handler/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.handler/pom.xml
@@ -58,6 +58,14 @@
             <artifactId>org.wso2.carbon.user.api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.idp.mgt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.role.management.service</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
             <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
         </dependency>
@@ -159,6 +167,7 @@
                             org.wso2.carbon.user.api;version="${carbon.user.api.imp.pkg.version.range}",
                             org.wso2.carbon.user.core.service;version="${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.user.core.util;version="${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.identity.application.common.util; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.organization.management.service; version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
                             org.wso2.carbon.identity.organization.management.service.constant; version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
                             org.wso2.carbon.identity.organization.management.service.exception; version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
@@ -174,6 +183,8 @@
                             org.wso2.carbon.identity.role.v2.mgt.core.*; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.organization.management.application.*;
                             version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
+                            org.wso2.carbon.idp.mgt;version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.idp.mgt.dao;version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.application.mgt.*;
                             version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.application.common.*;

--- a/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/OrganizationVersionHandler.java
+++ b/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/OrganizationVersionHandler.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.management.handler;
+
+import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.event.IdentityEventException;
+import org.wso2.carbon.identity.event.event.Event;
+import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
+import org.wso2.carbon.identity.organization.management.ext.Constants;
+import org.wso2.carbon.identity.organization.management.handler.internal.OrganizationManagementHandlerDataHolder;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.identity.organization.management.service.model.Organization;
+import org.wso2.carbon.identity.organization.management.service.model.PatchOperation;
+import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
+import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
+import org.wso2.carbon.idp.mgt.dao.CacheBackedIdPMgtDAO;
+import org.wso2.carbon.idp.mgt.dao.IdPManagementDAO;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Event handler to handle operations related to organization version updates.
+ */
+public class OrganizationVersionHandler extends AbstractEventHandler {
+
+
+    @Override
+    public void handleEvent(Event event) throws IdentityEventException {
+
+        String eventName = event.getEventName();
+        Map<String, Object> eventProperties = event.getEventProperties();
+
+        if (Constants.EVENT_PRE_UPDATE_ORGANIZATION.equals(eventName)) {
+            handlePreUpdateOrganization(eventProperties);
+        } else if (Constants.EVENT_PRE_PATCH_ORGANIZATION.equals(eventName)) {
+            handlePrePatchOrganization(eventProperties);
+        }
+    }
+
+    private void handlePrePatchOrganization(Map<String, Object> eventProperties) throws IdentityEventException {
+
+        String organizationId = (String) eventProperties.get(Constants.EVENT_PROP_ORGANIZATION_ID);
+        List<PatchOperation> patchOperations =
+                (List<PatchOperation>) eventProperties.get(Constants.EVENT_PROP_PATCH_OPERATIONS);
+
+        try {
+            if (OrganizationManagementUtil.isOrganization(
+                    getOrganizationManager().resolveTenantDomain(organizationId))) {
+                return;
+            }
+
+            String existingOrgVersion = getOrganizationManager().getOrganization(
+                    organizationId, false, false).getVersion();
+            String newOrgVersion = null;
+
+            for (PatchOperation patchOperation: patchOperations) {
+                if (OrganizationManagementConstants.PATCH_PATH_ORG_VERSION.equals(patchOperation.getPath())) {
+                    newOrgVersion = patchOperation.getValue();
+                    break;
+                }
+            }
+
+            if (isLoginAndRegistrationConfigInheritanceUpdated(existingOrgVersion, newOrgVersion)) {
+                clearIdpCache(organizationId);
+            }
+        } catch (OrganizationManagementException | IdentityProviderManagementException e) {
+            throw new IdentityEventException(String.format(
+                    "Error while handling pre-update organization event in %s for organization ID: %s", this.getName(),
+                    organizationId), e);
+
+        }
+    }
+
+    private void handlePreUpdateOrganization(Map<String, Object> eventProperties) throws IdentityEventException {
+
+        String organizationId = (String) eventProperties.get(Constants.EVENT_PROP_ORGANIZATION_ID);
+        Organization updatedOrganization =
+                (Organization) eventProperties.get(Constants.EVENT_PROP_ORGANIZATION);
+
+        try {
+            if (OrganizationManagementUtil.isOrganization(
+                    getOrganizationManager().resolveTenantDomain(organizationId))) {
+                return;
+            }
+
+            String existingOrgVersion = getOrganizationManager().getOrganization(
+                    organizationId, false, false).getVersion();
+            String newOrgVersion = updatedOrganization.getVersion();
+
+            if (isLoginAndRegistrationConfigInheritanceUpdated(existingOrgVersion, newOrgVersion)) {
+                clearIdpCache(organizationId);
+            }
+        } catch (OrganizationManagementException | IdentityProviderManagementException e) {
+            throw new IdentityEventException(String.format(
+                    "Error while handling pre-update organization event in %s for organization ID: %s", this.getName(),
+                    organizationId), e);
+
+        }
+    }
+
+    /**
+     * Clear the IDP cache for the resident IDP of the organization and all child organizations.
+     *
+     * @param organizationId Organization ID.
+     * @throws OrganizationManagementException If an error occurs while retrieving tenant information.
+     * @throws IdentityProviderManagementException If an error occurs while clearing the IDP cache.
+     */
+    private void clearIdpCache(String organizationId)
+            throws OrganizationManagementException, IdentityProviderManagementException {
+
+        CacheBackedIdPMgtDAO dao = new CacheBackedIdPMgtDAO(new IdPManagementDAO());
+        dao.clearIdpCache(
+                IdentityApplicationConstants.RESIDENT_IDP_RESERVED_NAME,
+                IdentityTenantUtil.getTenantId(getOrganizationManager().resolveTenantDomain(organizationId)),
+                getOrganizationManager().resolveTenantDomain(organizationId));
+
+    }
+
+    private static OrganizationManager getOrganizationManager() {
+
+        return OrganizationManagementHandlerDataHolder.getInstance().getOrganizationManager();
+    }
+
+    private boolean isLoginAndRegistrationConfigInheritanceUpdated(String existingVersion, String newVersion) {
+
+        return newVersion != null && !newVersion.equals(existingVersion) &&
+                (OrganizationManagementConstants.OrganizationVersion.ORG_VERSION_V0.equals(existingVersion) ||
+                        OrganizationManagementConstants.OrganizationVersion.ORG_VERSION_V0.equals(newVersion));
+    }
+}

--- a/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/internal/OrganizationManagementHandlerServiceComponent.java
+++ b/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/internal/OrganizationManagementHandlerServiceComponent.java
@@ -37,6 +37,7 @@ import org.wso2.carbon.identity.organization.management.application.OrgApplicati
 import org.wso2.carbon.identity.organization.management.handler.FragmentApplicationMgtHandler;
 import org.wso2.carbon.identity.organization.management.handler.GovernanceConfigUpdateHandler;
 import org.wso2.carbon.identity.organization.management.handler.OrganizationSessionHandler;
+import org.wso2.carbon.identity.organization.management.handler.OrganizationVersionHandler;
 import org.wso2.carbon.identity.organization.management.handler.SharedRoleMgtHandler;
 import org.wso2.carbon.identity.organization.management.handler.SharingPolicyCleanUpHandler;
 import org.wso2.carbon.identity.organization.management.handler.listener.SharedRoleMgtListener;
@@ -72,6 +73,7 @@ public class OrganizationManagementHandlerServiceComponent {
             bundleContext.registerService(AbstractEventHandler.class, new SharingPolicyCleanUpHandler(), null);
             bundleContext.registerService(AbstractEventHandler.class, new OrganizationSessionHandler(), null);
             bundleContext.registerService(AbstractEventHandler.class, new FragmentApplicationMgtHandler(), null);
+            bundleContext.registerService(AbstractEventHandler.class, new OrganizationVersionHandler(), null);
             LOG.debug("Organization management handler component activated successfully.");
         } catch (Throwable e) {
             LOG.error("Error while activating organization management handler module.", e);

--- a/components/org.wso2.carbon.identity.organization.management.handler/src/test/java/org/wso2/carbon/identity/organization/management/handler/OrganizationVersionHandlerTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.handler/src/test/java/org/wso2/carbon/identity/organization/management/handler/OrganizationVersionHandlerTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.management.handler;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.event.event.Event;
+import org.wso2.carbon.identity.organization.management.ext.Constants;
+import org.wso2.carbon.identity.organization.management.handler.internal.OrganizationManagementHandlerDataHolder;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants;
+import org.wso2.carbon.identity.organization.management.service.model.Organization;
+import org.wso2.carbon.identity.organization.management.service.model.PatchOperation;
+import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
+import org.wso2.carbon.idp.mgt.dao.CacheBackedIdPMgtDAO;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Unit tests for OrganizationVersionHandler.
+ */
+public class OrganizationVersionHandlerTest {
+
+    @Mock
+    private OrganizationManager organizationManager;
+    @Mock
+    private Organization organization;
+    @InjectMocks
+    private OrganizationVersionHandler handler;
+    private AutoCloseable autoCloseable;
+    private MockedStatic<OrganizationManagementUtil> organizationManagementUtilMockedStatic;
+    private MockedStatic<IdentityTenantUtil> identityTenantUtilMockedStatic;
+    private MockedConstruction<CacheBackedIdPMgtDAO> mockedDaoConstruction;
+
+    private static final String ORGANIZATION_ID = "org1";
+    private static final String TENANT_DOMAIN = "carbon.super";
+    private static final int TENANT_ID = -1234;
+    private static final String V1 = "v1.0.0";
+    private static final String V0 = "v0.0.0";
+
+    @BeforeMethod
+    public void setUp() {
+
+        autoCloseable = MockitoAnnotations.openMocks(this);
+        OrganizationManagementHandlerDataHolder.getInstance().setOrganizationManager(organizationManager);
+
+        organizationManagementUtilMockedStatic = mockStatic(OrganizationManagementUtil.class);
+        organizationManagementUtilMockedStatic.when(() -> OrganizationManagementUtil.isOrganization(any()))
+                .thenReturn(false);
+        mockedDaoConstruction = mockConstruction(CacheBackedIdPMgtDAO.class);
+
+        identityTenantUtilMockedStatic = mockStatic(IdentityTenantUtil.class);
+        identityTenantUtilMockedStatic.when(() -> IdentityTenantUtil.getTenantId(any()))
+                .thenReturn(TENANT_ID);
+
+    }
+
+    @AfterMethod
+    public void tearDown() throws Exception {
+
+        autoCloseable.close();
+        organizationManagementUtilMockedStatic.close();
+        identityTenantUtilMockedStatic.close();
+        mockedDaoConstruction.close();
+    }
+
+    @Test
+    public void testHandlePreUpdateOrganizationNoVersionChange() throws Exception {
+
+        Map<String, Object> props = new HashMap<>();
+        props.put(Constants.EVENT_PROP_ORGANIZATION_ID, ORGANIZATION_ID);
+        props.put(Constants.EVENT_PROP_ORGANIZATION, organization);
+
+        when(organizationManager.resolveTenantDomain(anyString())).thenReturn(TENANT_DOMAIN);
+        when(organizationManager.getOrganization(anyString(), anyBoolean(), anyBoolean())).thenReturn(organization);
+        when(organization.getVersion()).thenReturn(V1);
+
+        Event event = new Event(Constants.EVENT_PRE_UPDATE_ORGANIZATION, props);
+        handler.handleEvent(event);
+        // Checking that the CacheBackedIdPMgtDAO is not constructed to verify that no cache clearing is attempted.
+        assertTrue(mockedDaoConstruction.constructed().isEmpty(), "CacheBackedIdPMgtDAO should not be constructed");
+
+    }
+
+    @Test
+    public void testHandlePreUpdateOrganizationWithVersionChange() throws Exception {
+
+        Map<String, Object> props = new HashMap<>();
+        props.put(Constants.EVENT_PROP_ORGANIZATION_ID, ORGANIZATION_ID);
+        props.put(Constants.EVENT_PROP_ORGANIZATION, organization);
+
+        when(organizationManager.resolveTenantDomain(anyString())).thenReturn(TENANT_DOMAIN);
+        when(organizationManager.getOrganization(anyString(), anyBoolean(), anyBoolean())).thenReturn(organization);
+        when(organization.getVersion()).thenReturn(V0).thenReturn(V1);
+
+        Event event = new Event(Constants.EVENT_PRE_UPDATE_ORGANIZATION, props);
+        handler.handleEvent(event);
+        // Checking that the CacheBackedIdPMgtDAO is constructed to verify that cache clearing is attempted.
+        assertNotNull(mockedDaoConstruction, "CacheBackedIdPMgtDAO should be constructed.");
+    }
+
+    @Test
+    public void testHandlePrePatchOrganizationWithVersionChange() throws Exception {
+
+        PatchOperation patch = mock(PatchOperation.class);
+        when(patch.getPath()).thenReturn(OrganizationManagementConstants.PATCH_PATH_ORG_VERSION);
+        when(patch.getValue()).thenReturn(V1);
+        List<PatchOperation> patches = Collections.singletonList(patch);
+        Map<String, Object> props = new HashMap<>();
+        props.put(Constants.EVENT_PROP_ORGANIZATION_ID, ORGANIZATION_ID);
+        props.put(Constants.EVENT_PROP_PATCH_OPERATIONS, patches);
+
+        when(organizationManager.resolveTenantDomain(anyString())).thenReturn(TENANT_DOMAIN);
+        when(organizationManager.getOrganization(anyString(), anyBoolean(), anyBoolean())).thenReturn(organization);
+        when(organization.getVersion()).thenReturn(V0).thenReturn(V1);
+
+        Event event = new Event(Constants.EVENT_PRE_PATCH_ORGANIZATION, props);
+        handler.handleEvent(event);
+        // Checking that the CacheBackedIdPMgtDAO is constructed to verify that cache clearing is attempted.
+        assertNotNull(mockedDaoConstruction, "CacheBackedIdPMgtDAO should be constructed.");
+    }
+
+    @Test
+    public void testHandlePrePatchOrganizationNoVersionChange() throws Exception {
+
+        PatchOperation patch = mock(PatchOperation.class);
+        when(patch.getPath()).thenReturn(OrganizationManagementConstants.PATCH_PATH_ORG_VERSION);
+        when(patch.getValue()).thenReturn(V0);
+        List<PatchOperation> patches = Collections.singletonList(patch);
+        Map<String, Object> props = new HashMap<>();
+        props.put(Constants.EVENT_PROP_ORGANIZATION_ID, ORGANIZATION_ID);
+        props.put(Constants.EVENT_PROP_PATCH_OPERATIONS, patches);
+
+        when(organizationManager.resolveTenantDomain(anyString())).thenReturn(TENANT_DOMAIN);
+        when(organizationManager.getOrganization(anyString(), anyBoolean(), anyBoolean())).thenReturn(organization);
+        when(organization.getVersion()).thenReturn(V0);
+
+        Event event = new Event(Constants.EVENT_PRE_PATCH_ORGANIZATION, props);
+        handler.handleEvent(event);
+        // Checking that the CacheBackedIdPMgtDAO is not constructed to verify that no cache clearing is attempted.
+        assertTrue(mockedDaoConstruction.constructed().isEmpty(), "CacheBackedIdPMgtDAO should not be constructed");
+    }
+}


### PR DESCRIPTION
### Purpose
Adding an event handler to handle operations related to organization version updates. 

Current implementation includes logic to clear IDP cache in pre-patch and pre-update organization version events to make sure correct login & registration related configuration values are resolved when inheritance is enabled/disabled. 

### Related issue
- https://github.com/wso2/product-is/issues/24463