### PR TITLE
Declare Agent Sharing component as a plugin

### DIFF
--- a/features/org.wso2.carbon.identity.organization.management.server.feature/pom.xml
+++ b/features/org.wso2.carbon.identity.organization.management.server.feature/pom.xml
@@ -73,6 +73,10 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.identity.organization.management</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.organization.agent.sharing</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management</groupId>
             <artifactId>org.wso2.carbon.identity.organization.resource.sharing.policy.management</artifactId>
         </dependency>
         <dependency>
@@ -129,6 +133,7 @@
                                 <bundleDef>org.wso2.carbon.identity.organization.management:org.wso2.carbon.identity.organization.management.claim.provider</bundleDef>
                                 <bundleDef>org.wso2.carbon.identity.organization.management:org.wso2.carbon.identity.organization.management.governance.connector</bundleDef>
                                 <bundleDef>org.wso2.carbon.identity.organization.management:org.wso2.carbon.identity.organization.management.organization.user.sharing</bundleDef>
+                                <bundleDef>org.wso2.carbon.identity.organization.management:org.wso2.carbon.identity.organization.management.organization.agent.sharing</bundleDef>
                                 <bundleDef>org.wso2.carbon.identity.organization.management:org.wso2.carbon.identity.organization.resource.sharing.policy.management</bundleDef>
                                 <bundleDef>org.wso2.carbon.identity.organization.management:org.wso2.carbon.identity.organization.user.invitation.management</bundleDef>
                                 <bundleDef>org.wso2.carbon.identity.organization.management:org.wso2.carbon.identity.organization.config.service</bundleDef>


### PR DESCRIPTION
### Proposed changes in this pull request
$subject

Issue: https://github.com/wso2/product-is/issues/27526
Related: 

- https://github.com/wso2-extensions/identity-organization-management/pull/628
- https://github.com/wso2/identity-api-server/pull/1117

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to include organizational agent sharing module in the server feature distribution.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2-extensions/identity-organization-management/pull/633)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->