### PR TITLE
Fix role patch operations not cascading to descendant organizations in user sharing

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImplV2.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImplV2.java
@@ -1496,13 +1496,19 @@ public class UserSharingPolicyHandlerServiceImplV2 implements UserSharingPolicyH
                 }
                 continue;
             }
-            switch (patchOperation.getOperation()) {
-                case ADD:
-                    handleRoleAssignmentAddition(userAssociation, sharingInitiatedOrgId, roleIds);
-                    break;
-                case REMOVE:
-                    handleRoleAssignmentRemoval(userAssociation, roleIds);
-                    break;
+            try {
+                switch (patchOperation.getOperation()) {
+                    case ADD:
+                        handleRoleAssignmentAddition(userAssociation, sharingInitiatedOrgId, roleIds);
+                        break;
+                    case REMOVE:
+                        handleRoleAssignmentRemoval(userAssociation, roleIds);
+                        break;
+                }
+            } catch (OrganizationManagementException | IdentityRoleManagementException e) {
+                LOG.warn("Error occurred while performing " + patchOperation.getOperation()
+                        + " role assignment update for user: " + associatedUserId + " in organization: "
+                        + targetOrgId + ". Skipping and continuing with remaining organizations.", e);
             }
         }
     }

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImplV2.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImplV2.java
@@ -1477,17 +1477,29 @@ public class UserSharingPolicyHandlerServiceImplV2 implements UserSharingPolicyH
 
         logAsyncProcessing(ACTION_USER_SHARE_ROLE_ASSIGNMENT_UPDATE, sharingInitiatedUserId, sharingInitiatedOrgId);
         String orgId = extractOrgIdFromRolesPath(patchOperation.getPath());
-        UserAssociation userAssociation =
-                getOrganizationUserSharingService().getUserAssociationOfAssociatedUserByOrgId(associatedUserId, orgId);
         List<String> roleIds =
                 getRoleIds(castToRoleWithAudienceList(patchOperation.getValues()), sharingInitiatedOrgId);
-        switch (patchOperation.getOperation()) {
-            case ADD:
-                handleRoleAssignmentAddition(userAssociation, sharingInitiatedOrgId, roleIds);
-                break;
-            case REMOVE:
-                handleRoleAssignmentRemoval(userAssociation, roleIds);
-                break;
+
+        // Build the list of orgs to update: the target org plus all its descendants.
+        List<String> orgIdsToUpdate = new ArrayList<>();
+        orgIdsToUpdate.add(orgId);
+        orgIdsToUpdate.addAll(getOrganizationManager().getChildOrganizationsIds(orgId, true));
+
+        for (String targetOrgId : orgIdsToUpdate) {
+            UserAssociation userAssociation =
+                    getOrganizationUserSharingService().getUserAssociationOfAssociatedUserByOrgId(associatedUserId,
+                            targetOrgId);
+            if (userAssociation == null) {
+                continue;
+            }
+            switch (patchOperation.getOperation()) {
+                case ADD:
+                    handleRoleAssignmentAddition(userAssociation, sharingInitiatedOrgId, roleIds);
+                    break;
+                case REMOVE:
+                    handleRoleAssignmentRemoval(userAssociation, roleIds);
+                    break;
+            }
         }
     }
 

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImplV2.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImplV2.java
@@ -1490,6 +1490,10 @@ public class UserSharingPolicyHandlerServiceImplV2 implements UserSharingPolicyH
                     getOrganizationUserSharingService().getUserAssociationOfAssociatedUserByOrgId(associatedUserId,
                             targetOrgId);
             if (userAssociation == null) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("No user association found for user: " + associatedUserId + " in organization: "
+                            + targetOrgId + ". Skipping role assignment update for this organization.");
+                }
                 continue;
             }
             switch (patchOperation.getOperation()) {


### PR DESCRIPTION
### Purpose
Fixes a bug where PATCH operations (add/remove roles) on a shared user targeting a specific organization did not propagate to its descendant organizations in the hierarchy.

### Goals
 - Ensure role ADD operations via PATCH cascade to all descendant orgs under the targeted org.
 - Ensure role REMOVE operations via PATCH cascade to all descendant orgs under the targeted org.
 - Preserve correct behavior for leaf nodes (orgs with no children).

### Approach
 - In `updateRoleAssignmentsOfSharedUser`, after extracting the target `orgId` from the patch path, retrieve all descendant org IDs using the existing `getOrganizationManager().getChildOrganizationsIds(orgId, true)` utility.
 - Build a unified list of `[targetOrgId] + descendantOrgIds` and iterate over it, applying the role add/remove to each org where the user has an active association.
 - Skip orgs where `getUserAssociationOfAssociatedUserByOrgId` returns `null` (user not shared there), ensuring safe handling of partial sharing scenarios.

### Related Issues
 - https://github.com/wso2/product-is/issues/27487

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Role updates for shared users now apply recursively to descendant organizations, skip organizations without a user association (with improved handling), and correctly perform add/remove role changes across all applicable org levels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->