### PR TITLE
Return an empty list of organization IDs when the database is MSSQL and the limit is zero

### DIFF
--- a/components/org.wso2.carbon.identity.organization.discovery.service/src/main/java/org/wso2/carbon/identity/organization/discovery/service/dao/OrganizationDiscoveryDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.discovery.service/src/main/java/org/wso2/carbon/identity/organization/discovery/service/dao/OrganizationDiscoveryDAOImpl.java
@@ -476,6 +476,9 @@ public class OrganizationDiscoveryDAOImpl implements OrganizationDiscoveryDAO {
                                                      NamedJdbcTemplate namedJdbcTemplate)
             throws OrganizationManagementServerException {
 
+        if (isMSSqlDB() && limit == 0) {
+            return Collections.emptyList();
+        }
         try {
             String orgIdsQuery;
             if (isMSSqlDB() || isOracleDB()) {


### PR DESCRIPTION
## Purpose
> $subject

## Related Issue
- https://github.com/wso2/product-is/issues/27597

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized organization discovery queries to prevent unnecessary database operations in specific database configurations when no results are expected, reducing database load and improving application responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->