### PR TITLE
Avoid full role hydration when building associated roles for org-audience apps

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/listener/SharedRoleMgtListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.handler/src/main/java/org/wso2/carbon/identity/organization/management/handler/listener/SharedRoleMgtListener.java
@@ -43,7 +43,6 @@ import org.wso2.carbon.identity.organization.management.service.util.Organizatio
 import org.wso2.carbon.identity.role.v2.mgt.core.RoleConstants;
 import org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService;
 import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementException;
-import org.wso2.carbon.identity.role.v2.mgt.core.model.Role;
 import org.wso2.carbon.identity.role.v2.mgt.core.model.RoleBasicInfo;
 import org.wso2.carbon.utils.AuditLog;
 
@@ -144,15 +143,9 @@ public class SharedRoleMgtListener extends AbstractApplicationMgtListener {
                                 }
                             } while (chunkOfRoles.size() == maximumPage);
 
-                            List<String> roleIds = allRoles.stream().map(RoleBasicInfo::getId).collect(Collectors.
-                                    toList());
-                            for (String roleId : roleIds) {
-                                // Get all role details for each role id and create a RoleV2 object.
-                                Role roleBasicInfo = roleManagementService.getRole(roleId, tenantDomain);
-                                if (roleBasicInfo != null) {
-                                    updatedAssociatedRolesList.add(new RoleV2(roleBasicInfo.getId(),
-                                            roleBasicInfo.getName()));
-                                }
+                            for (RoleBasicInfo roleBasicInfo : allRoles) {
+                                updatedAssociatedRolesList.add(new RoleV2(roleBasicInfo.getId(),
+                                        roleBasicInfo.getName()));
                             }
                         }
                         break;


### PR DESCRIPTION
## Proposed changes

`SharedRoleMgtListener.doPreUpdateApplication`, when the application's allowed audience is `organization`, iterated every role ID returned by `getRoles("audience eq organization", ...)` and invoked `roleManagementService.getRole(roleId, tenantDomain)` for each — a full role hydration (7–8 SQL queries per role plus user-store lookups) of data that is not used downstream. Only `id` + `name` are read to construct `RoleV2(id, name)`, and the paginated `getRoles` result already carries both via `RoleBasicInfo`.

This PR mirrors [`wso2/carbon-identity-framework#7699`](https://github.com/wso2/carbon-identity-framework/pull/7699), which fixed the same N+1 pattern in `ApplicationDAOImpl#getAssociatedRoles`. The listener is the sibling site that PR did not touch.

The change maps `RoleBasicInfo → RoleV2(id, name)` directly inside the existing pagination loop, dropping the per-role `getRole()` call.

## Measured impact

Tenant with ~400 organization-audience roles, H2 in-process, DCR with `ext_allowed_audience=organization`:

| Metric | Before | After |
|---|---|---|
| Warm DCR latency | ~170 ms | ~50 ms (≈3.3× faster) |
| Per-DCR SELECTs against `UM_HYBRID_USER_ROLE` / `UM_HYBRID_GROUP_ROLE` / `UM_IDP_GROUP_ROLE` / `UM_SHARED_ROLE` / `APP_ROLE_ASSOCIATION` | ~403 each | 0 each |
| Per-DCR SELECTs against `ROLE_SCOPE` | ~408 | ~5 |
| Per-DCR `UM_HYBRID_ROLE` SELECT amplification | ~5240 | ~413 |
| Correlation log size per DCR | ~2.0 MB | ~150 KB (~13× smaller) |

The benefit scales linearly with network round-trip cost on an external database: a customer reproducer with ~400 roles on an external DB observed DCR latency drop from >80 s to well under 10 s (≈3200 per-DCR queries removed × ~10 ms RTT each).

## Behavior changes

None. `RoleBasicInfo.getId()` and `RoleBasicInfo.getName()` are the same values previously obtained via the fully-hydrated `Role` object. Other fields populated by `getRole(...)` (groups, users, audience, permissions, scopes, app associations) were never read by this code path.

## Related PRs / issues

- Same pattern fixed elsewhere: wso2/carbon-identity-framework#7699

## Related Issues
- https://github.com/wso2/product-is/issues/27740

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized role handling in application audience updates to improve performance and efficiency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2-extensions/identity-organization-management/pull/634)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->