### PR TITLE
Pass tenant domain instead of the organization ID to retrieve missing claims

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/handler/OrgClaimMgtHandler.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/handler/OrgClaimMgtHandler.java
@@ -174,9 +174,10 @@ public class OrgClaimMgtHandler extends AbstractEventHandler {
                                 .toArray(ClaimMapping[]::new);
 
                 for (BasicOrganization organization : sharedOrganizations) {
-                    List<String> missingClaims = getMissingClaims(organization.getId(), filteredClaimMappings);
-                    String sharedOrganizationTenantDomain = getOrganizationManager().
-                            resolveTenantDomain(organization.getId());
+                    String sharedOrganizationTenantDomain = getOrganizationManager()
+                            .resolveTenantDomain(organization.getId());
+                    List<String> missingClaims = getMissingClaims(sharedOrganizationTenantDomain,
+                            filteredClaimMappings);
                     List<LocalClaim> parentOrgCustomLocalClaims = getClaimMetadataManagementService().
                             getLocalClaims(tenantDomain);
                     CompletableFuture.runAsync(() -> {


### PR DESCRIPTION
## Purpose
$subject

With the introduction of the org handle, sub-organizations will now have the ability to use a separate tenant domain value instead of the org ID. Hence, the tenant domain must be accurately resolved and passed to methods in places where the org ID was previously used.