### PR TITLE
Add listener to resolve shared role Ids of password expiry rules

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.handler/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.handler/pom.xml
@@ -191,6 +191,7 @@
                             version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
                             org.wso2.carbon.idp.mgt;version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.idp.mgt.util;version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.idp.mgt.listener;version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.application.mgt.*;
                             version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.application.common.*;

--- a/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/internal/OrganizationManagementHandlerServiceComponent.java
+++ b/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/internal/OrganizationManagementHandlerServiceComponent.java
@@ -41,10 +41,12 @@ import org.wso2.carbon.identity.organization.management.handler.OrganizationSess
 import org.wso2.carbon.identity.organization.management.handler.OrganizationVersionHandler;
 import org.wso2.carbon.identity.organization.management.handler.SharedRoleMgtHandler;
 import org.wso2.carbon.identity.organization.management.handler.SharingPolicyCleanUpHandler;
+import org.wso2.carbon.identity.organization.management.handler.listener.ResidentIdPMgtListener;
 import org.wso2.carbon.identity.organization.management.handler.listener.SharedRoleMgtListener;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.organization.resource.sharing.policy.management.ResourceSharingPolicyHandlerService;
 import org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService;
+import org.wso2.carbon.idp.mgt.listener.IdentityProviderMgtListener;
 import org.wso2.carbon.user.core.service.RealmService;
 
 /**
@@ -77,6 +79,8 @@ public class OrganizationManagementHandlerServiceComponent {
             bundleContext.registerService(AbstractEventHandler.class, new OrganizationVersionHandler(), null);
             bundleContext.registerService(AbstractEventHandler.class.getName(),
                     OrganizationManagementAuditLogHandler.getInstance(), null);
+            bundleContext.registerService(IdentityProviderMgtListener.class.getName(), new ResidentIdPMgtListener(),
+                    null);
             LOG.debug("Organization management handler component activated successfully.");
         } catch (Throwable e) {
             LOG.error("Error while activating organization management handler module.", e);

--- a/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/listener/ResidentIdPMgtListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/listener/ResidentIdPMgtListener.java
@@ -41,9 +41,9 @@ public class ResidentIdPMgtListener extends AbstractIdentityProviderMgtListener 
 
     private static final Log LOG = LogFactory.getLog(ResidentIdPMgtListener.class);
     private static final String PASSWORD_EXPIRY_RULES_KEY_PREFIX = "passwordExpiry.rule";
-    public static final int ROLE_ID_INDEX = 4;
-    public static final int EXPECTED_RULE_TOKEN_COUNT = 5;
-    public static final int RULE_TYPE_INDEX = 2;
+    private static final int ROLE_ID_INDEX = 4;
+    private static final int EXPECTED_RULE_TOKEN_COUNT = 5;
+    private static final int RULE_TYPE_INDEX = 2;
 
     /**
      * Returns the priority of this listener.

--- a/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/listener/ResidentIdPMgtListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/listener/ResidentIdPMgtListener.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.management.handler.listener;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.common.model.IdentityProvider;
+import org.wso2.carbon.identity.application.common.model.IdentityProviderProperty;
+import org.wso2.carbon.identity.organization.management.handler.internal.OrganizationManagementHandlerDataHolder;
+import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementException;
+import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
+import org.wso2.carbon.idp.mgt.listener.AbstractIdentityProviderMgtListener;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Identity provider management listener to handle role Ids of inherited password expiry rules.
+ */
+public class ResidentIdPMgtListener extends AbstractIdentityProviderMgtListener {
+
+    private static final Log LOG = LogFactory.getLog(ResidentIdPMgtListener.class);
+    private static final String PASSWORD_EXPIRY_RULES_KEY_PREFIX = "passwordExpiry.rule";
+    public static final int ROLE_ID_INDEX = 4;
+    public static final int EXPECTED_RULE_TOKEN_COUNT = 5;
+    public static final int RULE_TYPE_INDEX = 2;
+
+    /**
+     * Returns the priority of this listener.
+     *
+     * @return The order of this listener.
+     */
+    @Override
+    public int getDefaultOrderId() {
+
+        return 300;
+    }
+
+    /**
+     * This method is called after the resident identity provider is retrieved from the database.
+     *
+     * @param identityProvider Resident identity provider to be processed.
+     * @param tenantDomain     Tenant domain of the organization.
+     * @return true if the operation is successful, false otherwise.
+     * @throws IdentityProviderManagementException If an error occurs while resolving shared roles.
+     */
+    @Override
+    public boolean doPostGetResidentIdP(IdentityProvider identityProvider, String tenantDomain) throws
+            IdentityProviderManagementException {
+
+        resolveSharedRoles(identityProvider, tenantDomain);
+        return true;
+    }
+
+    /**
+     * Resolves shared roles for password expiry rules by converting main role IDs to shared role IDs
+     * for organization contexts. Removes rules where the main role doesn't have a corresponding shared role and the
+     * main role does not exist in the sub-organization.
+     *
+     * @param identityProvider Identity provider containing password expiry rules.
+     * @param tenantDomain     Tenant domain of the organization.
+     * @throws IdentityProviderManagementException If an error occurs while resolving shared roles.
+     */
+    private void resolveSharedRoles(IdentityProvider identityProvider, String tenantDomain)
+            throws IdentityProviderManagementException {
+
+        List<IdentityProviderProperty> propertyList = new ArrayList<>(
+                Arrays.asList(identityProvider.getIdpProperties()));
+        List<IdentityProviderProperty> passwordExpiryRules = propertyList.stream()
+                .filter(property -> property.getName().startsWith(PASSWORD_EXPIRY_RULES_KEY_PREFIX))
+                .collect(Collectors.toList());
+
+        // Return if no password expiry rules exist.
+        if (passwordExpiryRules.isEmpty()) {
+            return;
+        }
+
+        List<String> mainRoleIds = extractMainRoleIds(passwordExpiryRules);
+        if (mainRoleIds.isEmpty()) {
+            return;
+        }
+
+        try {
+            Map<String, String> mainRoleToSharedRoleMap = OrganizationManagementHandlerDataHolder.getInstance()
+                    .getRoleManagementServiceV2()
+                    .getMainRoleToSharedRoleMappingsBySubOrg(mainRoleIds, tenantDomain);
+
+            propertyList.removeIf(property -> {
+                if (!property.getName().startsWith(PASSWORD_EXPIRY_RULES_KEY_PREFIX)) {
+                    // Keep non-password expiry properties.
+                    return false;
+                }
+
+                String[] ruleTokens = property.getValue().split(",");
+                if (ruleTokens.length != EXPECTED_RULE_TOKEN_COUNT || !"roles".equals(ruleTokens[RULE_TYPE_INDEX])) {
+                    // Keep non-role rules or malformed rules.
+                    return false;
+                }
+
+                String mainRoleId = ruleTokens[ROLE_ID_INDEX];
+                String sharedRoleId = mainRoleToSharedRoleMap.get(mainRoleId);
+                if (StringUtils.isNotEmpty(sharedRoleId)) {
+                    // Update the rule with the shared role ID.
+                    ruleTokens[ROLE_ID_INDEX] = sharedRoleId;
+                    property.setValue(String.join(",", ruleTokens));
+                    // Keep the updated rule.
+                    return false;
+                } else {
+                    try {
+                        if (!OrganizationManagementHandlerDataHolder.getInstance().getRoleManagementServiceV2()
+                                .isExistingRole(mainRoleId, tenantDomain)) {
+                            return true;
+                        }
+                    } catch (IdentityRoleManagementException e) {
+                        LOG.error("Error while checking if the main role ID: " + mainRoleId + " exists in tenant: "
+                                + tenantDomain, e);
+                        return false;
+                    }
+                    return false;
+                }
+            });
+        } catch (IdentityRoleManagementException e) {
+            throw new IdentityProviderManagementException(
+                    "Error while retrieving shared role mappings for main role IDs: " + mainRoleIds, e);
+        }
+
+        identityProvider.setIdpProperties(propertyList.toArray(new IdentityProviderProperty[0]));
+    }
+
+    private static List<String> extractMainRoleIds(List<IdentityProviderProperty> passwordExpiryRules) {
+
+        // Extract main role IDs from password expiry rules related to roles.
+        return passwordExpiryRules.stream()
+                .map(property -> property.getValue().split(","))
+                .filter(ruleTokens -> ruleTokens.length == EXPECTED_RULE_TOKEN_COUNT &&
+                        "roles".equals(ruleTokens[RULE_TYPE_INDEX]))
+                .map(ruleTokens -> ruleTokens[ROLE_ID_INDEX])
+                .filter(StringUtils::isNotBlank)
+                .distinct()
+                .collect(Collectors.toList());
+    }
+}

