### PR TITLE
Improve input validation for user sharing operations

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImpl.java
@@ -124,14 +124,17 @@ import static org.wso2.carbon.identity.organization.management.organization.user
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.ErrorMessage.ERROR_CODE_INVALID_POLICY;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.ErrorMessage.ERROR_CODE_NULL_SHARE;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.ErrorMessage.ERROR_CODE_NULL_UNSHARE;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.ErrorMessage.ERROR_CODE_ORGANIZATIONS_EMPTY;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.ErrorMessage.ERROR_CODE_ORGANIZATIONS_NULL;
-import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.ErrorMessage.ERROR_CODE_ORG_ID_NULL;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.ErrorMessage.ERROR_CODE_ORG_ID_BLANK;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.ErrorMessage.ERROR_CODE_POLICY_NULL;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.ErrorMessage.ERROR_CODE_ROLES_NULL;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.ErrorMessage.ERROR_CODE_ROLE_NAME_NULL;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.ErrorMessage.ERROR_CODE_ROLE_NOT_FOUND;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.ErrorMessage.ERROR_CODE_USER_CRITERIA_INVALID;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.ErrorMessage.ERROR_CODE_USER_CRITERIA_MISSING;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.ErrorMessage.ERROR_CODE_USER_IDS_EMPTY;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.ErrorMessage.ERROR_CODE_USER_ID_BLANK;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.ErrorMessage.ERROR_CODE_USER_SHARE;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.ErrorMessage.ERROR_CODE_USER_UNSHARE;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.ErrorMessage.ERROR_GENERAL_SHARE;
@@ -1770,12 +1773,20 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
             throwValidationException(ERROR_CODE_USER_CRITERIA_MISSING);
         }
 
+        // Validate userIds list is not empty and each userId is not blank.
+        validateUserIdList(selectiveUserShareDO.getUserCriteria());
+
         // Validate organizations list is not null.
         validateNotNull(selectiveUserShareDO.getOrganizations(), ERROR_CODE_ORGANIZATIONS_NULL);
 
+        // Validate organizations list is not empty.
+        if (selectiveUserShareDO.getOrganizations().isEmpty()) {
+            throwValidationException(ERROR_CODE_ORGANIZATIONS_EMPTY);
+        }
+
         // Validate each organization in the list.
         for (SelectiveUserShareOrgDetailsDO orgDetails : selectiveUserShareDO.getOrganizations()) {
-            validateNotNull(orgDetails.getOrganizationId(), ERROR_CODE_ORG_ID_NULL);
+            validateNotBlank(orgDetails.getOrganizationId(), ERROR_CODE_ORG_ID_BLANK);
             validateNotNull(orgDetails.getPolicy(), ERROR_CODE_POLICY_NULL);
 
             // Validate roles list is not null (it can be empty).
@@ -1798,6 +1809,7 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
         if (!generalDO.getUserCriteria().containsKey(USER_IDS) || generalDO.getUserCriteria().get(USER_IDS) == null) {
             throwValidationException(ERROR_CODE_USER_CRITERIA_MISSING);
         }
+        validateUserIdList(generalDO.getUserCriteria());
         validateNotNull(generalDO.getPolicy(), ERROR_CODE_POLICY_NULL);
         validateNotNull(generalDO.getRoles(), ERROR_CODE_ROLES_NULL);
 
@@ -1835,11 +1847,19 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
             throwValidationException(ERROR_CODE_USER_CRITERIA_MISSING);
         }
 
+        // Validate userIds list is not empty and each userId is not blank.
+        validateUserIdList(selectiveUserUnshareDO.getUserCriteria());
+
         // Validate organizations list is not null.
         validateNotNull(selectiveUserUnshareDO.getOrganizations(), ERROR_CODE_ORGANIZATIONS_NULL);
 
+        // Validate organizations list is not empty.
+        if (selectiveUserUnshareDO.getOrganizations().isEmpty()) {
+            throwValidationException(ERROR_CODE_ORGANIZATIONS_EMPTY);
+        }
+
         for (String organization : selectiveUserUnshareDO.getOrganizations()) {
-            validateNotNull(organization, ERROR_CODE_ORG_ID_NULL);
+            validateNotBlank(organization, ERROR_CODE_ORG_ID_BLANK);
         }
     }
 
@@ -1854,6 +1874,9 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
                 generalUserUnshareDO.getUserCriteria().get(USER_IDS) == null) {
             throwValidationException(ERROR_CODE_USER_CRITERIA_MISSING);
         }
