### PR TITLE
Auto-share agents to newly created organizations

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.organization.agent.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/agent/sharing/AgentSharingPolicyHandlerServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.agent.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/agent/sharing/AgentSharingPolicyHandlerServiceImpl.java
@@ -145,7 +145,7 @@ import static org.wso2.carbon.identity.organization.management.service.util.Util
 public class AgentSharingPolicyHandlerServiceImpl implements AgentSharingPolicyHandlerService {
 
     private static final Log LOG = LogFactory.getLog(AgentSharingPolicyHandlerServiceImpl.class);
-    private static final ExecutorService EXECUTOR = Executors.newFixedThreadPool(5);
+    private final ExecutorService executorService = Executors.newFixedThreadPool(5);
     private static final Set<String> SUPPORTED_GET_ATTRIBUTES =
             new HashSet<>(java.util.Arrays.asList(SHARED_AGENT_SHARING_MODE_INCLUDED_KEY,
                     SHARED_AGENT_ROLE_INCLUDED_KEY));
@@ -182,7 +182,7 @@ public class AgentSharingPolicyHandlerServiceImpl implements AgentSharingPolicyH
                         PrivilegedCarbonContext.endTenantFlow();
                         IdentityUtil.threadLocalProperties.get().clear();
                     }
-                }, EXECUTOR)
+                }, executorService)
                 .exceptionally(ex -> {
                     LOG.error("Error occurred during async selective agent share processing.", ex);
                     return null;
@@ -221,7 +221,7 @@ public class AgentSharingPolicyHandlerServiceImpl implements AgentSharingPolicyH
                         PrivilegedCarbonContext.endTenantFlow();
                         IdentityUtil.threadLocalProperties.get().clear();
                     }
-                }, EXECUTOR)
+                }, executorService)
                 .exceptionally(ex -> {
                     LOG.error("Error occurred during async selective agent share processing for organization: "
                             + sharingInitiatedOrgId, ex);
@@ -259,7 +259,7 @@ public class AgentSharingPolicyHandlerServiceImpl implements AgentSharingPolicyH
                         PrivilegedCarbonContext.endTenantFlow();
                         IdentityUtil.threadLocalProperties.get().clear();
                     }
-                }, EXECUTOR)
+                }, executorService)
                 .exceptionally(ex -> {
                     LOG.error("Error occurred during async selective agent unshare processing.", ex);
                     return null;
@@ -294,7 +294,7 @@ public class AgentSharingPolicyHandlerServiceImpl implements AgentSharingPolicyH
                         PrivilegedCarbonContext.endTenantFlow();
                         IdentityUtil.threadLocalProperties.get().clear();
                     }
-                }, EXECUTOR)
+                }, executorService)
                 .exceptionally(ex -> {
                     LOG.error("Error occurred during async general agent unshare processing.", ex);
                     return null;
@@ -330,7 +330,7 @@ public class AgentSharingPolicyHandlerServiceImpl implements AgentSharingPolicyH
                         PrivilegedCarbonContext.endTenantFlow();
                         IdentityUtil.threadLocalProperties.get().clear();
                     }
-                }, EXECUTOR)
+                }, executorService)
                 .exceptionally(ex -> {
                     LOG.error("Error occurred during async agent share role assignment update processing.", ex);
                     return null;

--- a/components/org.wso2.carbon.identity.organization.management.organization.agent.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/agent/sharing/AgentSharingPolicyHandlerServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.agent.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/agent/sharing/AgentSharingPolicyHandlerServiceImpl.java
@@ -68,6 +68,10 @@ import org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService;
 import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementException;
 import org.wso2.carbon.identity.role.v2.mgt.core.model.Role;
 import org.wso2.carbon.identity.role.v2.mgt.core.model.RoleBasicInfo;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.core.UserStoreManager;
+import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
+import org.wso2.carbon.user.core.service.RealmService;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -91,6 +95,8 @@ import static org.wso2.carbon.identity.organization.management.organization.agen
 import static org.wso2.carbon.identity.organization.management.organization.agent.sharing.constant.AgentSharingConstants.AGENT_IDS;
 import static org.wso2.carbon.identity.organization.management.organization.agent.sharing.constant.AgentSharingConstants.APPLICATION;
 import static org.wso2.carbon.identity.organization.management.organization.agent.sharing.constant.AgentSharingConstants.ASYNC_PROCESSING_LOG_TEMPLATE;
+import static org.wso2.carbon.identity.organization.management.organization.agent.sharing.constant.AgentSharingConstants.CLAIM_MANAGED_ORGANIZATION;
+import static org.wso2.carbon.identity.organization.management.organization.agent.sharing.constant.AgentSharingConstants.DEFAULT_PROFILE;
 import static org.wso2.carbon.identity.organization.management.organization.agent.sharing.constant.AgentSharingConstants.ErrorMessage.ERROR_CODE_AGENT_CRITERIA_INVALID;
 import static org.wso2.carbon.identity.organization.management.organization.agent.sharing.constant.AgentSharingConstants.ErrorMessage.ERROR_CODE_AGENT_CRITERIA_MISSING;
 import static org.wso2.carbon.identity.organization.management.organization.agent.sharing.constant.AgentSharingConstants.ErrorMessage.ERROR_CODE_AGENT_SHARE;
@@ -130,6 +136,7 @@ import static org.wso2.carbon.identity.organization.management.organization.agen
 import static org.wso2.carbon.identity.organization.management.organization.agent.sharing.constant.AgentSharingConstants.ErrorMessage.ERROR_CODE_ROLE_NOT_FOUND;
 import static org.wso2.carbon.identity.organization.management.organization.agent.sharing.constant.AgentSharingConstants.ErrorMessage.ERROR_GENERAL_SHARE;
 import static org.wso2.carbon.identity.organization.management.organization.agent.sharing.constant.AgentSharingConstants.ErrorMessage.ERROR_SELECTIVE_SHARE;
+import static org.wso2.carbon.identity.organization.management.organization.agent.sharing.constant.AgentSharingConstants.LOG_WARN_NON_RESIDENT_AGENT;
 import static org.wso2.carbon.identity.organization.management.organization.agent.sharing.constant.AgentSharingConstants.LOG_WARN_SKIP_ORG_SHARE_MESSAGE;
 import static org.wso2.carbon.identity.organization.management.organization.agent.sharing.constant.AgentSharingConstants.ORGANIZATION;
 import static org.wso2.carbon.identity.organization.management.organization.agent.sharing.constant.AgentSharingConstants.PATCH_PATH_PREFIX;
@@ -595,6 +602,14 @@ public class AgentSharingPolicyHandlerServiceImpl implements AgentSharingPolicyH
 
         for (String associatedAgentId : agentIds.getIds()) {
             try {
+                if (!isExistingAgent(associatedAgentId, sharingInitiatedOrgId) ||
+                        !isResidentAgentInOrg(associatedAgentId, sharingInitiatedOrgId)) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug(String.format(LOG_WARN_NON_RESIDENT_AGENT, associatedAgentId,
+                                sharingInitiatedOrgId));
+                    }
+                    continue;
+                }
                 deleteAllResourceSharingPoliciesOfAgent(associatedAgentId, sharingInitiatedOrgId);
                 for (SelectiveAgentShareOrgDetailsDO organization : organizations) {
                     List<String> targetOrgs =
@@ -656,6 +671,14 @@ public class AgentSharingPolicyHandlerServiceImpl implements AgentSharingPolicyH
 
         for (String associatedAgentId : agentIds.getIds()) {
             try {
+                if (!isExistingAgent(associatedAgentId, sharingInitiatedOrgId) ||
+                        !isResidentAgentInOrg(associatedAgentId, sharingInitiatedOrgId)) {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug(String.format(LOG_WARN_NON_RESIDENT_AGENT, associatedAgentId,
+                                sharingInitiatedOrgId));
+                    }
+                    continue;
+                }
                 deleteAllResourceSharingPoliciesOfAgent(associatedAgentId, sharingInitiatedOrgId);
                 List<String> targetOrgs = extractOrgListBasedOnSharingPolicy(sharingInitiatedOrgId, policy);
                 for (String targetOrgId : targetOrgs) {
@@ -1839,6 +1862,65 @@ public class AgentSharingPolicyHandlerServiceImpl implements AgentSharingPolicyH
             throws AgentSharingMgtClientException {
 
         throw new AgentSharingMgtClientException(error.getCode(), error.getMessage(), error.getDescription());
+    }
+
+    /**
+     * Checks whether the specified agent exists in the given organization's agent store.
+     *
+     * @param agentId The ID of the agent.
+     * @param orgId   The ID of the organization.
+     * @return {@code true} if the agent exists in the agent store, {@code false} otherwise.
+     */
+    private boolean isExistingAgent(String agentId, String orgId) {
+
+        try {
+            String tenantDomain = getOrganizationManager().resolveTenantDomain(orgId);
+            int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
+            String domainName = IdentityUtil.getAgentIdentityUserstoreName();
+            RealmService realmService = OrganizationAgentSharingDataHolder.getInstance().getRealmService();
+            AbstractUserStoreManager agentStoreManager = (AbstractUserStoreManager)
+                    ((UserStoreManager) realmService.getTenantUserRealm(tenantId).getUserStoreManager())
+                            .getSecondaryUserStoreManager(domainName);
+            if (agentStoreManager == null) {
+                return false;
+            }
+            return agentStoreManager.isExistingUserWithID(agentId);
+        } catch (UserStoreException | OrganizationManagementException e) {
+            LOG.error("Error occurred while checking if the agent is an existing agent in organization: " + orgId,
+                    e);
+            return false;
+        }
+    }
+
+    /**
+     * Checks whether the specified agent is a resident (non-shared) agent in the given organization.
+     *
+     * @param agentId The ID of the agent.
+     * @param orgId   The ID of the organization.
+     * @return {@code true} if the agent has no managed-organization claim (i.e. is resident),
+     *         {@code false} if the agent is a shared agent or the check fails.
+     */
+    private boolean isResidentAgentInOrg(String agentId, String orgId) {
+
+        try {
+            String tenantDomain = getOrganizationManager().resolveTenantDomain(orgId);
+            int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
+            String domainName = IdentityUtil.getAgentIdentityUserstoreName();
+            RealmService realmService = OrganizationAgentSharingDataHolder.getInstance().getRealmService();
+            AbstractUserStoreManager agentStoreManager = (AbstractUserStoreManager)
+                    ((UserStoreManager) realmService.getTenantUserRealm(tenantId).getUserStoreManager())
+                            .getSecondaryUserStoreManager(domainName);
+            if (agentStoreManager == null) {
+                return false;
+            }
+            String managedOrg = agentStoreManager.getUserClaimValue(agentId, CLAIM_MANAGED_ORGANIZATION,
+                    DEFAULT_PROFILE);
+            return managedOrg == null;
+        } catch (UserStoreException | OrganizationManagementException e) {
+            LOG.error("Error occurred while checking if the agent is a resident agent in organization: " + orgId,
+                    e);
+            return false;
+        }
     }
 
     private OrganizationAgentSharingService getOrganizationAgentSharingService() {

--- a/components/org.wso2.carbon.identity.organization.management.organization.agent.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/agent/sharing/OrganizationAgentSharingServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.agent.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/agent/sharing/OrganizationAgentSharingServiceImpl.java
@@ -71,6 +71,8 @@ import static org.wso2.carbon.identity.organization.management.service.util.Util
 public class OrganizationAgentSharingServiceImpl implements OrganizationAgentSharingService {
 
     private static final Log LOG = LogFactory.getLog(OrganizationAgentSharingServiceImpl.class);
+    private static final int AGENT_STORE_WAIT_TIMEOUT_MS = 15000;
+    private static final int AGENT_STORE_POLL_INTERVAL_MS = 50;
 
     private final OrganizationAgentSharingDAO organizationAgentSharingDAO = new OrganizationAgentSharingDAOImpl();
 
@@ -109,9 +111,31 @@ public class OrganizationAgentSharingServiceImpl implements OrganizationAgentSha
             int sharedOrgTenantId = IdentityTenantUtil.getTenantId(sharedOrgTenantDomain);
             String domainName = IdentityUtil.getAgentIdentityUserstoreName();
             RealmService realmService = OrganizationAgentSharingDataHolder.getInstance().getRealmService();
+            
+            // The AGENT user store is provisioned via UserStoreConfigService.addUserStore() during tenant
+            // initial activation, which triggers an asynchronous reload of the user store manager chain.
+            // Check immediately first, then poll with short intervals until the store appears or timeout elapses.
+            int waited = 0;
             AbstractUserStoreManager sharedOrgAgentStoreManager = (AbstractUserStoreManager)
                     ((UserStoreManager) realmService.getTenantUserRealm(sharedOrgTenantId).getUserStoreManager())
                             .getSecondaryUserStoreManager(domainName);
+            while (sharedOrgAgentStoreManager == null && waited < AGENT_STORE_WAIT_TIMEOUT_MS) {
+                try {
+                    Thread.sleep(AGENT_STORE_POLL_INTERVAL_MS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw handleServerException(ERROR_CODE_ERROR_CREATE_SHARED_USER, e, orgId);
+                }
+                waited += AGENT_STORE_POLL_INTERVAL_MS;
+                sharedOrgAgentStoreManager = (AbstractUserStoreManager)
+                        ((UserStoreManager) realmService.getTenantUserRealm(sharedOrgTenantId).getUserStoreManager())
+                                .getSecondaryUserStoreManager(domainName);
+            }
+            if (sharedOrgAgentStoreManager == null) {
+                throw handleServerException(ERROR_CODE_ERROR_CREATE_SHARED_USER,
+                        new OrganizationManagementServerException("Agent user store manager not available for domain: "
+                                + domainName + " in organization: " + orgId), orgId);
+            }
             User sharedUser = sharedOrgAgentStoreManager.addUserWithID(
                     associatedAgentId, generatePassword(), null, agentClaims, DEFAULT_PROFILE);
 
@@ -229,9 +253,29 @@ public class OrganizationAgentSharingServiceImpl implements OrganizationAgentSha
         try {
             String domainName = IdentityUtil.getAgentIdentityUserstoreName();
             RealmService realmService = OrganizationAgentSharingDataHolder.getInstance().getRealmService();
+            
+            // Check immediately first, then poll with short intervals until the store appears or timeout elapses.
+            int waited = 0;
             AbstractUserStoreManager sharedOrgAgentStoreManager = (AbstractUserStoreManager)
                     ((UserStoreManager) realmService.getTenantUserRealm(tenantId).getUserStoreManager())
                             .getSecondaryUserStoreManager(domainName);
+            while (sharedOrgAgentStoreManager == null && waited < AGENT_STORE_WAIT_TIMEOUT_MS) {
+                try {
+                    Thread.sleep(AGENT_STORE_POLL_INTERVAL_MS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw handleServerException(ERROR_CODE_ERROR_DELETE_SHARED_USER, e, agentId, organizationId);
+                }
+                waited += AGENT_STORE_POLL_INTERVAL_MS;
+                sharedOrgAgentStoreManager = (AbstractUserStoreManager)
+                        ((UserStoreManager) realmService.getTenantUserRealm(tenantId).getUserStoreManager())
+                                .getSecondaryUserStoreManager(domainName);
+            }
+            if (sharedOrgAgentStoreManager == null) {
+                throw handleServerException(ERROR_CODE_ERROR_DELETE_SHARED_USER,
+                        new OrganizationManagementServerException("Agent user store manager not available for domain: "
+                                + domainName + " in organization: " + organizationId), agentId, organizationId);
+            }
             deleteAgentInTenantFlow(sharedOrgAgentStoreManager, agentId, tenantDomain, organizationId);
         } catch (UserStoreException e) {
             throw handleServerException(ERROR_CODE_ERROR_DELETE_SHARED_USER, e, agentId, organizationId);

--- a/components/org.wso2.carbon.identity.organization.management.organization.agent.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/agent/sharing/OrganizationAgentSharingServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.agent.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/agent/sharing/OrganizationAgentSharingServiceImpl.java
@@ -272,8 +272,8 @@ public class OrganizationAgentSharingServiceImpl implements OrganizationAgentSha
                 if (future.isDone()) {
                     return;
                 }
-                PrivilegedCarbonContext.startTenantFlow();
                 try {
+                    PrivilegedCarbonContext.startTenantFlow();
                     PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(tenantDomain, true);
                     AbstractUserStoreManager manager = (AbstractUserStoreManager)
                             ((UserStoreManager) realmService.getTenantUserRealm(tenantId).getUserStoreManager())

--- a/components/org.wso2.carbon.identity.organization.management.organization.agent.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/agent/sharing/OrganizationAgentSharingServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.agent.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/agent/sharing/OrganizationAgentSharingServiceImpl.java
@@ -32,6 +32,7 @@ import org.wso2.carbon.identity.organization.management.organization.agent.shari
 import org.wso2.carbon.identity.organization.management.organization.agent.sharing.internal.OrganizationAgentSharingDataHolder;
 import org.wso2.carbon.identity.organization.management.organization.agent.sharing.models.AgentAssociation;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
+import org.wso2.carbon.identity.organization.management.service.constant.OrganizationManagementConstants;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementServerException;
 import org.wso2.carbon.identity.scim2.common.utils.SCIMCommonUtils;
@@ -45,6 +46,12 @@ import org.wso2.carbon.user.core.util.UserCoreUtil;
 import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.wso2.carbon.identity.organization.management.organization.agent.sharing.constant.AgentSharingConstants.CLAIM_MANAGED_ORGANIZATION;
 import static org.wso2.carbon.identity.organization.management.organization.agent.sharing.constant.AgentSharingConstants.DEFAULT_PROFILE;
@@ -110,32 +117,8 @@ public class OrganizationAgentSharingServiceImpl implements OrganizationAgentSha
             // Add the shared agent entry to the target organization's agent user store.
             int sharedOrgTenantId = IdentityTenantUtil.getTenantId(sharedOrgTenantDomain);
             String domainName = IdentityUtil.getAgentIdentityUserstoreName();
-            RealmService realmService = OrganizationAgentSharingDataHolder.getInstance().getRealmService();
-            
-            // The AGENT user store is provisioned via UserStoreConfigService.addUserStore() during tenant
-            // initial activation, which triggers an asynchronous reload of the user store manager chain.
-            // Check immediately first, then poll with short intervals until the store appears or timeout elapses.
-            int waited = 0;
-            AbstractUserStoreManager sharedOrgAgentStoreManager = (AbstractUserStoreManager)
-                    ((UserStoreManager) realmService.getTenantUserRealm(sharedOrgTenantId).getUserStoreManager())
-                            .getSecondaryUserStoreManager(domainName);
-            while (sharedOrgAgentStoreManager == null && waited < AGENT_STORE_WAIT_TIMEOUT_MS) {
-                try {
-                    Thread.sleep(AGENT_STORE_POLL_INTERVAL_MS);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    throw handleServerException(ERROR_CODE_ERROR_CREATE_SHARED_USER, e, orgId);
-                }
-                waited += AGENT_STORE_POLL_INTERVAL_MS;
-                sharedOrgAgentStoreManager = (AbstractUserStoreManager)
-                        ((UserStoreManager) realmService.getTenantUserRealm(sharedOrgTenantId).getUserStoreManager())
-                                .getSecondaryUserStoreManager(domainName);
-            }
-            if (sharedOrgAgentStoreManager == null) {
-                throw handleServerException(ERROR_CODE_ERROR_CREATE_SHARED_USER,
-                        new OrganizationManagementServerException("Agent user store manager not available for domain: "
-                                + domainName + " in organization: " + orgId), orgId);
-            }
+            AbstractUserStoreManager sharedOrgAgentStoreManager =
+                    waitForAgentStoreManager(sharedOrgTenantId, domainName, ERROR_CODE_ERROR_CREATE_SHARED_USER, orgId);
             User sharedUser = sharedOrgAgentStoreManager.addUserWithID(
                     associatedAgentId, generatePassword(), null, agentClaims, DEFAULT_PROFILE);
 
@@ -252,33 +235,79 @@ public class OrganizationAgentSharingServiceImpl implements OrganizationAgentSha
         int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
         try {
             String domainName = IdentityUtil.getAgentIdentityUserstoreName();
-            RealmService realmService = OrganizationAgentSharingDataHolder.getInstance().getRealmService();
-            
-            // Check immediately first, then poll with short intervals until the store appears or timeout elapses.
-            int waited = 0;
-            AbstractUserStoreManager sharedOrgAgentStoreManager = (AbstractUserStoreManager)
-                    ((UserStoreManager) realmService.getTenantUserRealm(tenantId).getUserStoreManager())
-                            .getSecondaryUserStoreManager(domainName);
-            while (sharedOrgAgentStoreManager == null && waited < AGENT_STORE_WAIT_TIMEOUT_MS) {
-                try {
-                    Thread.sleep(AGENT_STORE_POLL_INTERVAL_MS);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    throw handleServerException(ERROR_CODE_ERROR_DELETE_SHARED_USER, e, agentId, organizationId);
-                }
-                waited += AGENT_STORE_POLL_INTERVAL_MS;
-                sharedOrgAgentStoreManager = (AbstractUserStoreManager)
-                        ((UserStoreManager) realmService.getTenantUserRealm(tenantId).getUserStoreManager())
-                                .getSecondaryUserStoreManager(domainName);
-            }
-            if (sharedOrgAgentStoreManager == null) {
-                throw handleServerException(ERROR_CODE_ERROR_DELETE_SHARED_USER,
-                        new OrganizationManagementServerException("Agent user store manager not available for domain: "
-                                + domainName + " in organization: " + organizationId), agentId, organizationId);
-            }
+            AbstractUserStoreManager sharedOrgAgentStoreManager =
+                    waitForAgentStoreManager(tenantId, domainName, ERROR_CODE_ERROR_DELETE_SHARED_USER, agentId,
+                            organizationId);
             deleteAgentInTenantFlow(sharedOrgAgentStoreManager, agentId, tenantDomain, organizationId);
         } catch (UserStoreException e) {
             throw handleServerException(ERROR_CODE_ERROR_DELETE_SHARED_USER, e, agentId, organizationId);
+        }
+    }
+
+    /**
+     * Polls for the agent user store manager until it becomes available or the timeout elapses.
+     * Uses a ScheduledExecutorService to schedule repeated checks at AGENT_STORE_POLL_INTERVAL_MS intervals
+     * so the calling thread waits on a CompletableFuture instead of sleeping in a loop.
+     *
+     * @param tenantId    The tenant ID of the target organization.
+     * @param domainName  The domain name of the agent user store.
+     * @param errorCode   The error code to use if the wait fails.
+     * @param contextArgs The context arguments for the error message.
+     * @return The resolved AbstractUserStoreManager for the given domain.
+     * @throws OrganizationManagementException If the store is not available within the timeout or an error occurs.
+     */
+    private AbstractUserStoreManager waitForAgentStoreManager(int tenantId, String domainName,
+            OrganizationManagementConstants.ErrorMessages errorCode, String... contextArgs)
+            throws OrganizationManagementException {
+
+        // Resolve tenant domain on the calling thread (which has a valid CarbonContext) so the background
+        // scheduler thread can establish its own tenant flow without depending on thread-local context.
+        String tenantDomain = IdentityTenantUtil.getTenantDomain(tenantId);
+        RealmService realmService = OrganizationAgentSharingDataHolder.getInstance().getRealmService();
+        CompletableFuture<AbstractUserStoreManager> future = new CompletableFuture<>();
+        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+        try {
+            long deadline = System.currentTimeMillis() + AGENT_STORE_WAIT_TIMEOUT_MS;
+            scheduler.scheduleAtFixedRate(() -> {
+                if (future.isDone()) {
+                    return;
+                }
+                PrivilegedCarbonContext.startTenantFlow();
+                try {
+                    PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(tenantDomain, true);
+                    AbstractUserStoreManager manager = (AbstractUserStoreManager)
+                            ((UserStoreManager) realmService.getTenantUserRealm(tenantId).getUserStoreManager())
+                                    .getSecondaryUserStoreManager(domainName);
+                    if (manager != null) {
+                        future.complete(manager);
+                    } else if (System.currentTimeMillis() >= deadline) {
+                        future.completeExceptionally(
+                                new TimeoutException("Agent user store not available within timeout."));
+                    }
+                } catch (UserStoreException e) {
+                    future.completeExceptionally(e);
+                } finally {
+                    PrivilegedCarbonContext.endTenantFlow();
+                }
+            }, 0, AGENT_STORE_POLL_INTERVAL_MS, TimeUnit.MILLISECONDS);
+            return future.get(AGENT_STORE_WAIT_TIMEOUT_MS + AGENT_STORE_POLL_INTERVAL_MS, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw handleServerException(errorCode, e, contextArgs);
+        } catch (TimeoutException e) {
+            throw handleServerException(errorCode,
+                    new OrganizationManagementServerException(
+                            "Agent user store manager not available for domain: " + domainName), contextArgs);
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof TimeoutException) {
+                throw handleServerException(errorCode,
+                        new OrganizationManagementServerException(
+                                "Agent user store manager not available for domain: " + domainName), contextArgs);
+            }
+            throw handleServerException(errorCode, cause != null ? cause : e, contextArgs);
+        } finally {
+            scheduler.shutdownNow();
         }
     }
 

--- a/components/org.wso2.carbon.identity.organization.management.organization.agent.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/agent/sharing/constant/AgentSharingConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.agent.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/agent/sharing/constant/AgentSharingConstants.java
@@ -51,6 +51,8 @@ public class AgentSharingConstants {
     public static final String SHARING_ERROR_PREFIX = "OAS-";
     public static final String LOG_WARN_SKIP_ORG_SHARE_MESSAGE =
             "Skipping agent share for organizations that are not immediate children: %s";
+    public static final String LOG_WARN_NON_RESIDENT_AGENT =
+            "Skipping agent: %s from sharing because it is not a resident agent in organization: %s.";
 
     public static final String ACTION_GENERAL_AGENT_SHARE = "general agent share";
     public static final String ACTION_SELECTIVE_AGENT_SHARE = "selective agent share";

--- a/components/org.wso2.carbon.identity.organization.management.organization.agent.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/agent/sharing/listener/OrganizationAgentSharingHandler.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.agent.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/agent/sharing/listener/OrganizationAgentSharingHandler.java
@@ -139,8 +139,14 @@ public class OrganizationAgentSharingHandler extends AbstractEventHandler {
 
         List<String> allAncestorOrgs = getOrganizationManager().getAncestorOrganizationIds(createdOrgId);
         int topHierarchyLevel = Utils.getSubOrgStartLevel() >= 1 ? Utils.getSubOrgStartLevel() - 1 : 0;
-        List<String> relevantAncestorOrgs =
-                new ArrayList<>(allAncestorOrgs.subList(1, allAncestorOrgs.size() - topHierarchyLevel));
+        int startIndex = 1;
+        int safeEndIndex = allAncestorOrgs.size() - topHierarchyLevel;
+        List<String> relevantAncestorOrgs;
+        if (safeEndIndex > startIndex && safeEndIndex <= allAncestorOrgs.size()) {
+            relevantAncestorOrgs = new ArrayList<>(allAncestorOrgs.subList(startIndex, safeEndIndex));
+        } else {
+            relevantAncestorOrgs = new ArrayList<>();
+        }
 
         // Get agent resources of each ancestor organization.
         List<ResourceSharingPolicy> agentResources =
@@ -149,6 +155,10 @@ public class OrganizationAgentSharingHandler extends AbstractEventHandler {
 
         for (ResourceSharingPolicy resource : agentResources) {
             if (shouldShareAgent(resource.getSharingPolicy())) {
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("Sharing agent: " + resource.getResourceId() + " from organization: " +
+                            resource.getInitiatingOrgId() + " to organization: " + createdOrgId);
+                }
                 shareAgent(resource, resource.getResourceId(), resource.getInitiatingOrgId(), createdOrgId);
             }
         }

--- a/components/org.wso2.carbon.identity.organization.management.organization.agent.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/agent/sharing/listener/OrganizationAgentSharingHandler.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.agent.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/agent/sharing/listener/OrganizationAgentSharingHandler.java
@@ -22,24 +22,48 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.core.bean.context.MessageContext;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.IdentityEventException;
 import org.wso2.carbon.identity.event.event.Event;
 import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
 import org.wso2.carbon.identity.organization.management.ext.Constants;
+import org.wso2.carbon.identity.organization.management.organization.agent.sharing.OrganizationAgentSharingService;
+import org.wso2.carbon.identity.organization.management.organization.agent.sharing.constant.EditOperation;
+import org.wso2.carbon.identity.organization.management.organization.agent.sharing.constant.SharedType;
+import org.wso2.carbon.identity.organization.management.organization.agent.sharing.exception.AgentSharingMgtException;
 import org.wso2.carbon.identity.organization.management.organization.agent.sharing.internal.OrganizationAgentSharingDataHolder;
+import org.wso2.carbon.identity.organization.management.organization.agent.sharing.models.AgentAssociation;
+import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.identity.organization.management.service.model.Organization;
+import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
+import org.wso2.carbon.identity.organization.management.service.util.Utils;
+import org.wso2.carbon.identity.organization.resource.sharing.policy.management.ResourceSharingPolicyHandlerService;
+import org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.PolicyEnum;
+import org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.ResourceType;
+import org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.SharedAttributeType;
+import org.wso2.carbon.identity.organization.resource.sharing.policy.management.exception.ResourceSharingPolicyMgtException;
+import org.wso2.carbon.identity.organization.resource.sharing.policy.management.model.ResourceSharingPolicy;
+import org.wso2.carbon.identity.organization.resource.sharing.policy.management.model.SharedResourceAttribute;
+import org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService;
+import org.wso2.carbon.identity.role.v2.mgt.core.exception.IdentityRoleManagementException;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
- * The event handler for cleaning up agent sharing associations when an organization is deleted.
+ * The event handler for sharing agents to newly created organizations and cleaning up agent sharing associations
+ * when an organization is deleted.
  */
 public class OrganizationAgentSharingHandler extends AbstractEventHandler {
 
     private static final Log LOG = LogFactory.getLog(OrganizationAgentSharingHandler.class);
 
     /**
-     * Handles cleanup of agent associations for deleted organizations.
+     * Handles agent sharing for newly created organizations and cleanup for deleted organizations.
      *
      * @param event The event to be handled.
      * @throws IdentityEventException If an error occurs while handling the event.
@@ -48,27 +72,48 @@ public class OrganizationAgentSharingHandler extends AbstractEventHandler {
     public void handleEvent(Event event) throws IdentityEventException {
 
         String eventName = event.getEventName();
-        if (!Constants.EVENT_POST_DELETE_ORGANIZATION.equals(eventName)) {
-            return;
+        Map<String, Object> eventProperties = event.getEventProperties();
+
+        if (Constants.EVENT_POST_ADD_ORGANIZATION.equals(eventName)) {
+            Organization createdOrganization = (Organization) eventProperties.get(Constants.EVENT_PROP_ORGANIZATION);
+            if (createdOrganization == null) {
+                return;
+            }
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Handling agent sharing for created organization: " + createdOrganization.getId());
+            }
+            try {
+                if (OrganizationManagementUtil.isOrganization(createdOrganization.getOrganizationHandle())) {
+                    shareAgents(createdOrganization.getId());
+                }
+            } catch (OrganizationManagementException e) {
+                throw new IdentityEventException("Error while handling agent sharing for event: " + eventName, e);
+            } catch (ResourceSharingPolicyMgtException e) {
+                throw new IdentityEventException(
+                        "Error while retrieving resource sharing policies for event: " + eventName, e);
+            } catch (IdentityRoleManagementException e) {
+                throw new IdentityEventException("Error while handling role sharing for event: " + eventName, e);
+            }
         }
 
-        Map<String, Object> eventProperties = event.getEventProperties();
-        String deletedOrgId = (String) eventProperties.get(Constants.EVENT_PROP_ORGANIZATION_ID);
-        try {
-            if (StringUtils.isNotBlank(deletedOrgId)) {
-                cleanupAgentAssociations(deletedOrgId);
+        if (Constants.EVENT_POST_DELETE_ORGANIZATION.equals(eventName)) {
+            String deletedOrgId = (String) eventProperties.get(Constants.EVENT_PROP_ORGANIZATION_ID);
+            try {
+                if (StringUtils.isNotBlank(deletedOrgId)) {
+                    cleanupAgentAssociations(deletedOrgId);
+                }
+            } catch (OrganizationManagementException e) {
+                throw new IdentityEventException("Error while cleaning up agent associations for deleted " +
+                        "organization: " + deletedOrgId, e);
             }
-        } catch (OrganizationManagementException e) {
-            throw new IdentityEventException("Error while cleaning up agent associations for deleted " +
-                    "organization: " + deletedOrgId, e);
         }
     }
 
     /**
      * Returns the priority of this handler, defaulting to 15 when the super implementation returns -1.
      *
-     * @param messageContext the message context.
-     * @return the handler priority.
+     * @param messageContext The message context.
+     * @return The handler priority.
      */
     @Override
     public int getPriority(MessageContext messageContext) {
@@ -80,12 +125,142 @@ public class OrganizationAgentSharingHandler extends AbstractEventHandler {
         return priority;
     }
 
+    /**
+     * Shares agents that have a future-applicable sharing policy to the newly created organization.
+     *
+     * @param createdOrgId The ID of the newly created organization.
+     * @throws OrganizationManagementException    If an error occurs while managing organizations.
+     * @throws ResourceSharingPolicyMgtException  If an error occurs while retrieving sharing policies.
+         * @throws IdentityRoleManagementException    If an error occurs while managing role assignments.
+     */
+    private void shareAgents(String createdOrgId)
+             throws OrganizationManagementException, ResourceSharingPolicyMgtException,
+             IdentityRoleManagementException {
+
+        List<String> allAncestorOrgs = getOrganizationManager().getAncestorOrganizationIds(createdOrgId);
+        int topHierarchyLevel = Utils.getSubOrgStartLevel() >= 1 ? Utils.getSubOrgStartLevel() - 1 : 0;
+        List<String> relevantAncestorOrgs =
+                new ArrayList<>(allAncestorOrgs.subList(1, allAncestorOrgs.size() - topHierarchyLevel));
+
+        // Get agent resources of each ancestor organization.
+        List<ResourceSharingPolicy> agentResources =
+                getResourceSharingPolicyHandlerService().getResourceSharingPoliciesByResourceType(
+                        relevantAncestorOrgs, ResourceType.AGENT.name());
+
+        for (ResourceSharingPolicy resource : agentResources) {
+            if (shouldShareAgent(resource.getSharingPolicy())) {
+                shareAgent(resource, resource.getResourceId(), resource.getInitiatingOrgId(), createdOrgId);
+            }
+        }
+    }
+
+    /**
+     * Determines whether an agent should be shared to the newly created organization based on the sharing policy.
+     * Only future-applicable general policies are supported for agents: {@code ALL_EXISTING_AND_FUTURE_ORGS} and
+     * {@code SELECTED_ORG_WITH_ALL_EXISTING_AND_FUTURE_CHILDREN}.
+     *
+     * @param policy        The sharing policy defined for the agent.
+     * @return True if the agent should be shared; false otherwise.
+     */
+    private boolean shouldShareAgent(PolicyEnum policy) {
+
+        return PolicyEnum.ALL_EXISTING_AND_FUTURE_ORGS.equals(policy) ||
+                PolicyEnum.SELECTED_ORG_WITH_ALL_EXISTING_AND_FUTURE_CHILDREN.equals(policy);
+    }
+
+    /**
+     * Shares a single agent to the newly created organization if no existing association is found.
+     *
+     * @param associatedAgentId The ID of the agent to be shared.
+     * @param residentOrgId     The ID of the organization where the agent is managed.
+     * @param createdOrgId      The ID of the newly created organization.
+     * @throws OrganizationManagementException If an error occurs while sharing the agent.
+     */
+        private void shareAgent(ResourceSharingPolicy resource, String associatedAgentId, String residentOrgId,
+                    String createdOrgId)
+            throws OrganizationManagementException, ResourceSharingPolicyMgtException,
+            IdentityRoleManagementException {
+
+        List<SharedResourceAttribute> agentAttributes =
+            getResourceSharingPolicyHandlerService()
+                .getSharedResourceAttributesBySharingPolicyId(resource.getResourceSharingPolicyId());
+
+        List<String> roleIds = agentAttributes.stream()
+            .filter(attribute -> SharedAttributeType.ROLE.equals(attribute.getSharedAttributeType()))
+            .map(SharedResourceAttribute::getSharedAttributeId)
+            .collect(Collectors.toList());
+
+        AgentAssociation existingAssociation =
+                getOrganizationAgentSharingService()
+                        .getAgentAssociationOfAssociatedAgentByOrgId(associatedAgentId, createdOrgId);
+        AgentAssociation sharedAssociation = existingAssociation;
+        if (existingAssociation == null) {
+            getOrganizationAgentSharingService().shareOrganizationAgent(
+                    createdOrgId, associatedAgentId, residentOrgId, SharedType.SHARED);
+            sharedAssociation = getOrganizationAgentSharingService()
+                .getAgentAssociationOfAssociatedAgentByOrgId(associatedAgentId, createdOrgId);
+        } else if (LOG.isDebugEnabled()) {
+            LOG.debug("Agent: " + associatedAgentId + " is already shared with the organization: " + createdOrgId);
+        }
+
+        if (sharedAssociation == null || roleIds.isEmpty()) {
+            return;
+        }
+
+        String createdOrgTenantDomain = getOrganizationManager().resolveTenantDomain(createdOrgId);
+        Map<String, String> mainRoleToSharedRoleMappings = getRoleManagementService()
+            .getMainRoleToSharedRoleMappingsBySubOrg(roleIds, createdOrgTenantDomain);
+        List<String> sharedRoleIds = new ArrayList<>(mainRoleToSharedRoleMappings.values());
+        List<String> sharedAgentExistingRoles =
+            getRoleManagementService().getRoleIdListOfUser(sharedAssociation.getAgentId(), createdOrgTenantDomain);
+        sharedRoleIds.removeIf(sharedAgentExistingRoles::contains);
+
+        for (String sharedRoleId : sharedRoleIds) {
+            getRoleManagementService().updateUserListOfRole(sharedRoleId,
+                Collections.singletonList(sharedAssociation.getAgentId()),
+                Collections.emptyList(), createdOrgTenantDomain);
+            restrictAgentRoleDeletion(sharedRoleId, sharedAssociation, createdOrgTenantDomain,
+                resource.getInitiatingOrgId());
+        }
+    }
+
+        private void restrictAgentRoleDeletion(String roleId, AgentAssociation sharedAssociation, String tenantDomain,
+                           String permittedOrgId) {
+
+        try {
+            String domainName = IdentityUtil.getAgentIdentityUserstoreName();
+            getOrganizationAgentSharingService().addEditRestrictionsForSharedAgentRole(roleId,
+                sharedAssociation.getAgentId(), tenantDomain, domainName, EditOperation.DELETE, permittedOrgId);
+        } catch (AgentSharingMgtException e) {
+            LOG.error("Error while adding edit restrictions for shared agent role deletion.", e);
+        }
+        }
+
     private void cleanupAgentAssociations(String deletedOrgId) throws OrganizationManagementException {
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("Cleaning up agent associations for deleted organization: " + deletedOrgId);
         }
-        OrganizationAgentSharingDataHolder.getInstance().getOrganizationAgentSharingService()
-                .deleteAgentAssociationsByOrganizationId(deletedOrgId);
+        getOrganizationAgentSharingService().deleteAgentAssociationsByOrganizationId(deletedOrgId);
+    }
+
+    private OrganizationAgentSharingService getOrganizationAgentSharingService() {
+
+        return OrganizationAgentSharingDataHolder.getInstance().getOrganizationAgentSharingService();
+    }
+
+    private OrganizationManager getOrganizationManager() {
+
+        return OrganizationAgentSharingDataHolder.getInstance().getOrganizationManager();
+    }
+
+    private ResourceSharingPolicyHandlerService getResourceSharingPolicyHandlerService() {
+
+        return OrganizationAgentSharingDataHolder.getInstance().getResourceSharingPolicyHandlerService();
+    }
+
+    private RoleManagementService getRoleManagementService() {
+
+        return OrganizationAgentSharingDataHolder.getInstance().getRoleManagementService();
     }
 }

--- a/components/org.wso2.carbon.identity.organization.management.organization.agent.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/agent/sharing/listener/OrganizationAgentSharingHandler.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.agent.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/agent/sharing/listener/OrganizationAgentSharingHandler.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.identity.organization.management.organization.agent.shar
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.core.bean.context.MessageContext;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.event.IdentityEventException;
@@ -52,6 +53,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
 /**
@@ -61,6 +64,7 @@ import java.util.stream.Collectors;
 public class OrganizationAgentSharingHandler extends AbstractEventHandler {
 
     private static final Log LOG = LogFactory.getLog(OrganizationAgentSharingHandler.class);
+    private final ExecutorService executorService = Executors.newFixedThreadPool(5);
 
     /**
      * Handles agent sharing for newly created organizations and cleanup for deleted organizations.
@@ -83,17 +87,34 @@ public class OrganizationAgentSharingHandler extends AbstractEventHandler {
                 LOG.debug("Handling agent sharing for created organization: " + createdOrganization.getId());
             }
             try {
-                if (OrganizationManagementUtil.isOrganization(createdOrganization.getOrganizationHandle())) {
-                    shareAgents(createdOrganization.getId());
+                if (!OrganizationManagementUtil.isOrganization(createdOrganization.getOrganizationHandle())) {
+                    return;
                 }
             } catch (OrganizationManagementException e) {
-                throw new IdentityEventException("Error while handling agent sharing for event: " + eventName, e);
-            } catch (ResourceSharingPolicyMgtException e) {
-                throw new IdentityEventException(
-                        "Error while retrieving resource sharing policies for event: " + eventName, e);
-            } catch (IdentityRoleManagementException e) {
-                throw new IdentityEventException("Error while handling role sharing for event: " + eventName, e);
+                throw new IdentityEventException("Error while determining organization type for created " +
+                        "organization: " + createdOrganization.getId() + ".", e);
             }
+            // Capture calling tenant domain before dispatching to the background thread since
+            // CarbonContext is thread-local and won't be available on the executor thread.
+            String callerTenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+            String createdOrgId = createdOrganization.getId();
+            executorService.submit(() -> {
+                PrivilegedCarbonContext.startTenantFlow();
+                try {
+                    PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(callerTenantDomain, true);
+                    shareAgents(createdOrgId);
+                } catch (OrganizationManagementException e) {
+                    LOG.error("Error while sharing agents to created organization: " + createdOrgId + ".", e);
+                } catch (ResourceSharingPolicyMgtException e) {
+                    LOG.error("Error while retrieving resource sharing policies for created organization: "
+                            + createdOrgId + ".", e);
+                } catch (IdentityRoleManagementException e) {
+                    LOG.error("Error while assigning roles to shared agents for created organization: "
+                            + createdOrgId + ".", e);
+                } finally {
+                    PrivilegedCarbonContext.endTenantFlow();
+                }
+            });
         }
 
         if (Constants.EVENT_POST_DELETE_ORGANIZATION.equals(eventName)) {


### PR DESCRIPTION
## Purpose
When a new sub-org is created, it walks up the ancestor chain, finds any agents with a future-applicable sharing policy (ALL_EXISTING_AND_FUTURE_ORGS or SELECTED_ORG_WITH_ALL_EXISTING_AND_FUTURE_CHILDREN), and shares those agents to the new org, skipping ones that are already shared.

Issue: https://github.com/wso2/product-is/issues/27526
Related: https://github.com/wso2-extensions/identity-organization-management/pull/628


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent associations are automatically shared to newly created organizations (async) following applicable policies and hierarchy.

* **Bug Fixes**
  * Agent associations tied to deleted organizations are now removed during org deletion.

* **Improvements**
  * More reliable provisioning/removal of shared agents via configurable wait-and-retry for external user store availability; errors surfaced if unavailable within timeout.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2-extensions/identity-organization-management/pull/635)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->