### PR TITLE
Resolve tenant domain properly for invited parent user notification

### DIFF
--- a/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/InvitationCoreServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.user.invitation.management/src/main/java/org/wso2/carbon/identity/organization/user/invitation/management/InvitationCoreServiceImpl.java
@@ -491,7 +491,7 @@ public class InvitationCoreServiceImpl implements InvitationCoreService {
         properties.put(EVENT_PROP_USER_NAME, invitation.getUsername());
         properties.put(EVENT_PROP_EMAIL_ADDRESS, invitation.getEmail());
         properties.put(EVENT_PROP_CONFIRMATION_CODE, invitation.getConfirmationCode());
-        properties.put(EVENT_PROP_TENANT_DOMAIN, invitation.getInvitedOrganizationId());
+        properties.put(EVENT_PROP_TENANT_DOMAIN, resolveTenantDomain(invitation.getInvitedOrganizationId()));
         properties.put(EVENT_PROP_REDIRECT_URL, invitation.getUserRedirectUrl());
         properties.put(EVENT_PROP_PROPERTIES, invitation.getInvitationProperties());
         Event invitationEvent = new Event(EVENT_NAME_POST_ADD_INVITATION, properties);


### PR DESCRIPTION
## Purpose
This pull request makes a targeted fix to the `triggerInvitationAddNotification` method in `InvitationCoreServiceImpl.java`. The main change ensures that the tenant domain property is set correctly by resolving the organization ID to its corresponding tenant domain, rather than passing the organization ID directly.

**Notification event property correction:**

* Updated the assignment of the `EVENT_PROP_TENANT_DOMAIN` property to use the `resolveTenantDomain` method on `invitation.getInvitedOrganizationId()`, ensuring the correct tenant domain is used in the notification event.

Fixes issue: https://github.com/wso2/product-is/issues/24998