+
+        // Validate userIds list is not empty and each userId is not blank.
+        validateUserIdList(generalUserUnshareDO.getUserCriteria());
     }
 
     private void validateNotNull(Object obj, UserSharingConstants.ErrorMessage error)
@@ -1861,6 +1884,27 @@ public class UserSharingPolicyHandlerServiceImpl implements UserSharingPolicyHan
 
         if (obj == null) {
             throwValidationException(error);
+        }
+    }
+
+    private void validateNotBlank(String value, UserSharingConstants.ErrorMessage error)
+            throws UserSharingMgtClientException {
+
+        if (StringUtils.isBlank(value)) {
+            throwValidationException(error);
+        }
+    }
+
+    private void validateUserIdList(Map<String, ? extends UserCriteriaType> userCriteria)
+            throws UserSharingMgtClientException {
+
+        UserIdList userIdList = (UserIdList) userCriteria.get(USER_IDS);
+        List<String> ids = userIdList.getIds();
+        if (ids == null || ids.isEmpty()) {
+            throwValidationException(ERROR_CODE_USER_IDS_EMPTY);
+        }
+        for (String userId : ids) {
+            validateNotBlank(userId, ERROR_CODE_USER_ID_BLANK);
         }
     }
 

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImplV2.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImplV2.java
@@ -133,8 +133,10 @@ import static org.wso2.carbon.identity.organization.management.organization.user
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.ErrorMessage.ERROR_CODE_INVALID_POLICY;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.ErrorMessage.ERROR_CODE_NULL_SHARE;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.ErrorMessage.ERROR_CODE_NULL_UNSHARE;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.ErrorMessage.ERROR_CODE_ORGANIZATIONS_EMPTY;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.ErrorMessage.ERROR_CODE_ORGANIZATIONS_NULL;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.ErrorMessage.ERROR_CODE_ORG_DETAILS_NULL;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.ErrorMessage.ERROR_CODE_ORG_ID_BLANK;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.ErrorMessage.ERROR_CODE_ORG_ID_INVALID_FORMAT;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.ErrorMessage.ERROR_CODE_ORG_ID_NULL;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.ErrorMessage.ERROR_CODE_PATCH_OPERATIONS_NULL;
@@ -154,6 +156,8 @@ import static org.wso2.carbon.identity.organization.management.organization.user
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.ErrorMessage.ERROR_CODE_ROLE_NOT_FOUND;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.ErrorMessage.ERROR_CODE_USER_CRITERIA_INVALID;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.ErrorMessage.ERROR_CODE_USER_CRITERIA_MISSING;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.ErrorMessage.ERROR_CODE_USER_IDS_EMPTY;
+import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.ErrorMessage.ERROR_CODE_USER_ID_BLANK;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.ErrorMessage.ERROR_CODE_USER_ID_NULL;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.ErrorMessage.ERROR_CODE_USER_SHARE;
 import static org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.UserSharingConstants.ErrorMessage.ERROR_CODE_USER_SHARE_ROLE_ASSIGNMENT_UPDATE;
@@ -2341,11 +2345,16 @@ public class UserSharingPolicyHandlerServiceImplV2 implements UserSharingPolicyH
                 selectiveUserShareV2DO.getUserCriteria().get(USER_IDS) == null) {
             throwValidationException(ERROR_CODE_USER_CRITERIA_MISSING);
         }
+        validateUserIdList(selectiveUserShareV2DO.getUserCriteria());
         validateNotNull(selectiveUserShareV2DO.getOrganizations(), ERROR_CODE_ORGANIZATIONS_NULL);
+
+        if (selectiveUserShareV2DO.getOrganizations().isEmpty()) {
+            throwValidationException(ERROR_CODE_ORGANIZATIONS_EMPTY);
+        }
 
         for (SelectiveUserShareOrgDetailsV2DO orgDetails : selectiveUserShareV2DO.getOrganizations()) {
             validateNotNull(orgDetails, ERROR_CODE_ORG_DETAILS_NULL);
-            validateNotNull(orgDetails.getOrganizationId(), ERROR_CODE_ORG_ID_NULL);
+            validateNotBlank(orgDetails.getOrganizationId(), ERROR_CODE_ORG_ID_BLANK);
             validateNotNull(orgDetails.getPolicy(), ERROR_CODE_POLICY_NULL);
             validateRoleAssignments(orgDetails.getRoleAssignments());
         }
