### PR TITLE
Resolve sub org level discoverable app view issue in myaccount when org id and org handle are different

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManagerImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManagerImpl.java
@@ -2140,7 +2140,8 @@ public class OrgApplicationManagerImpl implements OrgApplicationManager {
                                                                           String tenantDomain)
             throws OrganizationManagementException {
 
-        String rootOrgId = getOrganizationManager().getPrimaryOrganizationId(tenantDomain);
+        String organizationId = getOrganizationManager().resolveOrganizationId(tenantDomain);
+        String rootOrgId = getOrganizationManager().getPrimaryOrganizationId(organizationId);
         return getOrgApplicationMgtDAO().getDiscoverableSharedApplicationBasicInfo(limit, offset, filter, sortOrder,
                 sortBy, tenantDomain, rootOrgId);
     }
@@ -2149,7 +2150,8 @@ public class OrgApplicationManagerImpl implements OrgApplicationManager {
     public int getCountOfDiscoverableSharedApplications(String filter, String tenantDomain)
             throws OrganizationManagementException {
 
-        String rootOrgId = getOrganizationManager().getPrimaryOrganizationId(tenantDomain);
+        String organizationId = getOrganizationManager().resolveOrganizationId(tenantDomain);
+        String rootOrgId = getOrganizationManager().getPrimaryOrganizationId(organizationId);
         return getOrgApplicationMgtDAO().getCountOfDiscoverableSharedApplications(filter, tenantDomain, rootOrgId);
     }
 

--- a/components/org.wso2.carbon.identity.organization.management.application/src/test/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManagerImplTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/test/java/org/wso2/carbon/identity/organization/management/application/OrgApplicationManagerImplTest.java
@@ -358,6 +358,7 @@ public class OrgApplicationManagerImplTest {
     public void testGetDiscoverableSharedApplicationBasicInfo() throws OrganizationManagementException {
 
         String tenantDomain = "abc.com";
+        String organizationId = "1111111-222222";
         String rootOrgId = "root-org-id";
 
         ApplicationBasicInfo app1 = new ApplicationBasicInfo();
@@ -367,25 +368,29 @@ public class OrgApplicationManagerImplTest {
         app2.setApplicationName("App2");
         app2.setDescription("Description2");
         List<ApplicationBasicInfo> expectedApps = Arrays.asList(app1, app2);
-        when(organizationManager.getPrimaryOrganizationId(tenantDomain)).thenReturn(rootOrgId);
+        when(organizationManager.resolveOrganizationId(tenantDomain)).thenReturn(organizationId);
+        when(organizationManager.getPrimaryOrganizationId(organizationId)).thenReturn(rootOrgId);
         when(orgApplicationMgtDAO.getDiscoverableSharedApplicationBasicInfo(10, 0, "*",
                 "ASC", "dummyName", tenantDomain, rootOrgId)).thenReturn(expectedApps);
         List<ApplicationBasicInfo> actualApps = orgApplicationManager.getDiscoverableSharedApplicationBasicInfo(
                 10, 0, "*", "ASC", "dummyName", tenantDomain);
-        assertEquals(expectedApps, actualApps);
+        assertEquals(actualApps, expectedApps);
     }
 
     @Test
     public void testGetCountOfDiscoverableSharedApplications() throws OrganizationManagementException {
 
         int expectedCount = 5;
+        String tenantDomain = "dummyTenant";
+        String organizationId = "1111111-222222";
+        String rootOrgId = "rootOrg123";
+        when(organizationManager.resolveOrganizationId(tenantDomain)).thenReturn(organizationId);
+        when(organizationManager.getPrimaryOrganizationId(organizationId)).thenReturn(rootOrgId);
+        when(orgApplicationMgtDAO.getCountOfDiscoverableSharedApplications("*", tenantDomain,
+                rootOrgId)).thenReturn(5);
 
-        when(organizationManager.getPrimaryOrganizationId("dummyTenant")).thenReturn("rootOrg123");
-        when(orgApplicationMgtDAO.getCountOfDiscoverableSharedApplications("*", "dummyTenant",
-                "rootOrg123")).thenReturn(5);
-
-        int actualCount = orgApplicationManager.getCountOfDiscoverableSharedApplications("*", "dummyTenant");
-        assertEquals(expectedCount, actualCount);
+        int actualCount = orgApplicationManager.getCountOfDiscoverableSharedApplications("*", tenantDomain);
+        assertEquals(actualCount, expectedCount);
     }
 
     @Test


### PR DESCRIPTION
## Purpose
Fix for https://github.com/wso2/product-is/issues/25347

This pull request refactors how organization IDs are resolved and used throughout the application management codebase, replacing direct usage of tenant domains with organization IDs for discoverable shared application queries. It also updates error messages and test cases to align with these changes, improving consistency and correctness in organization context handling.

**Core logic changes:**

* Updated `OrgApplicationManagerImpl.java` methods to resolve organization IDs from tenant domains before fetching root organization IDs, ensuring queries operate in the correct organization context. [[1]](diffhunk://#diff-6643b27201b8eee5beea7c151b17a82fc3ff7108d93f452041881197c0542b61L2143-R2144) [[2]](diffhunk://#diff-6643b27201b8eee5beea7c151b17a82fc3ff7108d93f452041881197c0542b61L2152-R2154)
* Refactored `OrgApplicationMgtDAOImpl.java` to consistently use organization IDs instead of tenant domains for all discoverable shared application queries and error messages. This includes changes to method signatures, SQL parameter bindings, and internal helper methods. [[1]](diffhunk://#diff-2f215c3d5809bf9d7e6841691905ab244b5d7da733c6a772d08223a35bc91220R399-R403) [[2]](diffhunk://#diff-2f215c3d5809bf9d7e6841691905ab244b5d7da733c6a772d08223a35bc91220L416-R418) [[3]](diffhunk://#diff-2f215c3d5809bf9d7e6841691905ab244b5d7da733c6a772d08223a35bc91220L433-R435) [[4]](diffhunk://#diff-2f215c3d5809bf9d7e6841691905ab244b5d7da733c6a772d08223a35bc91220R444-R451) [[5]](diffhunk://#diff-2f215c3d5809bf9d7e6841691905ab244b5d7da733c6a772d08223a35bc91220L460-R463) [[6]](diffhunk://#diff-2f215c3d5809bf9d7e6841691905ab244b5d7da733c6a772d08223a35bc91220L475-R478) [[7]](diffhunk://#diff-2f215c3d5809bf9d7e6841691905ab244b5d7da733c6a772d08223a35bc91220L493-R496) [[8]](diffhunk://#diff-2f215c3d5809bf9d7e6841691905ab244b5d7da733c6a772d08223a35bc91220L503-R506) [[9]](diffhunk://#diff-2f215c3d5809bf9d7e6841691905ab244b5d7da733c6a772d08223a35bc91220L517-R526) [[10]](diffhunk://#diff-2f215c3d5809bf9d7e6841691905ab244b5d7da733c6a772d08223a35bc91220L536-R539) [[11]](diffhunk://#diff-2f215c3d5809bf9d7e6841691905ab244b5d7da733c6a772d08223a35bc91220L552-R555) [[12]](diffhunk://#diff-2f215c3d5809bf9d7e6841691905ab244b5d7da733c6a772d08223a35bc91220R769-R773)

**Testing updates:**

* Modified unit tests in `OrgApplicationManagerImplTest.java` to mock organization ID resolution and root organization ID retrieval, and adjusted assertions for improved accuracy. [[1]](diffhunk://#diff-a1d9e4714747b637d4e2341082c33e32d867397befd02f64603941871c72d02dR361) [[2]](diffhunk://#diff-a1d9e4714747b637d4e2341082c33e32d867397befd02f64603941871c72d02dL370-R393)
* Enhanced test setup in `OrgApplicationMgtDAOImplTest.java` to mock organization manager and organization data holder, and added new test constants for organization IDs and tenant domains. [[1]](diffhunk://#diff-af5f713110017c3d4f28a75a3b5d35c861a4b3efa01dd09381d33ee05852c054R42-R44) [[2]](diffhunk://#diff-af5f713110017c3d4f28a75a3b5d35c861a4b3efa01dd09381d33ee05852c054R86-R94) [[3]](diffhunk://#diff-af5f713110017c3d4f28a75a3b5d35c861a4b3efa01dd09381d33ee05852c054R105-R113) [[4]](diffhunk://#diff-af5f713110017c3d4f28a75a3b5d35c861a4b3efa01dd09381d33ee05852c054R136-R138)