--- a/components/org.wso2.carbon.identity.organization.management.handler/src/test/java/org/wso2/carbon/identity/organization/management/handler/listener/ResidentIdPMgtListenerTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.handler/src/test/java/org/wso2/carbon/identity/organization/management/handler/listener/ResidentIdPMgtListenerTest.java
@@ -56,14 +56,14 @@ public class ResidentIdPMgtListenerTest {
     private static final String SHARED_ROLE_ID_1 = "shared-role-id-1";
     private static final String SHARED_ROLE_ID_2 = "shared-role-id-2";
     private static final String PASSWORD_EXPIRY_RULE_PREFIX = "passwordExpiry.rule";
-    public static final String ROLES_RULE_PREFIX = "1,30,roles,eq,";
-    public static final String GROUP_RULE = "1,30,groups,eq,groupId123";
-    public static final String OTHER_PROPERTY = "other.property";
-    public static final String VALUE_1 = "value1";
-    public static final String VALUE_2 = "value2";
-    public static final String ANOTHER_PROPERTY = "another.property";
-    public static final String RULE_1 = ".1";
-    public static final String RULE_2 = ".2";
+    private static final String ROLES_RULE_PREFIX = "1,30,roles,eq,";
+    private static final String GROUP_RULE = "1,30,groups,eq,groupId123";
+    private static final String OTHER_PROPERTY = "other.property";
+    private static final String VALUE_1 = "value1";
+    private static final String VALUE_2 = "value2";
+    private static final String ANOTHER_PROPERTY = "another.property";
+    private static final String RULE_1 = ".1";
+    private static final String RULE_2 = ".2";
 
     @Mock
     private OrganizationManagementHandlerDataHolder dataHolder;

--- a/components/org.wso2.carbon.identity.organization.management.handler/src/test/java/org/wso2/carbon/identity/organization/management/handler/listener/ResidentIdPMgtListenerTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.handler/src/test/java/org/wso2/carbon/identity/organization/management/handler/listener/ResidentIdPMgtListenerTest.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.management.handler.listener;
+
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.application.common.model.IdentityProvider;
+import org.wso2.carbon.identity.application.common.model.IdentityProviderProperty;
+import org.wso2.carbon.identity.organization.management.handler.internal.OrganizationManagementHandlerDataHolder;
+import org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService;
+import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementException;
+import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Test class for ResidentIdPMgtListener.
+ */
+public class ResidentIdPMgtListenerTest {
+
+    private static final String TENANT_DOMAIN = "test.domain";
+    private static final String MAIN_ROLE_ID_1 = "main-role-id-1";
+    private static final String MAIN_ROLE_ID_2 = "main-role-id-2";
+    private static final String SHARED_ROLE_ID_1 = "shared-role-id-1";
+    private static final String SHARED_ROLE_ID_2 = "shared-role-id-2";
+    private static final String PASSWORD_EXPIRY_RULE_PREFIX = "passwordExpiry.rule";
+    public static final String ROLES_RULE_PREFIX = "1,30,roles,eq,";
+    public static final String GROUP_RULE = "1,30,groups,eq,groupId123";
+    public static final String OTHER_PROPERTY = "other.property";
+    public static final String VALUE_1 = "value1";
+    public static final String VALUE_2 = "value2";
+    public static final String ANOTHER_PROPERTY = "another.property";
+    public static final String RULE_1 = ".1";
+    public static final String RULE_2 = ".2";
+
+    @Mock
+    private OrganizationManagementHandlerDataHolder dataHolder;
+
+    @Mock
+    private RoleManagementService roleManagementService;
+
+    private ResidentIdPMgtListener listener;
+    private MockedStatic<OrganizationManagementHandlerDataHolder> dataHolderMockedStatic;
+
+    @BeforeMethod
+    public void setUp() {
+
+        MockitoAnnotations.openMocks(this);
+        listener = new ResidentIdPMgtListener();
+
+        dataHolderMockedStatic = mockStatic(OrganizationManagementHandlerDataHolder.class);
+        dataHolderMockedStatic.when(OrganizationManagementHandlerDataHolder::getInstance)
+                .thenReturn(dataHolder);
+        when(dataHolder.getRoleManagementServiceV2()).thenReturn(roleManagementService);
+    }
+
+    @AfterMethod
+    public void tearDown() {
+
+        dataHolderMockedStatic.close();
+    }
+
+    @Test
+    public void testGetDefaultOrderId() {
+
+        assertEquals(listener.getDefaultOrderId(), 300);
+    }
+
+    @Test(description = "Test for doPostGetResidentIdP with no password expiry rules")
+    public void testDoPostGetResidentIdPWithNoPasswordExpiryRules() throws Exception {
+
+        IdentityProvider identityProvider = createIdentityProvider(new IdentityProviderProperty[]{
+                createProperty(OTHER_PROPERTY, VALUE_1),
+                createProperty(ANOTHER_PROPERTY, VALUE_2)
+        });
+
+        boolean result = listener.doPostGetResidentIdP(identityProvider, TENANT_DOMAIN);
+
+        assertTrue(result);
+        verify(roleManagementService, never()).getMainRoleToSharedRoleMappingsBySubOrg(anyList(), anyString());
+    }
+
+    @Test(description = "Test for doPostGetResidentIdP with group related password expiry rules")
+    public void testDoPostGetResidentIdPWithNonRolePasswordExpiryRules() throws Exception {
+
+        IdentityProviderProperty[] properties = {
+                createProperty(PASSWORD_EXPIRY_RULE_PREFIX + RULE_1, GROUP_RULE),
+                createProperty(OTHER_PROPERTY, VALUE_1)
+        };
+
+        IdentityProvider identityProvider = createIdentityProvider(properties);
+        boolean result = listener.doPostGetResidentIdP(identityProvider, TENANT_DOMAIN);
+
+        assertTrue(result);
+        verify(roleManagementService, never()).getMainRoleToSharedRoleMappingsBySubOrg(anyList(), anyString());
+    }
+
+    @Test(description = "Test for doPostGetResidentIdP with roles that are shared with the sub-organization")
+    public void testDoPostGetResidentIdPWithSharedRoleIds() throws Exception {
+
+        IdentityProviderProperty[] properties = {
+                createProperty(PASSWORD_EXPIRY_RULE_PREFIX + RULE_1, ROLES_RULE_PREFIX + MAIN_ROLE_ID_1),
+                createProperty(PASSWORD_EXPIRY_RULE_PREFIX + RULE_2, ROLES_RULE_PREFIX + MAIN_ROLE_ID_2),
+                createProperty(OTHER_PROPERTY, VALUE_1)
+        };
+
+        IdentityProvider identityProvider = createIdentityProvider(properties);
+        Map<String, String> roleMapping = new HashMap<>();
+        roleMapping.put(MAIN_ROLE_ID_1, SHARED_ROLE_ID_1);
+        roleMapping.put(MAIN_ROLE_ID_2, SHARED_ROLE_ID_2);
+
+        when(roleManagementService.getMainRoleToSharedRoleMappingsBySubOrg(
+                Arrays.asList(MAIN_ROLE_ID_1, MAIN_ROLE_ID_2), TENANT_DOMAIN))
+                .thenReturn(roleMapping);
+        boolean result = listener.doPostGetResidentIdP(identityProvider, TENANT_DOMAIN);
+
+        assertTrue(result);
+        IdentityProviderProperty[] updatedProperties = identityProvider.getIdpProperties();
+
+        boolean foundUpdatedRule1 = false, foundUpdatedRule2 = false;
+        for (IdentityProviderProperty property : updatedProperties) {
+            if (property.getName().equals(PASSWORD_EXPIRY_RULE_PREFIX + RULE_1)) {
+                assertEquals(property.getValue(), ROLES_RULE_PREFIX + SHARED_ROLE_ID_1);
+                foundUpdatedRule1 = true;
+            } else if (property.getName().equals(PASSWORD_EXPIRY_RULE_PREFIX + RULE_2)) {
+                assertEquals(property.getValue(), ROLES_RULE_PREFIX + SHARED_ROLE_ID_2);
+                foundUpdatedRule2 = true;
+            }
+        }
+
+        assertTrue(foundUpdatedRule1);
+        assertTrue(foundUpdatedRule2);
+    }
+
+    @Test(description = "Test for doPostGetResidentIdP with a shared role and a role that was created in the " +
+            "sub-organization")
+    public void testDoPostGetResidentIdPWithPartialSharedRoleMappings() throws Exception {
+
+        IdentityProviderProperty[] properties = {
+                createProperty(PASSWORD_EXPIRY_RULE_PREFIX + RULE_1, ROLES_RULE_PREFIX + MAIN_ROLE_ID_1),
+                createProperty(PASSWORD_EXPIRY_RULE_PREFIX + RULE_2, ROLES_RULE_PREFIX + MAIN_ROLE_ID_2),
+                createProperty(OTHER_PROPERTY, VALUE_1)
+        };
+
+        IdentityProvider identityProvider = createIdentityProvider(properties);
+        Map<String, String> roleMapping = new HashMap<>();
+        roleMapping.put(MAIN_ROLE_ID_1, SHARED_ROLE_ID_1);
+
+        when(roleManagementService.getMainRoleToSharedRoleMappingsBySubOrg(
+                Arrays.asList(MAIN_ROLE_ID_1, MAIN_ROLE_ID_2), TENANT_DOMAIN))
+                .thenReturn(roleMapping);
+        when(roleManagementService.isExistingRole(MAIN_ROLE_ID_2, TENANT_DOMAIN)).thenReturn(true);
+        boolean result = listener.doPostGetResidentIdP(identityProvider, TENANT_DOMAIN);
+
+        assertTrue(result);
+        IdentityProviderProperty[] updatedProperties = identityProvider.getIdpProperties();
+
+        boolean foundUpdatedRule1 = false, foundOriginalRule2 = false;
+        for (IdentityProviderProperty property : updatedProperties) {
+            if (property.getName().equals(PASSWORD_EXPIRY_RULE_PREFIX + RULE_1)) {
+                assertEquals(property.getValue(), ROLES_RULE_PREFIX + SHARED_ROLE_ID_1);
+                foundUpdatedRule1 = true;
+            } else if (property.getName().equals(PASSWORD_EXPIRY_RULE_PREFIX + RULE_2)) {
+                assertEquals(property.getValue(), ROLES_RULE_PREFIX + MAIN_ROLE_ID_2);
+                foundOriginalRule2 = true;
+            }
+        }
+
+        assertTrue(foundUpdatedRule1);
+        assertTrue(foundOriginalRule2);
+    }
+
+    @Test(description = "Test for doPostGetResidentIdP with a shared role and a role which was not shared")
+    public void testDoPostGetResidentIdPWithNonSharedRole() throws Exception {
+
+        IdentityProviderProperty[] properties = {
+                createProperty(PASSWORD_EXPIRY_RULE_PREFIX + RULE_1, ROLES_RULE_PREFIX + MAIN_ROLE_ID_1),
+                createProperty(PASSWORD_EXPIRY_RULE_PREFIX + RULE_2, ROLES_RULE_PREFIX + MAIN_ROLE_ID_2),
+                createProperty(OTHER_PROPERTY, VALUE_1)
+        };
+
+        IdentityProvider identityProvider = createIdentityProvider(properties);
+        Map<String, String> roleMapping = new HashMap<>();
+        when(roleManagementService.getMainRoleToSharedRoleMappingsBySubOrg(
+                Arrays.asList(MAIN_ROLE_ID_1, MAIN_ROLE_ID_2), TENANT_DOMAIN))
+                .thenReturn(roleMapping);
+        when(roleManagementService.isExistingRole(MAIN_ROLE_ID_1, TENANT_DOMAIN)).thenReturn(false);
+        when(roleManagementService.isExistingRole(MAIN_ROLE_ID_2, TENANT_DOMAIN)).thenReturn(true);
+        boolean result = listener.doPostGetResidentIdP(identityProvider, TENANT_DOMAIN);
+
+        assertTrue(result);
+        IdentityProviderProperty[] updatedProperties = identityProvider.getIdpProperties();
+
+        boolean foundRule1 = false, foundRule2 = false;
+        for (IdentityProviderProperty property : updatedProperties) {
+            if (property.getName().equals(PASSWORD_EXPIRY_RULE_PREFIX + RULE_1)) {
+                foundRule1 = true;
+            } else if (property.getName().equals(PASSWORD_EXPIRY_RULE_PREFIX + RULE_2)) {
+                foundRule2 = true;
+            }
+        }
+
+        assertFalse(foundRule1);
+        assertTrue(foundRule2);
+    }
+
+    @Test(description = "Test for doPostGetResidentIdP with an exception",
+            expectedExceptions = IdentityProviderManagementException.class)
+    public void testDoPostGetResidentIdPWithRoleMappingException() throws Exception {
+
+        IdentityProviderProperty[] properties = {
+                createProperty(PASSWORD_EXPIRY_RULE_PREFIX + RULE_1, ROLES_RULE_PREFIX + MAIN_ROLE_ID_1)
+        };
+
+        IdentityProvider identityProvider = createIdentityProvider(properties);
+        when(roleManagementService.getMainRoleToSharedRoleMappingsBySubOrg(anyList(), anyString()))
+                .thenThrow(new IdentityRoleManagementException("Test exception"));
+        listener.doPostGetResidentIdP(identityProvider, TENANT_DOMAIN);
+    }
+
+    private IdentityProvider createIdentityProvider(IdentityProviderProperty[] properties) {
+
+        IdentityProvider identityProvider = new IdentityProvider();
+        identityProvider.setIdpProperties(properties);
+        return identityProvider;
+    }
+
+    private IdentityProviderProperty createProperty(String name, String value) {
+
+        IdentityProviderProperty property = new IdentityProviderProperty();
+        property.setName(name);
+        property.setValue(value);
+        return property;
+    }
+}

--- a/components/org.wso2.carbon.identity.organization.management.handler/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.organization.management.handler/src/test/resources/testng.xml
@@ -27,6 +27,7 @@
             <class name="org.wso2.carbon.identity.organization.management.handler.SharingPolicyCleanUpHandlerTest"/>
             <class name="org.wso2.carbon.identity.organization.management.handler.OrganizationSessionHandlerTest"/>
             <class name="org.wso2.carbon.identity.organization.management.handler.OrganizationManagementAuditLogHandlerTest"/>
+            <class name="org.wso2.carbon.identity.organization.management.handler.listener.ResidentIdPMgtListenerTest"/>
         </classes>
     </test>
 </suite>

--- a/pom.xml
+++ b/pom.xml
@@ -602,7 +602,7 @@
         <carbon.multitenancy.package.import.version.range>[4.7.0,5.0.0)
         </carbon.multitenancy.package.import.version.range>
 
-        <carbon.identity.framework.version>7.8.326</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.346</carbon.identity.framework.version>
         <carbon.identity.package.import.version.range>[5.20.0, 8.0.0)
         </carbon.identity.package.import.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -602,7 +602,7 @@
         <carbon.multitenancy.package.import.version.range>[4.7.0,5.0.0)
         </carbon.multitenancy.package.import.version.range>
 
-        <carbon.identity.framework.version>7.8.346</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.8.385</carbon.identity.framework.version>
         <carbon.identity.package.import.version.range>[5.20.0, 8.0.0)
         </carbon.identity.package.import.version.range>
 


### PR DESCRIPTION
## Purpose
Password expiry rules related to roles are stored in the format: `1,30,roles,eq,<ROLE-ID>`

When these roles are inherited, corresponding shared role Ids should be resolved based on wether they are shared to the sub-organization or not.

#### Depends on
- https://github.com/wso2/carbon-identity-framework/pull/7050

### Related issue
- https://github.com/wso2/product-is/issues/24904