@@ -2361,6 +2370,7 @@ public class UserSharingPolicyHandlerServiceImplV2 implements UserSharingPolicyH
                 generalUserShareV2DO.getUserCriteria().get(USER_IDS) == null) {
             throwValidationException(ERROR_CODE_USER_CRITERIA_MISSING);
         }
+        validateUserIdList(generalUserShareV2DO.getUserCriteria());
         validateNotNull(generalUserShareV2DO.getPolicy(), ERROR_CODE_POLICY_NULL);
         validateRoleAssignments(generalUserShareV2DO.getRoleAssignments());
 
@@ -2395,11 +2405,19 @@ public class UserSharingPolicyHandlerServiceImplV2 implements UserSharingPolicyH
             throwValidationException(ERROR_CODE_USER_CRITERIA_MISSING);
         }
 
+        // Validate userIds list is not empty and each userId is not blank.
+        validateUserIdList(selectiveUserUnshareDO.getUserCriteria());
+
         // Validate organizations list is not null.
         validateNotNull(selectiveUserUnshareDO.getOrganizations(), ERROR_CODE_ORGANIZATIONS_NULL);
 
+        // Validate organizations list is not empty.
+        if (selectiveUserUnshareDO.getOrganizations().isEmpty()) {
+            throwValidationException(ERROR_CODE_ORGANIZATIONS_EMPTY);
+        }
+
         for (String organization : selectiveUserUnshareDO.getOrganizations()) {
-            validateNotNull(organization, ERROR_CODE_ORG_ID_NULL);
+            validateNotBlank(organization, ERROR_CODE_ORG_ID_BLANK);
         }
 
         LOG.debug("Validated selective user unshare V2 DO successfully.");
@@ -2416,6 +2434,9 @@ public class UserSharingPolicyHandlerServiceImplV2 implements UserSharingPolicyH
                 generalUserUnshareDO.getUserCriteria().get(USER_IDS) == null) {
             throwValidationException(ERROR_CODE_USER_CRITERIA_MISSING);
         }
+
+        // Validate userIds list is not empty and each userId is not blank.
+        validateUserIdList(generalUserUnshareDO.getUserCriteria());
 
         LOG.debug("Validated general user unshare V2 DO successfully.");
     }
@@ -2434,6 +2455,7 @@ public class UserSharingPolicyHandlerServiceImplV2 implements UserSharingPolicyH
                 userSharePatchDO.getUserCriteria().get(USER_IDS) == null) {
             throwValidationException(ERROR_CODE_USER_CRITERIA_MISSING);
         }
+        validateUserIdList(userSharePatchDO.getUserCriteria());
 
         // 3. validate operations is not null (empty list is okay).
         validateNotNull(userSharePatchDO.getPatchOperations(), ERROR_CODE_PATCH_OPERATIONS_NULL);
@@ -2615,6 +2637,27 @@ public class UserSharingPolicyHandlerServiceImplV2 implements UserSharingPolicyH
 
         if (obj == null) {
             throwValidationException(error);
+        }
+    }
+
+    private void validateNotBlank(String value, UserSharingConstants.ErrorMessage error)
+            throws UserSharingMgtClientException {
+
+        if (StringUtils.isBlank(value)) {
+            throwValidationException(error);
+        }
+    }
+
+    private void validateUserIdList(Map<String, ? extends UserCriteriaType> userCriteria)
+            throws UserSharingMgtClientException {
+
+        UserIdList userIdList = (UserIdList) userCriteria.get(USER_IDS);
+        List<String> ids = userIdList.getIds();
+        if (ids == null || ids.isEmpty()) {
+            throwValidationException(ERROR_CODE_USER_IDS_EMPTY);
+        }
+        for (String userId : ids) {
+            validateNotBlank(userId, ERROR_CODE_USER_ID_BLANK);
         }
     }
 

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/constant/UserSharingConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/constant/UserSharingConstants.java
@@ -358,7 +358,19 @@ public class UserSharingConstants {
                 "One of the attribute names provided is null and must be valid."),
         ERROR_CODE_INVALID_FILTER_VALUE("10069",
                 "Invalid filter value provided: %s.",
-                "The filter value provided is invalid and cannot be processed.");
+                "The filter value provided is invalid and cannot be processed."),
+        ERROR_CODE_USER_IDS_EMPTY("10070",
+                "User IDs list is empty.",
+                "The user IDs list must contain at least one user ID."),
+        ERROR_CODE_USER_ID_BLANK("10071",
+                "User ID is blank.",
+                "A user ID in the list is null, empty, or contains only whitespace."),
+        ERROR_CODE_ORG_ID_BLANK("10072",
+                "Organization ID is blank.",
+                "An organization ID is empty or contains only whitespace."),
+        ERROR_CODE_ORGANIZATIONS_EMPTY("10073",
+                "Organizations list is empty.",
+                "The organizations list must contain at least one organization.");
 
         private final String code;
         private final String message;

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/test/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImplTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/test/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImplTest.java
@@ -32,13 +32,21 @@ import org.wso2.carbon.identity.organization.management.organization.user.sharin
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.exception.UserSharingMgtClientException;
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.internal.OrganizationUserSharingDataHolder;
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.models.UserAssociation;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.models.dos.GeneralUserShareDO;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.models.dos.GeneralUserUnshareDO;
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.models.dos.ResponseOrgDetailsDO;
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.models.dos.ResponseSharedOrgsDO;
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.models.dos.ResponseSharedRolesDO;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.models.dos.SelectiveUserShareDO;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.models.dos.SelectiveUserShareOrgDetailsDO;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.models.dos.SelectiveUserUnshareDO;
 import org.wso2.carbon.identity.organization.management.organization.user.sharing.models.dos.UserSharingResultDO;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.models.usercriteria.UserCriteriaType;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.models.usercriteria.UserIdList;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 import org.wso2.carbon.identity.organization.management.service.util.Utils;
