### PR TITLE
Fix shared role reconciliation during user share updates

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImplV2.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImplV2.java
@@ -2200,6 +2200,17 @@ public class UserSharingPolicyHandlerServiceImplV2 implements UserSharingPolicyH
 
         deleteOldSharedRoles(userAssociation, rolesToBeRemoved);
 
+        // Invert the mapping to convert sub-org role IDs back to parent-org role IDs, so the returned list
+        // is in the initiating-org space and can be processed correctly by assignRolesToTheSharedUser().
+        Map<String, String> sharedToMainRoleMap = new HashMap<>();
+        for (Map.Entry<String, String> entry : mainToSharedRoleMap.entrySet()) {
+            sharedToMainRoleMap.put(entry.getValue(), entry.getKey());
+        }
+        List<String> rolesToBeAddedInParentOrg = new ArrayList<>();
+        for (String subOrgRoleId : rolesToBeAdded) {
+            rolesToBeAddedInParentOrg.add(sharedToMainRoleMap.getOrDefault(subOrgRoleId, subOrgRoleId));
+        }
+
         String tenantDomain = CarbonContext.getThreadLocalCarbonContext().getTenantDomain();
         AUDIT_LOG.info(String.format(AUDIT_MESSAGE, getInitiator(tenantDomain),
                 "Reconcile Shared User Roles", userAssociation.getUserId(),
@@ -2207,10 +2218,10 @@ public class UserSharingPolicyHandlerServiceImplV2 implements UserSharingPolicyH
                                 "Roles To Be Removed : %s, Roles Unchanged : %s, Roles To Be Added : %s",
                         getAuditData(tenantDomain, subOrgId),
                         currentRoleIds, newRoleIdsInParentOrg,
-                        rolesToBeRemoved, rolesUnchanged, rolesToBeAdded),
+                        rolesToBeRemoved, rolesUnchanged, rolesToBeAddedInParentOrg),
                 SUCCESS));
 
-        return rolesToBeAdded;
+        return rolesToBeAddedInParentOrg;
     }
 
     /**

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImplV2.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImplV2.java
@@ -1392,15 +1392,13 @@ public class UserSharingPolicyHandlerServiceImplV2 implements UserSharingPolicyH
                             userSharingOrg);
             List<String> roleIds = baseUserShare.getRoles();
             RoleAssignmentMode roleAssignmentMode = baseUserShare.getRoleAssignmentMode();
+            List<String> currentSharedRoleIds = getCurrentSharedRoleIdsForSharedUser(userAssociation);
             if (roleAssignmentMode != RoleAssignmentMode.NONE) {
-
-                List<String> currentSharedRoleIds = getCurrentSharedRoleIdsForSharedUser(userAssociation);
                 List<String> newSharedRoleIds =
-                        getRolesToBeAddedAfterUpdate(userAssociation, currentSharedRoleIds, roleIds);
-
-                if (hasRoleChanges(currentSharedRoleIds, newSharedRoleIds)) {
-                    assignRolesIfPresent(userAssociation, sharingInitiatedOrgId, newSharedRoleIds);
-                }
+                        removeObsoleteRolesAndGetRolesToAdd(userAssociation, currentSharedRoleIds, roleIds);
+                assignRolesIfPresent(userAssociation, sharingInitiatedOrgId, newSharedRoleIds);
+            } else {
+                deleteOldSharedRoles(userAssociation, currentSharedRoleIds);
             }
         } catch (OrganizationManagementException | IdentityRoleManagementException e) {
             LOG.error("Error while handling roles assigment to the previously shared user" + e.getMessage());
@@ -2163,24 +2161,38 @@ public class UserSharingPolicyHandlerServiceImplV2 implements UserSharingPolicyH
      * Determines the roles that need to be added after an update by comparing the current roles
      * with the new set of roles. Note that this will only be affected to the roles which have been assigned to user
      * with the sharing of that user. If this particular user has been assigned to some roles within the sub
-     * organization, there won't be any effect to those roles.
+     * organization, there won't be any effect to those roles. And if there are any roles in the currentRoleIds which
+     * are not in the newRoleIds, those roles will be removed from the user as they are no longer assigned to the user
+     * after the update.
      *
-     * @param userAssociation The user association object containing user and organization details.
-     * @param currentRoleIds  The list of role IDs currently assigned to the shared user.
-     * @param newRoleIds      The list of new role IDs to be assigned.
+     * @param userAssociation       The user association object containing user and organization details.
+     * @param currentRoleIds        The list of role IDs currently assigned to the shared user.
+     * @param newRoleIdsInParentOrg The list of new role IDs in the parent organization that are intended to be
+     *                              assigned to the shared user.
      * @return A list of roles that need to be added.
      */
