### PR TITLE
Add Organization Discovery Handler Implementation

### DIFF
--- a/components/org.wso2.carbon.identity.organization.discovery.service/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.discovery.service/pom.xml
@@ -60,6 +60,10 @@
             <artifactId>org.wso2.carbon.identity.claim.metadata.mgt</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.mgt</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.identity.governance</groupId>
             <artifactId>org.wso2.carbon.identity.governance</artifactId>
         </dependency>
@@ -130,12 +134,15 @@
                             org.wso2.carbon.identity.organization.management.service.util;version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.util; version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.application.authentication.framework.handler.orgdiscovery; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.handler.request; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.config.model; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.context; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.model; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.exception; version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.application.common; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.application.common.model; version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.application.mgt; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.claim.metadata.mgt; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.claim.metadata.mgt.exception; version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.core;version="${carbon.identity.package.import.version.range}",

--- a/components/org.wso2.carbon.identity.organization.discovery.service/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.discovery.service/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2023-2024, WSO2 LLC. (http://www.wso2.com).
+  ~ Copyright (c) 2023-2025, WSO2 LLC. (http://www.wso2.com).
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/components/org.wso2.carbon.identity.organization.discovery.service/src/main/java/org/wso2/carbon/identity/organization/discovery/service/OrganizationDiscoveryHandlerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.discovery.service/src/main/java/org/wso2/carbon/identity/organization/discovery/service/OrganizationDiscoveryHandlerImpl.java
@@ -118,14 +118,17 @@ public class OrganizationDiscoveryHandlerImpl implements OrganizationDiscoveryHa
         try {
             orgId = OrganizationDiscoveryServiceHolder.getInstance().getOrganizationManager()
                     .resolveOrganizationId(orgHandle);
-            if (StringUtils.isBlank(orgId)) {
+        } catch (OrganizationManagementException e) {
+            if (e instanceof OrganizationManagementClientException &&
+                    OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ORGANIZATION_NOT_FOUND_FOR_TENANT.getCode()
+                            .equals(e.getErrorCode())) {
                 return OrganizationDiscoveryResult.failure(
                         FrameworkConstants.OrgDiscoveryFailureDetails.ORGANIZATION_NOT_FOUND.getCode(),
                         FrameworkConstants.OrgDiscoveryFailureDetails.ORGANIZATION_NOT_FOUND.getMessage());
+            } else {
+                throw new FrameworkException("Error while resolving organization ID for organization handle: "
+                        + orgHandle, e);
             }
-        } catch (OrganizationManagementException e) {
-            throw new FrameworkException("Error while resolving organization ID for organization handle: "
-                    + orgHandle, e);
         }
         return handleOrgDiscoveryByOrgId(orgId, appId, mainAppOrgId);
     }

--- a/components/org.wso2.carbon.identity.organization.discovery.service/src/main/java/org/wso2/carbon/identity/organization/discovery/service/OrganizationDiscoveryHandlerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.discovery.service/src/main/java/org/wso2/carbon/identity/organization/discovery/service/OrganizationDiscoveryHandlerImpl.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.wso2.carbon.identity.organization.config.service.constant.OrganizationConfigConstants.ErrorMessages.ERROR_CODE_DISCOVERY_CONFIG_NOT_EXIST;
+import static org.wso2.carbon.identity.organization.discovery.service.constant.DiscoveryConstants.EMAIL_DOMAIN_DISCOVERY_TYPE;
 import static org.wso2.carbon.identity.organization.discovery.service.constant.DiscoveryConstants.ENABLE_CONFIG;
 
 /**
@@ -76,7 +77,7 @@ public class OrganizationDiscoveryHandlerImpl implements OrganizationDiscoveryHa
         } else if (StringUtils.isNotBlank(orgDiscoveryInput.getLoginHint())) {
             String loginHint = orgDiscoveryInput.getLoginHint();
             String orgDiscoveryType = StringUtils.isNotBlank(orgDiscoveryInput.getOrgDiscoveryType()) ?
-                    orgDiscoveryInput.getOrgDiscoveryType() : "emailDomain";
+                    orgDiscoveryInput.getOrgDiscoveryType() : EMAIL_DOMAIN_DISCOVERY_TYPE;
             return handleOrgDiscoveryByLoginHint(loginHint, appId, mainAppOrgId, orgDiscoveryType, context);
         } else {
             //TODO: Need to handle the default this based on the default parameter.
@@ -201,15 +202,15 @@ public class OrganizationDiscoveryHandlerImpl implements OrganizationDiscoveryHa
                 StringUtils.isNotBlank(orgDiscoveryInput.getOrgName());
     }
 
-    private Optional<String> getSharedApplicationId(String appName, String appResideOrgId, String sharedOrgId)
+    private Optional<String> getSharedApplicationId(String appId, String appResideOrgId, String sharedOrgId)
             throws FrameworkException {
 
         String sharedAppId;
         try {
             sharedAppId = OrganizationDiscoveryServiceHolder.getInstance().getApplicationManagementService()
-                    .getSharedAppId(appName, appResideOrgId, sharedOrgId);
+                    .getSharedAppId(appId, appResideOrgId, sharedOrgId);
         } catch (IdentityApplicationManagementException e) {
-            throw new FrameworkException("Error while retrieving shared application id: " + appName
+            throw new FrameworkException("Error while retrieving shared application id: " + appId
                     + " for organization ID: " + sharedOrgId, e);
         }
         return Optional.ofNullable(sharedAppId);

--- a/components/org.wso2.carbon.identity.organization.discovery.service/src/main/java/org/wso2/carbon/identity/organization/discovery/service/OrganizationDiscoveryHandlerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.discovery.service/src/main/java/org/wso2/carbon/identity/organization/discovery/service/OrganizationDiscoveryHandlerImpl.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.discovery.service;
+
+import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
+import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
+import org.wso2.carbon.identity.application.authentication.framework.handler.orgdiscovery.OrganizationDiscoveryHandler;
+import org.wso2.carbon.identity.application.authentication.framework.model.OrganizationDiscoveryInput;
+import org.wso2.carbon.identity.application.authentication.framework.model.OrganizationDiscoveryResult;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
+import org.wso2.carbon.identity.organization.config.service.exception.OrganizationConfigException;
+import org.wso2.carbon.identity.organization.config.service.model.ConfigProperty;
+import org.wso2.carbon.identity.organization.config.service.model.DiscoveryConfig;
+import org.wso2.carbon.identity.organization.discovery.service.internal.OrganizationDiscoveryServiceHolder;
+import org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementClientException;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.identity.organization.management.service.model.BasicOrganization;
+import org.wso2.carbon.identity.organization.management.service.model.Organization;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.wso2.carbon.identity.organization.config.service.constant.OrganizationConfigConstants.ErrorMessages.ERROR_CODE_DISCOVERY_CONFIG_NOT_EXIST;
+import static org.wso2.carbon.identity.organization.discovery.service.constant.DiscoveryConstants.ENABLE_CONFIG;
+
+/**
+ * Implementation of the Organization Discovery Handler.
+ */
+public class OrganizationDiscoveryHandlerImpl implements OrganizationDiscoveryHandler {
+
+    @Override
+    public OrganizationDiscoveryResult discoverOrganization(OrganizationDiscoveryInput orgDiscoveryInput,
+                                                            AuthenticationContext context)
+            throws FrameworkException {
+
+        boolean validDiscoveryParams = validateDiscoveryParameters(orgDiscoveryInput);
+        if (!validDiscoveryParams) {
+            return OrganizationDiscoveryResult.failure(
+                    FrameworkConstants.OrgDiscoveryFailureDetails.VALID_DISCOVERY_PARAMETERS_NOT_FOUND.getCode(),
+                    FrameworkConstants.OrgDiscoveryFailureDetails.VALID_DISCOVERY_PARAMETERS_NOT_FOUND.getMessage());
+        }
+
+        String appId = context.getServiceProviderResourceId();
+        String mainAppResideTenantDomain = context.getTenantDomain();
+        String mainAppOrgId;
+        try {
+            mainAppOrgId = OrganizationDiscoveryServiceHolder.getInstance().getOrganizationManager()
+                    .resolveOrganizationId(mainAppResideTenantDomain);
+        } catch (OrganizationManagementException e) {
+            throw new FrameworkException("Error while getting organization ID for tenant domain: "
+                    + mainAppResideTenantDomain, e);
+        }
+
+        if (StringUtils.isNotBlank(orgDiscoveryInput.getOrgId())) {
+            return handleOrgDiscoveryByOrgId(orgDiscoveryInput.getOrgId(), appId, mainAppOrgId);
+        } else if (StringUtils.isNotBlank(orgDiscoveryInput.getLoginHint())) {
+            String loginHint = orgDiscoveryInput.getLoginHint();
+            String orgDiscoveryType = StringUtils.isNotBlank(orgDiscoveryInput.getOrgDiscoveryType()) ?
+                    orgDiscoveryInput.getOrgDiscoveryType() : "emailDomain";
+            return handleOrgDiscoveryByLoginHint(loginHint, appId, mainAppOrgId, orgDiscoveryType, context);
+        } else {
+            //TODO: Need to handle the default this based on the default parameter.
+            if (StringUtils.isNotBlank(orgDiscoveryInput.getOrgHandle())) {
+                return handleOrgDiscoveryByOrgHandle(orgDiscoveryInput.getOrgHandle(), appId, mainAppOrgId);
+            } else if (StringUtils.isNotBlank(orgDiscoveryInput.getOrgName())) {
+                return handleOrgDiscoveryByOrgName(orgDiscoveryInput.getOrgName(), appId, mainAppOrgId);
+            }
+        }
+        // If any of the above conditions are not met, it means valid discovery parameters are not found.
+        return OrganizationDiscoveryResult.failure(
+                FrameworkConstants.OrgDiscoveryFailureDetails.VALID_DISCOVERY_PARAMETERS_NOT_FOUND.getCode(),
+                FrameworkConstants.OrgDiscoveryFailureDetails.VALID_DISCOVERY_PARAMETERS_NOT_FOUND.getMessage());
+    }
+
+    private OrganizationDiscoveryResult handleOrgDiscoveryByOrgId(String orgId, String appId, String mainAppOrgId)
+            throws FrameworkException {
+
+        Optional<BasicOrganization> organization = getBasicOrganizationDetails(orgId);
+        if (!organization.isPresent()) {
+            return OrganizationDiscoveryResult.failure(
+                    FrameworkConstants.OrgDiscoveryFailureDetails.ORGANIZATION_NOT_FOUND.getCode(),
+                    FrameworkConstants.OrgDiscoveryFailureDetails.ORGANIZATION_NOT_FOUND.getMessage());
+        }
+        Optional<String> sharedApplicationId = getSharedApplicationId(appId, mainAppOrgId, orgId);
+        if (!sharedApplicationId.isPresent()) {
+            return OrganizationDiscoveryResult.failure(
+                    FrameworkConstants.OrgDiscoveryFailureDetails.APPLICATION_NOT_SHARED.getCode(),
+                    FrameworkConstants.OrgDiscoveryFailureDetails.APPLICATION_NOT_SHARED.getMessage());
+        }
+        return OrganizationDiscoveryResult.success(organization.get(), sharedApplicationId.get());
+    }
+
+    private OrganizationDiscoveryResult handleOrgDiscoveryByOrgHandle(String orgHandle, String appId,
+                                                                      String mainAppOrgId)
+            throws FrameworkException {
+
+        String orgId;
+        try {
+            orgId = OrganizationDiscoveryServiceHolder.getInstance().getOrganizationManager()
+                    .resolveOrganizationId(orgHandle);
+            if (StringUtils.isBlank(orgId)) {
+                return OrganizationDiscoveryResult.failure(
+                        FrameworkConstants.OrgDiscoveryFailureDetails.ORGANIZATION_NOT_FOUND.getCode(),
+                        FrameworkConstants.OrgDiscoveryFailureDetails.ORGANIZATION_NOT_FOUND.getMessage());
+            }
+        } catch (OrganizationManagementException e) {
+            throw new FrameworkException("Error while resolving organization ID for organization handle: "
+                    + orgHandle, e);
+        }
+        return handleOrgDiscoveryByOrgId(orgId, appId, mainAppOrgId);
+    }
+
+    private OrganizationDiscoveryResult handleOrgDiscoveryByOrgName(String orgName, String appId,
+                                                                    String mainAppOrgId)
+            throws FrameworkException {
+
+        String orgId;
+        try {
+            orgId = OrganizationDiscoveryServiceHolder.getInstance().getOrganizationManager()
+                    .getOrganizationIdByName(orgName);
+            if (StringUtils.isBlank(orgId)) {
+                return OrganizationDiscoveryResult.failure(
+                        FrameworkConstants.OrgDiscoveryFailureDetails.ORGANIZATION_NOT_FOUND.getCode(),
+                        FrameworkConstants.OrgDiscoveryFailureDetails.ORGANIZATION_NOT_FOUND.getMessage());
+            }
+        } catch (OrganizationManagementException e) {
+            throw new FrameworkException("Error while resolving organization ID for organization name: "
+                    + orgName, e);
+        }
+        return handleOrgDiscoveryByOrgId(orgId, appId, mainAppOrgId);
+    }
+
+    private OrganizationDiscoveryResult handleOrgDiscoveryByLoginHint(String loginHint, String appId,
+                                                                      String mainAppOrgId, String orgDiscoveryType,
+                                                                      AuthenticationContext context)
+            throws FrameworkException {
+
+        if (!isOrganizationDiscoveryTypeEnabled(orgDiscoveryType)) {
+            return OrganizationDiscoveryResult.failure(
+                    FrameworkConstants.OrgDiscoveryFailureDetails.ORGANIZATION_DISCOVERY_TYPE_NOT_ENABLED_OR_SUPPORTED
+                            .getCode(),
+                    FrameworkConstants.OrgDiscoveryFailureDetails.ORGANIZATION_DISCOVERY_TYPE_NOT_ENABLED_OR_SUPPORTED
+                            .getMessage());
+        }
+        try {
+            String orgId = OrganizationDiscoveryServiceHolder.getInstance()
+                    .getOrganizationDiscoveryManager()
+                    .getOrganizationIdByDiscoveryAttribute(orgDiscoveryType, loginHint, mainAppOrgId, context);
+            if (StringUtils.isBlank(orgId)) {
+                return OrganizationDiscoveryResult.failure(
+                        FrameworkConstants.OrgDiscoveryFailureDetails.ORGANIZATION_NOT_FOUND.getCode(),
+                        FrameworkConstants.OrgDiscoveryFailureDetails.ORGANIZATION_NOT_FOUND.getMessage());
+            }
+            Optional<BasicOrganization> organization = getBasicOrganizationDetails(orgId);
+            if (!organization.isPresent()) {
+                return OrganizationDiscoveryResult.failure(
+                        FrameworkConstants.OrgDiscoveryFailureDetails.ORGANIZATION_NOT_FOUND.getCode(),
+                        FrameworkConstants.OrgDiscoveryFailureDetails.ORGANIZATION_NOT_FOUND.getMessage());
+            }
+            Optional<String> sharedApplicationId = getSharedApplicationId(appId, mainAppOrgId, orgId);
+            if (!sharedApplicationId.isPresent()) {
+                return OrganizationDiscoveryResult.failure(
+                        FrameworkConstants.OrgDiscoveryFailureDetails.APPLICATION_NOT_SHARED.getCode(),
+                        FrameworkConstants.OrgDiscoveryFailureDetails.APPLICATION_NOT_SHARED.getMessage());
+            }
+            return OrganizationDiscoveryResult.success(organization.get(), sharedApplicationId.get());
+        } catch (OrganizationManagementException e) {
+            throw new FrameworkException("Error while discovering organization by login hint for application: "
+                    + appId + " in organization ID: " + mainAppOrgId, e);
+        }
+    }
+
+    private boolean validateDiscoveryParameters(OrganizationDiscoveryInput orgDiscoveryInput) {
+
+        return StringUtils.isNotBlank(orgDiscoveryInput.getOrgId()) ||
+                StringUtils.isNotBlank(orgDiscoveryInput.getLoginHint()) ||
+                StringUtils.isNotBlank(orgDiscoveryInput.getOrgHandle()) ||
+                StringUtils.isNotBlank(orgDiscoveryInput.getOrgName());
+    }
+
+    private Optional<String> getSharedApplicationId(String appName, String appResideOrgId, String sharedOrgId)
+            throws FrameworkException {
+
+        String sharedAppId;
+        try {
+            sharedAppId = OrganizationDiscoveryServiceHolder.getInstance().getApplicationManagementService()
+                    .getSharedAppId(appName, appResideOrgId, sharedOrgId);
+        } catch (IdentityApplicationManagementException e) {
+            throw new FrameworkException("Error while retrieving shared application id: " + appName
+                    + " for organization ID: " + sharedOrgId, e);
+        }
+        return Optional.ofNullable(sharedAppId);
+    }
+
+    private Optional<BasicOrganization> getBasicOrganizationDetails(String orgId) throws FrameworkException {
+
+        Organization organization;
+        try {
+            //TODO: Need to introduce a new method to get basic organization details.
+            organization = OrganizationDiscoveryServiceHolder.getInstance()
+                    .getOrganizationManager().getOrganization(orgId, false, false);
+        } catch (OrganizationManagementException e) {
+            if (e instanceof OrganizationManagementClientException &&
+                    OrganizationManagementConstants.ErrorMessages.ERROR_CODE_INVALID_ORGANIZATION.getCode()
+                            .equals(e.getErrorCode())) {
+                return Optional.empty();
+            } else {
+                throw new FrameworkException("Error while retrieving organization details for organization ID: "
+                        + orgId, e);
+            }
+        }
+        BasicOrganization basicOrganization = new BasicOrganization();
+        basicOrganization.setId(orgId);
+        basicOrganization.setName(organization.getName());
+        basicOrganization.setOrganizationHandle(organization.getOrganizationHandle());
+        return Optional.of(basicOrganization);
+    }
+
+    private boolean isOrganizationDiscoveryTypeEnabled(String discoveryType) throws FrameworkException {
+
+        try {
+            DiscoveryConfig discoveryConfig = OrganizationDiscoveryServiceHolder.getInstance()
+                    .getOrganizationConfigManager().getDiscoveryConfiguration();
+            Map<String, AttributeBasedOrganizationDiscoveryHandler> discoveryHandlers =
+                    OrganizationDiscoveryServiceHolder.getInstance().getAttributeBasedOrganizationDiscoveryHandlers();
+
+            List<ConfigProperty> configProperties = discoveryConfig.getConfigProperties();
+            for (ConfigProperty configProperty : configProperties) {
+                String type = configProperty.getKey().split(ENABLE_CONFIG)[0];
+                if (discoveryType.equals(type) && discoveryHandlers.get(type) != null &&
+                        Boolean.parseBoolean(configProperty.getValue())) {
+                    return true;
+                }
+            }
+        } catch (OrganizationConfigException e) {
+            if (ERROR_CODE_DISCOVERY_CONFIG_NOT_EXIST.getCode().equals(e.getErrorCode())) {
+                return false;
+            }
+            throw new FrameworkException("Error while retrieving organization discovery configuration.", e);
+        }
+        return false;
+    }
+}

--- a/components/org.wso2.carbon.identity.organization.discovery.service/src/main/java/org/wso2/carbon/identity/organization/discovery/service/OrganizationDiscoveryHandlerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.discovery.service/src/main/java/org/wso2/carbon/identity/organization/discovery/service/OrganizationDiscoveryHandlerImpl.java
@@ -32,7 +32,6 @@ import org.wso2.carbon.identity.organization.config.service.model.DiscoveryConfi
 import org.wso2.carbon.identity.organization.discovery.service.internal.OrganizationDiscoveryServiceHolder;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementClientException;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
-import org.wso2.carbon.identity.organization.management.service.model.BasicOrganization;
 import org.wso2.carbon.identity.organization.management.service.model.Organization;
 
 import java.util.List;
@@ -98,7 +97,7 @@ public class OrganizationDiscoveryHandlerImpl implements OrganizationDiscoveryHa
     private OrganizationDiscoveryResult handleOrgDiscoveryByOrgId(String orgId, String appId, String mainAppOrgId)
             throws FrameworkException {
 
-        Optional<BasicOrganization> organization = getBasicOrganizationDetails(orgId);
+        Optional<Organization> organization = getOrganization(orgId);
         if (!organization.isPresent()) {
             return OrganizationDiscoveryResult.failure(
                     FrameworkConstants.OrgDiscoveryFailureDetails.ORGANIZATION_NOT_FOUND.getCode(),
@@ -176,7 +175,7 @@ public class OrganizationDiscoveryHandlerImpl implements OrganizationDiscoveryHa
                         FrameworkConstants.OrgDiscoveryFailureDetails.ORGANIZATION_NOT_FOUND.getCode(),
                         FrameworkConstants.OrgDiscoveryFailureDetails.ORGANIZATION_NOT_FOUND.getMessage());
             }
-            Optional<BasicOrganization> organization = getBasicOrganizationDetails(orgId);
+            Optional<Organization> organization = getOrganization(orgId);
             if (!organization.isPresent()) {
                 return OrganizationDiscoveryResult.failure(
                         FrameworkConstants.OrgDiscoveryFailureDetails.ORGANIZATION_NOT_FOUND.getCode(),
@@ -217,13 +216,12 @@ public class OrganizationDiscoveryHandlerImpl implements OrganizationDiscoveryHa
         return Optional.ofNullable(sharedAppId);
     }
 
-    private Optional<BasicOrganization> getBasicOrganizationDetails(String orgId) throws FrameworkException {
+    private Optional<Organization> getOrganization(String orgId) throws FrameworkException {
 
-        Organization organization;
         try {
-            //TODO: Need to introduce a new method to get basic organization details.
-            organization = OrganizationDiscoveryServiceHolder.getInstance()
+            Organization organization = OrganizationDiscoveryServiceHolder.getInstance()
                     .getOrganizationManager().getOrganization(orgId, false, false);
+            return Optional.of(organization);
         } catch (OrganizationManagementException e) {
             if (e instanceof OrganizationManagementClientException &&
                     (ERROR_CODE_INVALID_ORGANIZATION.getCode().equals(e.getErrorCode()) ||
@@ -234,11 +232,6 @@ public class OrganizationDiscoveryHandlerImpl implements OrganizationDiscoveryHa
                         + orgId, e);
             }
         }
-        BasicOrganization basicOrganization = new BasicOrganization();
-        basicOrganization.setId(orgId);
-        basicOrganization.setName(organization.getName());
-        basicOrganization.setOrganizationHandle(organization.getOrganizationHandle());
-        return Optional.of(basicOrganization);
     }
 
     private boolean isOrganizationDiscoveryTypeEnabled(String discoveryType) throws FrameworkException {

--- a/components/org.wso2.carbon.identity.organization.discovery.service/src/main/java/org/wso2/carbon/identity/organization/discovery/service/OrganizationDiscoveryHandlerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.discovery.service/src/main/java/org/wso2/carbon/identity/organization/discovery/service/OrganizationDiscoveryHandlerImpl.java
@@ -30,7 +30,6 @@ import org.wso2.carbon.identity.organization.config.service.exception.Organizati
 import org.wso2.carbon.identity.organization.config.service.model.ConfigProperty;
 import org.wso2.carbon.identity.organization.config.service.model.DiscoveryConfig;
 import org.wso2.carbon.identity.organization.discovery.service.internal.OrganizationDiscoveryServiceHolder;
-import org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementClientException;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 import org.wso2.carbon.identity.organization.management.service.model.BasicOrganization;
@@ -43,6 +42,9 @@ import java.util.Optional;
 import static org.wso2.carbon.identity.organization.config.service.constant.OrganizationConfigConstants.ErrorMessages.ERROR_CODE_DISCOVERY_CONFIG_NOT_EXIST;
 import static org.wso2.carbon.identity.organization.discovery.service.constant.DiscoveryConstants.EMAIL_DOMAIN_DISCOVERY_TYPE;
 import static org.wso2.carbon.identity.organization.discovery.service.constant.DiscoveryConstants.ENABLE_CONFIG;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_INVALID_ORGANIZATION;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ORGANIZATION_NOT_FOUND_FOR_TENANT;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_UNAUTHORIZED_ORG_ACCESS;
 
 /**
  * Implementation of the Organization Discovery Handler.
@@ -121,8 +123,7 @@ public class OrganizationDiscoveryHandlerImpl implements OrganizationDiscoveryHa
                     .resolveOrganizationId(orgHandle);
         } catch (OrganizationManagementException e) {
             if (e instanceof OrganizationManagementClientException &&
-                    OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ORGANIZATION_NOT_FOUND_FOR_TENANT.getCode()
-                            .equals(e.getErrorCode())) {
+                    ERROR_CODE_ORGANIZATION_NOT_FOUND_FOR_TENANT.getCode().equals(e.getErrorCode())) {
                 return OrganizationDiscoveryResult.failure(
                         FrameworkConstants.OrgDiscoveryFailureDetails.ORGANIZATION_NOT_FOUND.getCode(),
                         FrameworkConstants.OrgDiscoveryFailureDetails.ORGANIZATION_NOT_FOUND.getMessage());
@@ -225,8 +226,8 @@ public class OrganizationDiscoveryHandlerImpl implements OrganizationDiscoveryHa
                     .getOrganizationManager().getOrganization(orgId, false, false);
         } catch (OrganizationManagementException e) {
             if (e instanceof OrganizationManagementClientException &&
-                    OrganizationManagementConstants.ErrorMessages.ERROR_CODE_INVALID_ORGANIZATION.getCode()
-                            .equals(e.getErrorCode())) {
+                    (ERROR_CODE_INVALID_ORGANIZATION.getCode().equals(e.getErrorCode()) ||
+                            ERROR_CODE_UNAUTHORIZED_ORG_ACCESS.getCode().equals(e.getErrorCode()))) {
                 return Optional.empty();
             } else {
                 throw new FrameworkException("Error while retrieving organization details for organization ID: "

--- a/components/org.wso2.carbon.identity.organization.discovery.service/src/main/java/org/wso2/carbon/identity/organization/discovery/service/constant/DiscoveryConstants.java
+++ b/components/org.wso2.carbon.identity.organization.discovery.service/src/main/java/org/wso2/carbon/identity/organization/discovery/service/constant/DiscoveryConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023-2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.organization.discovery.service/src/main/java/org/wso2/carbon/identity/organization/discovery/service/constant/DiscoveryConstants.java
+++ b/components/org.wso2.carbon.identity.organization.discovery.service/src/main/java/org/wso2/carbon/identity/organization/discovery/service/constant/DiscoveryConstants.java
@@ -39,6 +39,7 @@ public class DiscoveryConstants {
     public static final String ENABLE_CONFIG = ".enable";
     public static final String PRE_ADD_USER_EMAIL_DOMAIN_VALIDATE = "PRE_ADD_USER_EMAIL_DOMAIN_VALIDATE";
     public static final String ORGANIZATION_NAME = "organizationName";
+    public static final String EMAIL_DOMAIN_DISCOVERY_TYPE = "emailDomain";
     public static final Set<String> SUPPORTED_OPERATIONS;
     public static final Map<String, String> ATTRIBUTE_COLUMN_MAP;
 

--- a/components/org.wso2.carbon.identity.organization.discovery.service/src/main/java/org/wso2/carbon/identity/organization/discovery/service/internal/OrganizationDiscoveryServiceComponent.java
+++ b/components/org.wso2.carbon.identity.organization.discovery.service/src/main/java/org/wso2/carbon/identity/organization/discovery/service/internal/OrganizationDiscoveryServiceComponent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2023-2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/components/org.wso2.carbon.identity.organization.discovery.service/src/main/java/org/wso2/carbon/identity/organization/discovery/service/internal/OrganizationDiscoveryServiceHolder.java
+++ b/components/org.wso2.carbon.identity.organization.discovery.service/src/main/java/org/wso2/carbon/identity/organization/discovery/service/internal/OrganizationDiscoveryServiceHolder.java
@@ -18,9 +18,11 @@
 
 package org.wso2.carbon.identity.organization.discovery.service.internal;
 
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
 import org.wso2.carbon.identity.organization.config.service.AttributeBasedOrganizationDiscoveryHandlerRegistry;
 import org.wso2.carbon.identity.organization.config.service.OrganizationConfigManager;
 import org.wso2.carbon.identity.organization.discovery.service.AttributeBasedOrganizationDiscoveryHandler;
+import org.wso2.carbon.identity.organization.discovery.service.OrganizationDiscoveryManager;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 
 import java.util.HashMap;
@@ -33,8 +35,10 @@ import java.util.Set;
 public class OrganizationDiscoveryServiceHolder {
 
     private static final OrganizationDiscoveryServiceHolder instance = new OrganizationDiscoveryServiceHolder();
+    private ApplicationManagementService applicationManagementService;
     private OrganizationManager organizationManager = null;
     private OrganizationConfigManager organizationConfigManager = null;
+    private OrganizationDiscoveryManager organizationDiscoveryManager;
     private Map<String, AttributeBasedOrganizationDiscoveryHandler> attributeBasedOrganizationDiscoveryHandlerMap;
 
     public static OrganizationDiscoveryServiceHolder getInstance() {
@@ -97,5 +101,25 @@ public class OrganizationDiscoveryServiceHolder {
                                                                          attributeBasedOrganizationDiscoveryHandler) {
 
         attributeBasedOrganizationDiscoveryHandlerMap.remove(attributeBasedOrganizationDiscoveryHandler.getType());
+    }
+
+    public OrganizationDiscoveryManager getOrganizationDiscoveryManager() {
+
+        return organizationDiscoveryManager;
+    }
+
+    public void setOrganizationDiscoveryManager(OrganizationDiscoveryManager organizationDiscoveryManager) {
+
+        this.organizationDiscoveryManager = organizationDiscoveryManager;
+    }
+
+    public ApplicationManagementService getApplicationManagementService() {
+
+        return applicationManagementService;
+    }
+
+    public void setApplicationManagementService(ApplicationManagementService applicationManagementService) {
+
+        this.applicationManagementService = applicationManagementService;
     }
 }

--- a/components/org.wso2.carbon.identity.organization.discovery.service/src/test/java/org.wso2.carbon.identity.organization.discovery.service/OrganizationDiscoveryHandlerImplTest.java
+++ b/components/org.wso2.carbon.identity.organization.discovery.service/src/test/java/org.wso2.carbon.identity.organization.discovery.service/OrganizationDiscoveryHandlerImplTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.discovery.service;
+
+import org.mockito.Mock;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
+import org.wso2.carbon.identity.application.authentication.framework.model.OrganizationDiscoveryInput;
+import org.wso2.carbon.identity.application.authentication.framework.model.OrganizationDiscoveryResult;
+import org.wso2.carbon.identity.application.mgt.ApplicationManagementService;
+import org.wso2.carbon.identity.organization.config.service.OrganizationConfigManager;
+import org.wso2.carbon.identity.organization.config.service.model.ConfigProperty;
+import org.wso2.carbon.identity.organization.config.service.model.DiscoveryConfig;
+import org.wso2.carbon.identity.organization.discovery.service.internal.OrganizationDiscoveryServiceHolder;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementClientException;
+import org.wso2.carbon.identity.organization.management.service.model.Organization;
+
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.OrgDiscoveryFailureDetails.ORGANIZATION_DISCOVERY_TYPE_NOT_ENABLED_OR_SUPPORTED;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.OrgDiscoveryFailureDetails.ORGANIZATION_NOT_FOUND;
+import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.OrgDiscoveryFailureDetails.VALID_DISCOVERY_PARAMETERS_NOT_FOUND;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_INVALID_ORGANIZATION;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ORGANIZATION_NOT_FOUND_FOR_TENANT;
+
+/**
+ * Test class for Organization Discovery Handler Implementation.
+ */
+public class OrganizationDiscoveryHandlerImplTest {
+
+    private static final String ROOT_ORG_ID = "rootOrgId";
+    private static final String ROOT_TENANT_DOMAIN = "rootTenantDomain";
+    private static final String MAIN_APP_ID = "mainAppId";
+    private static final String ORG_ID = "orgId";
+    private static final String INVALID_ORG_ID = "invalidOrgId";
+    private static final String ORG_HANDLE = "orgHandle";
+    private static final String INVALID_ORG_HANDLE = "invalidOrgHandle";
+    private static final String ORG_NAME = "orgName";
+    private static final String INVALID_ORG_NAME = "invalidOrgName";
+    private static final String LOGIN_HINT = "loginHint";
+    private static final String INVALID_LOGIN_HINT = "invalidLoginHint";
+    private static final String ORG_DISCOVERY_TYPE = "emailDomain";
+    private static final String INVALID_ORG_DISCOVERY_TYPE = "invalidOrgDiscoveryType";
+    private static final String SHARED_APP_ID = "sharedAppId";
+
+    private final OrganizationDiscoveryHandlerImpl organizationDiscoveryHandler =
+            new OrganizationDiscoveryHandlerImpl();
+
+    private AutoCloseable closeable;
+    @Mock
+    private OrganizationManager organizationManager;
+    @Mock
+    private ApplicationManagementService applicationManagementService;
+    @Mock
+    private OrganizationDiscoveryManager organizationDiscoveryManager;
+    @Mock
+    private OrganizationConfigManager organizationConfigManager;
+    @Mock
+    private AuthenticationContext authenticationContext;
+
+    @BeforeClass
+    public void setUp() throws Exception {
+
+        closeable = openMocks(this);
+
+        OrganizationDiscoveryServiceHolder.getInstance().setOrganizationManager(organizationManager);
+        OrganizationDiscoveryServiceHolder.getInstance().setApplicationManagementService(applicationManagementService);
+        OrganizationDiscoveryServiceHolder.getInstance().setOrganizationDiscoveryManager(organizationDiscoveryManager);
+        OrganizationDiscoveryServiceHolder.getInstance().setOrganizationConfigManager(organizationConfigManager);
+
+        when(authenticationContext.getServiceProviderResourceId()).thenReturn(MAIN_APP_ID);
+        when(authenticationContext.getTenantDomain()).thenReturn(ROOT_TENANT_DOMAIN);
+
+        when(organizationManager.resolveOrganizationId(ROOT_TENANT_DOMAIN)).thenReturn(ROOT_ORG_ID);
+
+        Organization organization = new Organization();
+        organization.setId(ORG_ID);
+        organization.setOrganizationHandle(ORG_HANDLE);
+        organization.setName(ORG_NAME);
+        when(organizationManager.getOrganization(ORG_ID, false, false))
+                .thenReturn(organization);
+        when(organizationManager.getOrganization(INVALID_ORG_ID, false, false))
+                .thenThrow(new OrganizationManagementClientException(
+                        ERROR_CODE_INVALID_ORGANIZATION.getMessage(),
+                        ERROR_CODE_INVALID_ORGANIZATION.getDescription(),
+                        ERROR_CODE_INVALID_ORGANIZATION.getCode()));
+
+        when(organizationManager.resolveOrganizationId(ORG_HANDLE)).thenReturn(ORG_ID);
+        when(organizationManager.resolveOrganizationId(INVALID_ORG_HANDLE))
+                .thenThrow(new OrganizationManagementClientException(
+                        ERROR_CODE_ORGANIZATION_NOT_FOUND_FOR_TENANT.getMessage(),
+                        ERROR_CODE_ORGANIZATION_NOT_FOUND_FOR_TENANT.getDescription(),
+                        ERROR_CODE_ORGANIZATION_NOT_FOUND_FOR_TENANT.getCode()));
+
+        when(organizationManager.getOrganizationIdByName(ORG_NAME)).thenReturn(ORG_ID);
+        when(organizationManager.getOrganizationIdByName(INVALID_ORG_NAME)).thenReturn(null);
+
+        when(organizationDiscoveryManager.getOrganizationIdByDiscoveryAttribute(
+                ORG_DISCOVERY_TYPE, LOGIN_HINT, ROOT_ORG_ID, authenticationContext)).thenReturn(ORG_ID);
+        when(organizationDiscoveryManager.getOrganizationIdByDiscoveryAttribute(
+                ORG_DISCOVERY_TYPE, INVALID_LOGIN_HINT, ROOT_ORG_ID, authenticationContext)).thenReturn(null);
+
+        ConfigProperty emailDomainDiscoveryEnableConfig = new ConfigProperty("emailDomain.enable", "true");
+        List<ConfigProperty> discoveryConfigurationList = List.of(emailDomainDiscoveryEnableConfig);
+        DiscoveryConfig discoveryConfig = new DiscoveryConfig(discoveryConfigurationList);
+        when(organizationConfigManager.getDiscoveryConfiguration()).thenReturn(discoveryConfig);
+        OrganizationDiscoveryServiceHolder.getInstance().setAttributeBasedOrganizationDiscoveryHandler(
+                new EmailDomainBasedDiscoveryHandler());
+
+        when(applicationManagementService.getSharedAppId(MAIN_APP_ID, ROOT_ORG_ID, ORG_ID)).thenReturn(SHARED_APP_ID);
+    }
+
+    @AfterClass
+    public void tearDown() throws Exception {
+
+        closeable.close();
+    }
+
+    @DataProvider
+    public Object[][] discoverOrganizationSuccessDataProvider() {
+
+        return new Object[][]{
+                {ORG_ID, null, null, null, null},
+                {null, ORG_HANDLE, null, null, null},
+                {null, null, ORG_NAME, null, null},
+                {null, null, null, LOGIN_HINT, null},
+                {null, null, null, LOGIN_HINT, ORG_DISCOVERY_TYPE},
+        };
+    }
+
+    @Test(dataProvider = "discoverOrganizationSuccessDataProvider")
+    public void testDiscoverOrganizationSuccess(String orgId, String orgHandle, String orgName, String loginHint,
+                                                String orgDiscoveryType) throws Exception {
+
+        OrganizationDiscoveryInput orgDiscoveryInput = new OrganizationDiscoveryInput.Builder()
+                .orgId(orgId)
+                .orgHandle(orgHandle)
+                .orgName(orgName)
+                .loginHint(loginHint)
+                .orgDiscoveryType(orgDiscoveryType)
+                .build();
+
+        OrganizationDiscoveryResult orgDiscoveryResult = organizationDiscoveryHandler
+                .discoverOrganization(orgDiscoveryInput, authenticationContext);
+
+        assertTrue(orgDiscoveryResult.isSuccessful(), "Organization discovery should be successful.");
+        assertNotNull(orgDiscoveryResult.getDiscoveredOrganization(),
+                "Discovered organization should not be null.");
+        assertEquals(orgDiscoveryResult.getDiscoveredOrganization().getId(), ORG_ID,
+                "Discovered organization ID should match the expected ID.");
+        assertEquals(orgDiscoveryResult.getDiscoveredOrganization().getOrganizationHandle(), ORG_HANDLE,
+                "Discovered organization handle should match the expected handle.");
+        assertEquals(orgDiscoveryResult.getDiscoveredOrganization().getName(), ORG_NAME,
+                "Discovered organization name should match the expected name.");
+        assertEquals(orgDiscoveryResult.getSharedApplicationId(), SHARED_APP_ID,
+                "Shared application ID should match the expected shared application ID.");
+    }
+
+    @DataProvider
+    public Object[][] discoverOrganizationFailureDataProvider() {
+
+        return new Object[][]{
+                {null, null, null, null, null, VALID_DISCOVERY_PARAMETERS_NOT_FOUND.getCode()},
+                {INVALID_ORG_ID, null, null, null, null, ORGANIZATION_NOT_FOUND.getCode()},
+                {null, null, INVALID_ORG_NAME, null, null, ORGANIZATION_NOT_FOUND.getCode()},
+                {null, null, null, INVALID_LOGIN_HINT, ORG_DISCOVERY_TYPE, ORGANIZATION_NOT_FOUND.getCode()},
+                {null, null, null, LOGIN_HINT, INVALID_ORG_DISCOVERY_TYPE,
+                        ORGANIZATION_DISCOVERY_TYPE_NOT_ENABLED_OR_SUPPORTED.getCode()},
+        };
+    }
+
+    @Test(dataProvider = "discoverOrganizationFailureDataProvider")
+    public void testDiscoverOrganizationFailure(String orgId, String orgHandle, String orgName, String loginHint,
+                                                String orgDiscoveryType, String failureCode)
+            throws Exception {
+
+        OrganizationDiscoveryInput orgDiscoveryInput = new OrganizationDiscoveryInput.Builder()
+                .orgId(orgId)
+                .orgHandle(orgHandle)
+                .orgName(orgName)
+                .loginHint(loginHint)
+                .orgDiscoveryType(orgDiscoveryType)
+                .build();
+
+        OrganizationDiscoveryResult orgDiscoveryResult = organizationDiscoveryHandler
+                .discoverOrganization(orgDiscoveryInput, authenticationContext);
+
+        assertFalse(orgDiscoveryResult.isSuccessful(), "Organization discovery should be not successful.");
+        assertNotNull(orgDiscoveryResult.getFailureDetails(), "Failure details should not be null.");
+        assertEquals(orgDiscoveryResult.getFailureDetails().getCode(), failureCode,
+                "Failure code should match the expected code.");
+    }
+}

--- a/components/org.wso2.carbon.identity.organization.discovery.service/src/test/java/org.wso2.carbon.identity.organization.discovery.service/OrganizationDiscoveryHandlerImplTest.java
+++ b/components/org.wso2.carbon.identity.organization.discovery.service/src/test/java/org.wso2.carbon.identity.organization.discovery.service/OrganizationDiscoveryHandlerImplTest.java
@@ -188,6 +188,7 @@ public class OrganizationDiscoveryHandlerImplTest {
         return new Object[][]{
                 {null, null, null, null, null, VALID_DISCOVERY_PARAMETERS_NOT_FOUND.getCode()},
                 {INVALID_ORG_ID, null, null, null, null, ORGANIZATION_NOT_FOUND.getCode()},
+                {null, INVALID_ORG_HANDLE, null, null, null, ORGANIZATION_NOT_FOUND.getCode()},
                 {null, null, INVALID_ORG_NAME, null, null, ORGANIZATION_NOT_FOUND.getCode()},
                 {null, null, null, INVALID_LOGIN_HINT, ORG_DISCOVERY_TYPE, ORGANIZATION_NOT_FOUND.getCode()},
                 {null, null, null, LOGIN_HINT, INVALID_ORG_DISCOVERY_TYPE,

--- a/components/org.wso2.carbon.identity.organization.discovery.service/src/test/java/org.wso2.carbon.identity.organization.discovery.service/OrganizationDiscoveryHandlerImplTest.java
+++ b/components/org.wso2.carbon.identity.organization.discovery.service/src/test/java/org.wso2.carbon.identity.organization.discovery.service/OrganizationDiscoveryHandlerImplTest.java
@@ -46,8 +46,8 @@ import static org.testng.Assert.assertTrue;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.OrgDiscoveryFailureDetails.ORGANIZATION_DISCOVERY_TYPE_NOT_ENABLED_OR_SUPPORTED;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.OrgDiscoveryFailureDetails.ORGANIZATION_NOT_FOUND;
 import static org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants.OrgDiscoveryFailureDetails.VALID_DISCOVERY_PARAMETERS_NOT_FOUND;
-import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_INVALID_ORGANIZATION;
 import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_ORGANIZATION_NOT_FOUND_FOR_TENANT;
+import static org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants.ErrorMessages.ERROR_CODE_UNAUTHORIZED_ORG_ACCESS;
 
 /**
  * Test class for Organization Discovery Handler Implementation.
@@ -107,9 +107,9 @@ public class OrganizationDiscoveryHandlerImplTest {
                 .thenReturn(organization);
         when(organizationManager.getOrganization(INVALID_ORG_ID, false, false))
                 .thenThrow(new OrganizationManagementClientException(
-                        ERROR_CODE_INVALID_ORGANIZATION.getMessage(),
-                        ERROR_CODE_INVALID_ORGANIZATION.getDescription(),
-                        ERROR_CODE_INVALID_ORGANIZATION.getCode()));
+                        ERROR_CODE_UNAUTHORIZED_ORG_ACCESS.getMessage(),
+                        ERROR_CODE_UNAUTHORIZED_ORG_ACCESS.getDescription(),
+                        ERROR_CODE_UNAUTHORIZED_ORG_ACCESS.getCode()));
 
         when(organizationManager.resolveOrganizationId(ORG_HANDLE)).thenReturn(ORG_ID);
         when(organizationManager.resolveOrganizationId(INVALID_ORG_HANDLE))

--- a/components/org.wso2.carbon.identity.organization.discovery.service/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.organization.discovery.service/src/test/resources/testng.xml
@@ -23,6 +23,7 @@
         <classes>
             <class name="org.wso2.carbon.identity.organization.discovery.service.listener.OrganizationDiscoveryUserOperationListenerTest"/>
             <class name="org.wso2.carbon.identity.organization.discovery.service.OrganizationDiscoveryManagerImplTest"/>
+            <class name="org.wso2.carbon.identity.organization.discovery.service.OrganizationDiscoveryHandlerImplTest"/>
         </classes>
     </test>
 </suite>

--- a/components/org.wso2.carbon.identity.organization.discovery.service/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.organization.discovery.service/src/test/resources/testng.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com).
+  ~ Copyright (c) 2024-2025, WSO2 LLC. (http://www.wso2.com).
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -602,7 +602,7 @@
         <carbon.multitenancy.package.import.version.range>[4.7.0,5.0.0)
         </carbon.multitenancy.package.import.version.range>
 
-        <carbon.identity.framework.version>7.8.292</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.297</carbon.identity.framework.version>
         <carbon.identity.package.import.version.range>[5.20.0, 8.0.0)
         </carbon.identity.package.import.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -602,7 +602,7 @@
         <carbon.multitenancy.package.import.version.range>[4.7.0,5.0.0)
         </carbon.multitenancy.package.import.version.range>
 
-        <carbon.identity.framework.version>7.8.234</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.292</carbon.identity.framework.version>
         <carbon.identity.package.import.version.range>[5.20.0, 8.0.0)
         </carbon.identity.package.import.version.range>
 


### PR DESCRIPTION
## Purpose
> This PR introduces organization discovery handler implementation to discover organization based on provided discovery parameters.

Related PRs - https://github.com/wso2/carbon-identity-framework/pull/6890

Issue - https://github.com/wso2/product-is/issues/24454