+import org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.PolicyEnum;
 import org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService;
 import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementException;
 import org.wso2.carbon.identity.role.v2.mgt.core.model.Role;
@@ -578,6 +586,181 @@ public class UserSharingPolicyHandlerServiceImplTest {
         role2.setAudience(APPLICATION_AUDIENCE);
 
         return Arrays.asList(role1, role2);
+    }
+
+    // Input Validation Tests.
+
+    @DataProvider(name = "selectiveShareValidationDataProvider")
+    public Object[][] selectiveShareValidationDataProvider() {
+
+        return new Object[][]{
+                // Empty userIds list.
+                {Collections.emptyList(), ORG_1_ID, "OUS-10070"},
+                // Null userId in list.
+                {Arrays.asList(USER_1_ID, null), ORG_1_ID, "OUS-10071"},
+                // Empty string userId.
+                {Collections.singletonList(""), ORG_1_ID, "OUS-10071"},
+                // Whitespace-only userId.
+                {Collections.singletonList("   "), ORG_1_ID, "OUS-10071"},
+                // Valid userIds but empty organizations list.
+                {Collections.singletonList(USER_1_ID), null, "OUS-10073"},
+                // Valid userIds but blank orgId.
+                {Collections.singletonList(USER_1_ID), "", "OUS-10072"},
+                // Valid userIds but whitespace-only orgId.
+                {Collections.singletonList(USER_1_ID), "   ", "OUS-10072"},
+        };
+    }
+
+    @Test(dataProvider = "selectiveShareValidationDataProvider")
+    public void testValidateSelectiveUserShareDO(List<String> userIds, String orgId, String expectedErrorCode)
+            throws Exception {
+
+        SelectiveUserShareDO selectiveUserShareDO = new SelectiveUserShareDO();
+        Map<String, UserCriteriaType> userCriteria = new HashMap<>();
+        userCriteria.put("userIds", new UserIdList(userIds));
+        selectiveUserShareDO.setUserCriteria(userCriteria);
+
+        if (orgId == null) {
+            // Empty organizations list case.
+            selectiveUserShareDO.setOrganizations(new ArrayList<>());
+        } else {
+            SelectiveUserShareOrgDetailsDO orgDetails = new SelectiveUserShareOrgDetailsDO();
+            orgDetails.setOrganizationId(orgId);
+            orgDetails.setPolicy(PolicyEnum.SELECTED_ORG_ONLY);
+            orgDetails.setRoles(new ArrayList<>());
+            selectiveUserShareDO.setOrganizations(Collections.singletonList(orgDetails));
+        }
+
+        Method method = UserSharingPolicyHandlerServiceImpl.class.getDeclaredMethod(
+                "validateSelectiveUserShareDO", SelectiveUserShareDO.class);
+        method.setAccessible(true);
+
+        try {
+            method.invoke(userSharingPolicyHandlerService, selectiveUserShareDO);
+        } catch (java.lang.reflect.InvocationTargetException e) {
+            assertTrue(e.getCause() instanceof UserSharingMgtClientException, VALIDATE_MSG_EXCEPTION);
+            UserSharingMgtClientException clientException = (UserSharingMgtClientException) e.getCause();
+            assertEquals(clientException.getErrorCode(), expectedErrorCode,
+                    "Expected error code " + expectedErrorCode);
+            return;
+        }
+        throw new AssertionError("Expected UserSharingMgtClientException was not thrown.");
+    }
+
+    @DataProvider(name = "generalShareValidationDataProvider")
+    public Object[][] generalShareValidationDataProvider() {
+
+        return new Object[][]{
+                {Collections.emptyList(), "OUS-10070"},
+                {Arrays.asList(USER_1_ID, null), "OUS-10071"},
+                {Collections.singletonList(""), "OUS-10071"},
+                {Collections.singletonList("   "), "OUS-10071"},
+        };
+    }
+
+    @Test(dataProvider = "generalShareValidationDataProvider")
+    public void testValidateGeneralUserShareDO(List<String> userIds, String expectedErrorCode) throws Exception {
+
+        GeneralUserShareDO generalUserShareDO = new GeneralUserShareDO();
+        Map<String, UserCriteriaType> userCriteria = new HashMap<>();
+        userCriteria.put("userIds", new UserIdList(userIds));
+        generalUserShareDO.setUserCriteria(userCriteria);
+        generalUserShareDO.setPolicy(PolicyEnum.SELECTED_ORG_ONLY);
+        generalUserShareDO.setRoles(new ArrayList<>());
+
+        Method method = UserSharingPolicyHandlerServiceImpl.class.getDeclaredMethod(
+                "validateGeneralUserShareDO", GeneralUserShareDO.class);
+        method.setAccessible(true);
+
+        try {
+            method.invoke(userSharingPolicyHandlerService, generalUserShareDO);
+        } catch (java.lang.reflect.InvocationTargetException e) {
+            assertTrue(e.getCause() instanceof UserSharingMgtClientException, VALIDATE_MSG_EXCEPTION);
+            UserSharingMgtClientException clientException = (UserSharingMgtClientException) e.getCause();
+            assertEquals(clientException.getErrorCode(), expectedErrorCode,
+                    "Expected error code " + expectedErrorCode);
+            return;
+        }
+        throw new AssertionError("Expected UserSharingMgtClientException was not thrown.");
+    }
+
+    @DataProvider(name = "selectiveUnshareValidationDataProvider")
+    public Object[][] selectiveUnshareValidationDataProvider() {
+
+        return new Object[][]{
+                {Collections.emptyList(), ORG_1_ID, "OUS-10070"},
+                {Collections.singletonList(null), ORG_1_ID, "OUS-10071"},
+                {Collections.singletonList(""), ORG_1_ID, "OUS-10071"},
+                {Collections.singletonList(USER_1_ID), null, "OUS-10073"},
+                {Collections.singletonList(USER_1_ID), "", "OUS-10072"},
+                {Collections.singletonList(USER_1_ID), "   ", "OUS-10072"},
+        };
+    }
+
+    @Test(dataProvider = "selectiveUnshareValidationDataProvider")
+    public void testValidateSelectiveUserUnshareDO(List<String> userIds, String orgId, String expectedErrorCode)
+            throws Exception {
+
+        SelectiveUserUnshareDO selectiveUserUnshareDO = new SelectiveUserUnshareDO();
+        Map<String, UserCriteriaType> userCriteria = new HashMap<>();
+        userCriteria.put("userIds", new UserIdList(userIds));
+        selectiveUserUnshareDO.setUserCriteria(userCriteria);
+
+        if (orgId == null) {
+            selectiveUserUnshareDO.setOrganizations(new ArrayList<>());
+        } else {
+            selectiveUserUnshareDO.setOrganizations(Collections.singletonList(orgId));
+        }
+
+        Method method = UserSharingPolicyHandlerServiceImpl.class.getDeclaredMethod(
+                "validateSelectiveUserUnshareDO", SelectiveUserUnshareDO.class);
+        method.setAccessible(true);
+
+        try {
+            method.invoke(userSharingPolicyHandlerService, selectiveUserUnshareDO);
+        } catch (java.lang.reflect.InvocationTargetException e) {
+            assertTrue(e.getCause() instanceof UserSharingMgtClientException, VALIDATE_MSG_EXCEPTION);
+            UserSharingMgtClientException clientException = (UserSharingMgtClientException) e.getCause();
+            assertEquals(clientException.getErrorCode(), expectedErrorCode,
+                    "Expected error code " + expectedErrorCode);
+            return;
+        }
+        throw new AssertionError("Expected UserSharingMgtClientException was not thrown.");
+    }
+
+    @DataProvider(name = "generalUnshareValidationDataProvider")
+    public Object[][] generalUnshareValidationDataProvider() {
+
+        return new Object[][]{
+                {Collections.emptyList(), "OUS-10070"},
+                {Collections.singletonList(null), "OUS-10071"},
+                {Collections.singletonList(""), "OUS-10071"},
+                {Collections.singletonList("   "), "OUS-10071"},
+        };
+    }
+
+    @Test(dataProvider = "generalUnshareValidationDataProvider")
+    public void testValidateGeneralUserUnshareDO(List<String> userIds, String expectedErrorCode) throws Exception {
+
+        GeneralUserUnshareDO generalUserUnshareDO = new GeneralUserUnshareDO();
+        Map<String, UserCriteriaType> userCriteria = new HashMap<>();
+        userCriteria.put("userIds", new UserIdList(userIds));
+        generalUserUnshareDO.setUserCriteria(userCriteria);
+
+        Method method = UserSharingPolicyHandlerServiceImpl.class.getDeclaredMethod(
+                "validateGeneralUserUnshareDO", GeneralUserUnshareDO.class);
+        method.setAccessible(true);
+
+        try {
+            method.invoke(userSharingPolicyHandlerService, generalUserUnshareDO);
+        } catch (java.lang.reflect.InvocationTargetException e) {
+            assertTrue(e.getCause() instanceof UserSharingMgtClientException, VALIDATE_MSG_EXCEPTION);
+            UserSharingMgtClientException clientException = (UserSharingMgtClientException) e.getCause();
+            assertEquals(clientException.getErrorCode(), expectedErrorCode,
+                    "Expected error code " + expectedErrorCode);
+            return;
+        }
+        throw new AssertionError("Expected UserSharingMgtClientException was not thrown.");
     }
 
     // Helper Methods.

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/test/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImplV2Test.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/test/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImplV2Test.java
@@ -21,15 +21,36 @@ package org.wso2.carbon.identity.organization.management.organization.user.shari
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.constant.RoleAssignmentMode;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.exception.UserSharingMgtClientException;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.models.dos.GeneralUserShareV2DO;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.models.dos.GeneralUserUnshareDO;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.models.dos.RoleAssignmentDO;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.models.dos.SelectiveUserShareOrgDetailsV2DO;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.models.dos.SelectiveUserShareV2DO;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.models.dos.SelectiveUserUnshareDO;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.models.usercriteria.UserCriteriaType;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.models.usercriteria.UserIdList;
+import org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.PolicyEnum;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 /**
  * Unit tests for UserSharingPolicyHandlerServiceImplV2.
  */
 public class UserSharingPolicyHandlerServiceImplV2Test {
+
+    private static final String USER_1_ID = "user-1-id";
+    private static final String ORG_1_ID = "org-1-id";
 
     private UserSharingPolicyHandlerServiceImplV2 userSharingPolicyHandlerService;
 
@@ -60,5 +81,180 @@ public class UserSharingPolicyHandlerServiceImplV2Test {
         String actualUsername = (String) method.invoke(userSharingPolicyHandlerService, originalUsername);
 
         assertEquals(actualUsername, expectedUsername);
+    }
+
+    // Input Validation Tests.
+
+    @DataProvider(name = "selectiveShareV2ValidationDataProvider")
+    public Object[][] selectiveShareV2ValidationDataProvider() {
+
+        return new Object[][]{
+                {Collections.emptyList(), ORG_1_ID, "OUS-10070"},
+                {Arrays.asList(USER_1_ID, null), ORG_1_ID, "OUS-10071"},
+                {Collections.singletonList(""), ORG_1_ID, "OUS-10071"},
+                {Collections.singletonList("   "), ORG_1_ID, "OUS-10071"},
+                {Collections.singletonList(USER_1_ID), null, "OUS-10073"},
+                {Collections.singletonList(USER_1_ID), "", "OUS-10072"},
+                {Collections.singletonList(USER_1_ID), "   ", "OUS-10072"},
+        };
+    }
+
+    @Test(dataProvider = "selectiveShareV2ValidationDataProvider")
+    public void testValidateSelectiveUserShareV2DO(List<String> userIds, String orgId, String expectedErrorCode)
+            throws Exception {
+
+        SelectiveUserShareV2DO selectiveUserShareV2DO = new SelectiveUserShareV2DO();
+        Map<String, UserCriteriaType> userCriteria = new HashMap<>();
+        userCriteria.put("userIds", new UserIdList(userIds));
+        selectiveUserShareV2DO.setUserCriteria(userCriteria);
+
+        if (orgId == null) {
+            selectiveUserShareV2DO.setOrganizations(new ArrayList<>());
+        } else {
+            SelectiveUserShareOrgDetailsV2DO orgDetails = new SelectiveUserShareOrgDetailsV2DO();
+            orgDetails.setOrganizationId(orgId);
+            orgDetails.setPolicy(PolicyEnum.SELECTED_ORG_ONLY);
+            RoleAssignmentDO roleAssignment = new RoleAssignmentDO();
+            roleAssignment.setMode(RoleAssignmentMode.NONE);
+            orgDetails.setRoleAssignments(roleAssignment);
+            selectiveUserShareV2DO.setOrganizations(Collections.singletonList(orgDetails));
+        }
+
+        Method method = UserSharingPolicyHandlerServiceImplV2.class.getDeclaredMethod(
+                "validateSelectiveUserShareV2DO", SelectiveUserShareV2DO.class);
+        method.setAccessible(true);
+
+        try {
+            method.invoke(userSharingPolicyHandlerService, selectiveUserShareV2DO);
+        } catch (java.lang.reflect.InvocationTargetException e) {
+            assertTrue(e.getCause() instanceof UserSharingMgtClientException,
+                    "Expected UserSharingMgtClientException");
+            UserSharingMgtClientException clientException = (UserSharingMgtClientException) e.getCause();
+            assertEquals(clientException.getErrorCode(), expectedErrorCode,
+                    "Expected error code " + expectedErrorCode);
+            return;
+        }
+        throw new AssertionError("Expected UserSharingMgtClientException was not thrown.");
+    }
+
+    @DataProvider(name = "generalShareV2ValidationDataProvider")
+    public Object[][] generalShareV2ValidationDataProvider() {
+
+        return new Object[][]{
+                {Collections.emptyList(), "OUS-10070"},
+                {Arrays.asList(USER_1_ID, null), "OUS-10071"},
+                {Collections.singletonList(""), "OUS-10071"},
+                {Collections.singletonList("   "), "OUS-10071"},
+        };
+    }
+
+    @Test(dataProvider = "generalShareV2ValidationDataProvider")
+    public void testValidateGeneralUserShareV2DO(List<String> userIds, String expectedErrorCode) throws Exception {
+
+        GeneralUserShareV2DO generalUserShareV2DO = new GeneralUserShareV2DO();
+        Map<String, UserCriteriaType> userCriteria = new HashMap<>();
+        userCriteria.put("userIds", new UserIdList(userIds));
+        generalUserShareV2DO.setUserCriteria(userCriteria);
+        generalUserShareV2DO.setPolicy(PolicyEnum.SELECTED_ORG_ONLY);
+        RoleAssignmentDO roleAssignment = new RoleAssignmentDO();
+        roleAssignment.setMode(RoleAssignmentMode.NONE);
+        generalUserShareV2DO.setRoleAssignments(roleAssignment);
+
+        Method method = UserSharingPolicyHandlerServiceImplV2.class.getDeclaredMethod(
+                "validateGeneralUserShareV2DO", GeneralUserShareV2DO.class);
+        method.setAccessible(true);
+
+        try {
+            method.invoke(userSharingPolicyHandlerService, generalUserShareV2DO);
+        } catch (java.lang.reflect.InvocationTargetException e) {
+            assertTrue(e.getCause() instanceof UserSharingMgtClientException,
+                    "Expected UserSharingMgtClientException");
+            UserSharingMgtClientException clientException = (UserSharingMgtClientException) e.getCause();
+            assertEquals(clientException.getErrorCode(), expectedErrorCode,
+                    "Expected error code " + expectedErrorCode);
+            return;
+        }
+        throw new AssertionError("Expected UserSharingMgtClientException was not thrown.");
+    }
+
+    @DataProvider(name = "selectiveUnshareValidationDataProvider")
+    public Object[][] selectiveUnshareValidationDataProvider() {
+
+        return new Object[][]{
+                {Collections.emptyList(), ORG_1_ID, "OUS-10070"},
+                {Collections.singletonList(null), ORG_1_ID, "OUS-10071"},
+                {Collections.singletonList(""), ORG_1_ID, "OUS-10071"},
+                {Collections.singletonList(USER_1_ID), null, "OUS-10073"},
+                {Collections.singletonList(USER_1_ID), "", "OUS-10072"},
+                {Collections.singletonList(USER_1_ID), "   ", "OUS-10072"},
+        };
+    }
+
+    @Test(dataProvider = "selectiveUnshareValidationDataProvider")
+    public void testValidateSelectiveUserUnshareDO(List<String> userIds, String orgId, String expectedErrorCode)
+            throws Exception {
+
+        SelectiveUserUnshareDO selectiveUserUnshareDO = new SelectiveUserUnshareDO();
+        Map<String, UserCriteriaType> userCriteria = new HashMap<>();
+        userCriteria.put("userIds", new UserIdList(userIds));
+        selectiveUserUnshareDO.setUserCriteria(userCriteria);
+
+        if (orgId == null) {
+            selectiveUserUnshareDO.setOrganizations(new ArrayList<>());
+        } else {
+            selectiveUserUnshareDO.setOrganizations(Collections.singletonList(orgId));
+        }
+
+        Method method = UserSharingPolicyHandlerServiceImplV2.class.getDeclaredMethod(
+                "validateSelectiveUserUnshareDO", SelectiveUserUnshareDO.class);
+        method.setAccessible(true);
+
+        try {
+            method.invoke(userSharingPolicyHandlerService, selectiveUserUnshareDO);
+        } catch (java.lang.reflect.InvocationTargetException e) {
+            assertTrue(e.getCause() instanceof UserSharingMgtClientException,
+                    "Expected UserSharingMgtClientException");
+            UserSharingMgtClientException clientException = (UserSharingMgtClientException) e.getCause();
+            assertEquals(clientException.getErrorCode(), expectedErrorCode,
+                    "Expected error code " + expectedErrorCode);
+            return;
+        }
+        throw new AssertionError("Expected UserSharingMgtClientException was not thrown.");
+    }
+
+    @DataProvider(name = "generalUnshareValidationDataProvider")
+    public Object[][] generalUnshareValidationDataProvider() {
+
+        return new Object[][]{
+                {Collections.emptyList(), "OUS-10070"},
+                {Collections.singletonList(null), "OUS-10071"},
+                {Collections.singletonList(""), "OUS-10071"},
+                {Collections.singletonList("   "), "OUS-10071"},
+        };
+    }
+
+    @Test(dataProvider = "generalUnshareValidationDataProvider")
+    public void testValidateGeneralUserUnshareDO(List<String> userIds, String expectedErrorCode) throws Exception {
+
+        GeneralUserUnshareDO generalUserUnshareDO = new GeneralUserUnshareDO();
+        Map<String, UserCriteriaType> userCriteria = new HashMap<>();
+        userCriteria.put("userIds", new UserIdList(userIds));
+        generalUserUnshareDO.setUserCriteria(userCriteria);
+
+        Method method = UserSharingPolicyHandlerServiceImplV2.class.getDeclaredMethod(
+                "validateGeneralUserUnshareDO", GeneralUserUnshareDO.class);
+        method.setAccessible(true);
+
+        try {
+            method.invoke(userSharingPolicyHandlerService, generalUserUnshareDO);
+        } catch (java.lang.reflect.InvocationTargetException e) {
+            assertTrue(e.getCause() instanceof UserSharingMgtClientException,
+                    "Expected UserSharingMgtClientException");
+            UserSharingMgtClientException clientException = (UserSharingMgtClientException) e.getCause();
+            assertEquals(clientException.getErrorCode(), expectedErrorCode,
+                    "Expected error code " + expectedErrorCode);
+            return;
+        }
+        throw new AssertionError("Expected UserSharingMgtClientException was not thrown.");
     }
 }


### PR DESCRIPTION
## Summary

Fixes: https://github.com/wso2/product-is/issues/26490

- Add validation to reject empty user ID lists and blank user IDs in share/unshare requests
- Add validation to reject empty organization lists and blank organization IDs
- Apply stricter validation (blank check instead of null check) for org IDs across selective share/unshare flows
- Add corresponding unit tests for all new validation paths in both V1 and V2 implementations

## Test plan
- [ ] Verify existing unit tests pass
- [ ] Verify new validation tests cover empty lists, blank IDs, and null checks
- [ ] Test share/unshare API calls with empty/blank inputs return proper error responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)