-    private List<String> getRolesToBeAddedAfterUpdate(UserAssociation userAssociation, List<String> currentRoleIds,
-                                                      List<String> newRoleIds)
+    private List<String> removeObsoleteRolesAndGetRolesToAdd(UserAssociation userAssociation,
+                                                             List<String> currentRoleIds,
+                                                             List<String> newRoleIdsInParentOrg)
             throws OrganizationManagementException, IdentityRoleManagementException {
 
+        String subOrgId = userAssociation.getOrganizationId();
+        String subOrgTenantDomain = getOrganizationManager().resolveTenantDomain(subOrgId);
+
+        // Map parent-org role IDs to their corresponding sub-org role IDs so both sides of the comparison are in the
+        // same org space.
+        Map<String, String> mainToSharedRoleMap =
+                getRoleManagementService().getMainRoleToSharedRoleMappingsBySubOrg(newRoleIdsInParentOrg,
+                        subOrgTenantDomain);
+        Set<String> newSubOrgRoleIds = new HashSet<>(mainToSharedRoleMap.values());
+
         // Roles to be added are those in newRoleIds that are not in currentRoleIds.
-        List<String> rolesToBeAdded = new ArrayList<>(newRoleIds);
+        List<String> rolesToBeAdded = new ArrayList<>(newSubOrgRoleIds);
         rolesToBeAdded.removeAll(currentRoleIds);
 
         // Roles to be removed are those in currentRoleIds that are not in newRoleIds.
         List<String> rolesToBeRemoved = new ArrayList<>(currentRoleIds);
-        rolesToBeRemoved.removeAll(newRoleIds);
+        rolesToBeRemoved.removeAll(newSubOrgRoleIds);
 
         deleteOldSharedRoles(userAssociation, rolesToBeRemoved);
         return rolesToBeAdded;
@@ -2209,20 +2221,6 @@ public class UserSharingPolicyHandlerServiceImplV2 implements UserSharingPolicyH
                     "Remove Roles from Shared User", userId,
                     getAuditData(tenantDomain, orgId), SUCCESS));
         }
-    }
-
-    /**
-     * Checks if there are any role changes when updating a shared user.
-     *
-     * @param oldSharedRoleIds The list of old shared role IDs.
-     * @param newRoleIds       The list of new role IDs.
-     * @return True if there are role changes, false otherwise.
-     */
-    private boolean hasRoleChanges(List<String> oldSharedRoleIds, List<String> newRoleIds) {
-
-        Set<String> oldRoleSet = new HashSet<>(oldSharedRoleIds);
-        Set<String> newRoleSet = new HashSet<>(newRoleIds);
-        return !oldRoleSet.equals(newRoleSet);
     }
 
     private void logAsyncProcessing(String action, String sharingInitiatedUserId, String sharingInitiatedOrgId) {

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImplV2.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImplV2.java
@@ -1401,7 +1401,7 @@ public class UserSharingPolicyHandlerServiceImplV2 implements UserSharingPolicyH
                 deleteOldSharedRoles(userAssociation, currentSharedRoleIds);
             }
         } catch (OrganizationManagementException | IdentityRoleManagementException e) {
-            LOG.error("Error while handling roles assigment to the previously shared user" + e.getMessage());
+            LOG.error("Error while handling roles assignment to the previously shared user" + e.getMessage());
         }
     }
 
@@ -2194,7 +2194,22 @@ public class UserSharingPolicyHandlerServiceImplV2 implements UserSharingPolicyH
         List<String> rolesToBeRemoved = new ArrayList<>(currentRoleIds);
         rolesToBeRemoved.removeAll(newSubOrgRoleIds);
 
