### PR TITLE
Improve shared user claim resolution for sub-org apps and enhanced organization login flow.

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/SharedUserOperationEventListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/SharedUserOperationEventListener.java
@@ -146,12 +146,25 @@ public class SharedUserOperationEventListener extends AbstractIdentityUserOperat
             return true;
         }
         String currentTenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+        /*
+         * Need to use the app resident org ID to resolve user claims when shared users login to sub-orgs via
+         * sub-org apps or via enhanced organization login.
+         */
+        String appResidentOrganizationId =
+                PrivilegedCarbonContext.getThreadLocalCarbonContext().getApplicationResidentOrganizationId();
         try {
-            if (!OrganizationManagementUtil.isOrganization(currentTenantDomain)) {
+            if (StringUtils.isBlank(appResidentOrganizationId) &&
+                    !OrganizationManagementUtil.isOrganization(currentTenantDomain)) {
                 // There is no shared users in root organizations. Hence, return.
                 return true;
             }
-            String currentOrganizationId = resolveOrganizationId(currentTenantDomain);
+
+            String currentOrganizationId;
+            if (StringUtils.isNotBlank(appResidentOrganizationId)) {
+                currentOrganizationId = appResidentOrganizationId;
+            } else {
+                currentOrganizationId = resolveOrganizationId(currentTenantDomain);
+            }
             UserAssociation userAssociation = getUserAssociation(userID, currentOrganizationId);
             if (userAssociation == null) {
                 // User is not a shared user. Hence, return.

--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/SharedUserOperationEventListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/listener/SharedUserOperationEventListener.java
@@ -150,18 +150,18 @@ public class SharedUserOperationEventListener extends AbstractIdentityUserOperat
          * Need to use the app resident org ID to resolve user claims when shared users login to sub-orgs via
          * sub-org apps or via enhanced organization login.
          */
-        String appResidentOrganizationId =
-                PrivilegedCarbonContext.getThreadLocalCarbonContext().getApplicationResidentOrganizationId();
+        String accessingOrganizationId =
+                PrivilegedCarbonContext.getThreadLocalCarbonContext().getAccessingOrganizationId();
         try {
-            if (StringUtils.isBlank(appResidentOrganizationId) &&
+            if (StringUtils.isBlank(accessingOrganizationId) &&
                     !OrganizationManagementUtil.isOrganization(currentTenantDomain)) {
                 // There is no shared users in root organizations. Hence, return.
                 return true;
             }
 
             String currentOrganizationId;
-            if (StringUtils.isNotBlank(appResidentOrganizationId)) {
-                currentOrganizationId = appResidentOrganizationId;
+            if (StringUtils.isNotBlank(accessingOrganizationId)) {
+                currentOrganizationId = accessingOrganizationId;
             } else {
                 currentOrganizationId = resolveOrganizationId(currentTenantDomain);
             }

--- a/pom.xml
+++ b/pom.xml
@@ -555,7 +555,7 @@
     <properties>
 
         <!-- Carbon kernel version -->
-        <carbon.kernel.version>4.10.48</carbon.kernel.version>
+        <carbon.kernel.version>4.12.34</carbon.kernel.version>
         <carbon.kernel.package.import.version.range>[4.7.0, 5.0.0)</carbon.kernel.package.import.version.range>
         <carbon.kernel.feature.version>4.6.0</carbon.kernel.feature.version>
 


### PR DESCRIPTION
### Purpose
Improve `SharedUserOperationEventListener` to handle claim resolution when shared users login to sub-organizations via sub-org apps or via enhanced organization authentication. 

During shared user direct logins, we need to resolve the user claim values from the organization hierarchy. With current logic, hierarchical claim resolution is skipped since `PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain()` does not contain the accessing sub-org in sub-org application and enhanced org authentication login flows.

### Related issue
- https://github.com/wso2/product-is/issues/27371

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of user claim resolution in multi-organization scenarios by fixing organization-context handling and edge-case behavior for root vs non-root organizations, reducing incorrect shared-profile attribution.
* **Chores**
  * Updated underlying platform kernel version, aligning managed dependency versions for platform components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->