+        // Roles that remain unchanged (intersection of current and new).
+        List<String> rolesUnchanged = new ArrayList<>(currentRoleIds);
+        rolesUnchanged.retainAll(newSubOrgRoleIds);
+
         deleteOldSharedRoles(userAssociation, rolesToBeRemoved);
+
+        String tenantDomain = CarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+        AUDIT_LOG.info(String.format(AUDIT_MESSAGE, getInitiator(tenantDomain),
+                "Reconcile Shared User Roles", userAssociation.getUserId(),
+                String.format("%s, Previous Roles : %s, Incoming New Roles (parent org) : %s, " +
+                                "Roles To Be Removed : %s, Roles Unchanged : %s, Roles To Be Added : %s",
+                        getAuditData(tenantDomain, subOrgId),
+                        currentRoleIds, newRoleIdsInParentOrg,
+                        rolesToBeRemoved, rolesUnchanged, rolesToBeAdded),
+                SUCCESS));
+
         return rolesToBeAdded;
     }
 


### PR DESCRIPTION
### Purpose
This change fixes how shared user roles are updated in the v2 user sharing flow. Previously, when a shared user's roles were updated, the system did not correctly compare the old roles and new roles in the same role space. The new role IDs came from the parent organization, while the existing assigned role IDs belonged to the sub-organization. Because of that mismatch, outdated shared roles could remain assigned even after they were removed from the policy. This also caused another gap: if the role assignment mode was changed to `NONE`, the previously shared roles were not explicitly removed.

### Goals
- Ensure role updates are compared using the correct sub-organization role IDs.
- Remove shared roles that are no longer part of the updated sharing configuration.
- Clean up previously assigned shared roles when role assignment is disabled.

### Approach
 - First retrieves the currently assigned shared roles for the user.
 - Then, instead of only checking what should be newly added, it converts the incoming parent-organization role IDs into their corresponding shared role IDs in the sub-organization and compares both sets in the same space.
 - From there:
    - roles that no longer belong to the user are removed
    - roles that are newly introduced are added
    - if the assignment mode is `NONE`, all previously shared roles assigned through sharing are removed

### Related PRs
  - API layer logic impl: https://github.com/wso2/identity-api-server/pull/1044
  - API layer response fine-tuning: https://github.com/wso2/identity-api-server/pull/1089
  - API layer resource defining - https://github.com/wso2/carbon-identity-framework/pull/7695 
  - API Servlet registration: https://github.com/wso2/product-is/pull/26602
  - Service layer scaffolding - Part 1: https://github.com/wso2-extensions/identity-organization-management/pull/586
  - Service layer scaffolding - Part 2: https://github.com/wso2-extensions/identity-organization-management/pull/588
  - Service layer scaffolding - Part 3: https://github.com/wso2-extensions/identity-organization-management/pull/590
  - Service layer scaffolding - Part 4: https://github.com/wso2-extensions/identity-organization-management/pull/592 
  - Service layer scaffolding - Part 5: https://github.com/wso2-extensions/identity-organization-management/pull/595
  - Service layer scaffolding - Part 6: https://github.com/wso2-extensions/identity-organization-management/pull/596
  - Service layer logic impl: https://github.com/wso2-extensions/identity-organization-management/pull/594
  - Service layer policy replacement: https://github.com/wso2-extensions/identity-organization-management/pull/609
  - Service layer role reconciliation: https://github.com/wso2-extensions/identity-organization-management/pull/610 (This PR)
  - Service layer GET sharingMode resolution: https://github.com/wso2-extensions/identity-organization-management/pull/611
  - Service layer GET filter validation: https://github.com/wso2-extensions/identity-organization-management/pull/613
  - Service layer bump: https://github.com/wso2/identity-api-server/pull/1071
  - Integration Tests: https://github.com/wso2/product-is/pull/26997
  - API Docs: https://github.com/wso2/docs-is/pull/5913 

## Related Issues
 - public-issue: https://github.com/wso2/product-is/issues/26395

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined role reconciliation and assignment for shared users across parent/sub-organizations for more consistent updates.
* **Bug Fix**
  * Ensured obsolete shared roles are removed correctly when role-assignment is disabled; fixed a typo in an error message.
* **Documentation**
  * Improved audit logging and internal comments to provide clearer reconciliation details for shared-role changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->