### PR TITLE
Prevent unauthorized deletion of shared agents and clean up associations on delete

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.organization.agent.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/agent/sharing/OrganizationAgentSharingService.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.agent.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/agent/sharing/OrganizationAgentSharingService.java
@@ -139,4 +139,28 @@ public interface OrganizationAgentSharingService {
     List<String> getRolesSharedWithAgentInOrganization(String agentName, int tenantId, String domainName)
             throws AgentSharingMgtException;
 
+    /**
+     * Deletes the agent association DB record for a shared agent within its resident organization.
+     * This is used during agent deletion cleanup to remove only the association entry without
+     * triggering a secondary userstore deletion.
+     *
+     * @param agentId         The shared agent's ID within the shared organization.
+     * @param associatedOrgId The resident organization ID where the agent's identity is managed.
+     * @return True if the association was deleted successfully.
+     * @throws OrganizationManagementException If an error occurs while deleting the association.
+     */
+    boolean deleteAgentAssociation(String agentId, String associatedOrgId) throws OrganizationManagementException;
+
+    /**
+     * Get the agent association of a shared agent entry in a given organization, looked up by the shared
+     * agent's own ID (not the master/associated agent ID).
+     *
+     * @param sharedAgentId The ID of the shared agent entry within the organization.
+     * @param sharedOrgId   The organization ID where the agent is shared.
+     * @return The {@link AgentAssociation} for the shared agent, or {@code null} if not found.
+     * @throws OrganizationManagementException If an error occurs while retrieving the association.
+     */
+    AgentAssociation getAgentAssociation(String sharedAgentId, String sharedOrgId)
+            throws OrganizationManagementException;
+
 }

--- a/components/org.wso2.carbon.identity.organization.management.organization.agent.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/agent/sharing/OrganizationAgentSharingServiceImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.agent.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/agent/sharing/OrganizationAgentSharingServiceImpl.java
@@ -217,6 +217,20 @@ public class OrganizationAgentSharingServiceImpl implements OrganizationAgentSha
         return organizationAgentSharingDAO.getRolesSharedWithAgentInOrganization(agentName, tenantId, domainName);
     }
 
+    @Override
+    public boolean deleteAgentAssociation(String agentId, String associatedOrgId)
+            throws OrganizationManagementException {
+
+        return organizationAgentSharingDAO.deleteAgentAssociationOfAgentByAssociatedOrg(agentId, associatedOrgId);
+    }
+
+    @Override
+    public AgentAssociation getAgentAssociation(String sharedAgentId, String sharedOrgId)
+            throws OrganizationManagementException {
+
+        return organizationAgentSharingDAO.getAgentAssociation(sharedAgentId, sharedOrgId);
+    }
+
     private void removeSharedAgent(AgentAssociation agentAssociation) throws OrganizationManagementException {
 
         if (agentAssociation == null) {

--- a/components/org.wso2.carbon.identity.organization.management.organization.agent.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/agent/sharing/constant/AgentSharingConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.agent.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/agent/sharing/constant/AgentSharingConstants.java
@@ -169,6 +169,10 @@ public class AgentSharingConstants {
         ERROR_CODE_REQUEST_BODY_NULL("10031",
                 "Request body is null.",
                 "Request body must be provided."),
+        ERROR_CODE_UNAUTHORIZED_DELETION_OF_SHARED_AGENT("10032",
+                "Unauthorized deletion of shared agent.",
+                "Agents shared by ancestor organization requests can only be deleted by that particular " +
+                        "agent's resident organization."),
 
         // Server errors.
         ERROR_SELECTIVE_SHARE("15001",

--- a/components/org.wso2.carbon.identity.organization.management.organization.agent.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/agent/sharing/constant/AgentSharingConstants.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.agent.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/agent/sharing/constant/AgentSharingConstants.java
@@ -171,8 +171,8 @@ public class AgentSharingConstants {
                 "Request body must be provided."),
         ERROR_CODE_UNAUTHORIZED_DELETION_OF_SHARED_AGENT("10032",
                 "Unauthorized deletion of shared agent.",
-                "Agents shared by ancestor organization requests can only be deleted by that particular " +
-                        "agent's resident organization."),
+                "Agents shared by an ancestor organization can only be deleted by the shared agent's " +
+                        "resident organization."),
 
         // Server errors.
         ERROR_SELECTIVE_SHARE("15001",

--- a/components/org.wso2.carbon.identity.organization.management.organization.agent.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/agent/sharing/dao/OrganizationAgentSharingDAO.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.agent.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/agent/sharing/dao/OrganizationAgentSharingDAO.java
@@ -142,4 +142,14 @@ public interface OrganizationAgentSharingDAO {
     List<String> getRolesSharedWithAgentInOrganization(String agentName, int tenantId, String domainName)
             throws AgentSharingMgtServerException;
 
+    /**
+     * Get the agent association of a shared agent in a given organization, looked up by the shared agent's own ID.
+     *
+     * @param sharedAgentId The ID of the shared agent entry within the organization.
+     * @param sharedOrgId   The organization ID where the agent is shared.
+     * @return The {@link AgentAssociation} for the shared agent, or {@code null} if not found.
+     * @throws OrganizationManagementServerException If an error occurs while retrieving the association.
+     */
+    AgentAssociation getAgentAssociation(String sharedAgentId, String sharedOrgId)
+            throws OrganizationManagementServerException;
 }

--- a/components/org.wso2.carbon.identity.organization.management.organization.agent.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/agent/sharing/dao/OrganizationAgentSharingDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.agent.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/agent/sharing/dao/OrganizationAgentSharingDAOImpl.java
@@ -82,6 +82,10 @@ public class OrganizationAgentSharingDAOImpl implements OrganizationAgentSharing
     public boolean deleteAgentAssociationOfAgentByAssociatedOrg(String agentId, String associatedOrgId)
             throws OrganizationManagementServerException {
 
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Deleting agent association for agentId: " + agentId + " in associatedOrgId: "
+                    + associatedOrgId);
+        }
         return userSharingDao.deleteUserAssociationOfUserByAssociatedOrg(agentId, associatedOrgId);
     }
 

--- a/components/org.wso2.carbon.identity.organization.management.organization.agent.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/agent/sharing/dao/OrganizationAgentSharingDAOImpl.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.agent.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/agent/sharing/dao/OrganizationAgentSharingDAOImpl.java
@@ -179,6 +179,13 @@ public class OrganizationAgentSharingDAOImpl implements OrganizationAgentSharing
         }
     }
 
+    @Override
+    public AgentAssociation getAgentAssociation(String sharedAgentId, String sharedOrgId)
+            throws OrganizationManagementServerException {
+
+        return toAgentAssociation(userSharingDao.getUserAssociation(sharedAgentId, sharedOrgId));
+    }
+
     private AgentAssociation toAgentAssociation(UserAssociation ua) {
 
         if (ua == null) {

--- a/components/org.wso2.carbon.identity.organization.management.organization.agent.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/agent/sharing/internal/OrganizationAgentSharingServiceComponent.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.agent.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/agent/sharing/internal/OrganizationAgentSharingServiceComponent.java
@@ -37,11 +37,13 @@ import org.wso2.carbon.identity.organization.management.organization.agent.shari
 import org.wso2.carbon.identity.organization.management.organization.agent.sharing.OrganizationAgentSharingService;
 import org.wso2.carbon.identity.organization.management.organization.agent.sharing.OrganizationAgentSharingServiceImpl;
 import org.wso2.carbon.identity.organization.management.organization.agent.sharing.listener.OrganizationAgentSharingHandler;
+import org.wso2.carbon.identity.organization.management.organization.agent.sharing.listener.SharedAgentOperationEventListener;
 import org.wso2.carbon.identity.organization.management.role.management.service.RoleManager;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.organization.resource.hierarchy.traverse.service.OrgResourceResolverService;
 import org.wso2.carbon.identity.organization.resource.sharing.policy.management.ResourceSharingPolicyHandlerService;
 import org.wso2.carbon.identity.role.v2.mgt.core.RoleManagementService;
+import org.wso2.carbon.user.core.listener.UserOperationEventListener;
 import org.wso2.carbon.user.core.service.RealmService;
 
 /**
@@ -72,6 +74,8 @@ public class OrganizationAgentSharingServiceComponent {
                     agentSharingPolicyHandlerService, null);
             bundleContext.registerService(AbstractEventHandler.class.getName(),
                     new OrganizationAgentSharingHandler(), null);
+            bundleContext.registerService(UserOperationEventListener.class.getName(),
+                    new SharedAgentOperationEventListener(), null);
             if (LOG.isDebugEnabled()) {
                 LOG.debug("OrganizationAgentSharingServiceComponent activated successfully.");
             }

--- a/components/org.wso2.carbon.identity.organization.management.organization.agent.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/agent/sharing/listener/OrganizationAgentSharingHandler.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.agent.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/agent/sharing/listener/OrganizationAgentSharingHandler.java
@@ -65,7 +65,7 @@ public class OrganizationAgentSharingHandler extends AbstractEventHandler {
     }
 
     /**
-     * Returns the priority of this handler, defaulting to 15 when the super implementation returns -1.
+     * Returns the priority of this handler, defaulting to 16 when the super implementation returns -1.
      *
      * @param messageContext the message context.
      * @return the handler priority.

--- a/components/org.wso2.carbon.identity.organization.management.organization.agent.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/agent/sharing/listener/SharedAgentOperationEventListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.agent.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/agent/sharing/listener/SharedAgentOperationEventListener.java
@@ -87,7 +87,9 @@ public class SharedAgentOperationEventListener extends AbstractIdentityUserOpera
                         userStoreManager.getRealmConfiguration().getUserStoreProperty(DOMAIN_NAME))) {
             return true;
         }
-
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Processing pre-delete operation for agent: " + userID);
+        }
         try {
             // Retrieve the managedOrg claim to determine whether this is a shared agent copy or a master agent.
             String associatedOrgId = getAgentManagedOrganizationClaim(abstractUserStoreManager, userID);
@@ -96,8 +98,10 @@ public class SharedAgentOperationEventListener extends AbstractIdentityUserOpera
             if (associatedOrgId != null) {
                 // This is a shared agent copy – clean up only its association record.
                 AgentAssociation agentAssociation = getAgentAssociation(userID, orgId);
-                SharedType sharedType = agentAssociation != null ? agentAssociation.getSharedType() : null;
-
+                if (agentAssociation == null || agentAssociation.getSharedType() == null) {
+                    throw new UserStoreException("Unable to resolve shared-agent association for deletion.");
+                }
+                SharedType sharedType = agentAssociation.getSharedType();
                 int loginTenantId = IdentityTenantUtil.getLoginTenantId();
                 String tenantDomain = getTenantDomain(loginTenantId);
                 String requestInitiatedOrg = OrganizationAgentSharingDataHolder.getInstance()

--- a/components/org.wso2.carbon.identity.organization.management.organization.agent.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/agent/sharing/listener/SharedAgentOperationEventListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.agent.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/agent/sharing/listener/SharedAgentOperationEventListener.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.organization.management.organization.agent.sharing.listener;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.core.AbstractIdentityUserOperationEventListener;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.organization.management.organization.agent.sharing.OrganizationAgentSharingService;
+import org.wso2.carbon.identity.organization.management.organization.agent.sharing.OrganizationAgentSharingServiceImpl;
+import org.wso2.carbon.identity.organization.management.organization.agent.sharing.constant.SharedType;
+import org.wso2.carbon.identity.organization.management.organization.agent.sharing.internal.OrganizationAgentSharingDataHolder;
+import org.wso2.carbon.identity.organization.management.organization.agent.sharing.models.AgentAssociation;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
+import org.wso2.carbon.identity.organization.resource.sharing.policy.management.ResourceSharingPolicyHandlerService;
+import org.wso2.carbon.identity.organization.resource.sharing.policy.management.constant.ResourceType;
+import org.wso2.carbon.identity.organization.resource.sharing.policy.management.exception.ResourceSharingPolicyMgtException;
+import org.wso2.carbon.user.core.UserStoreClientException;
+import org.wso2.carbon.user.core.UserStoreException;
+import org.wso2.carbon.user.core.UserStoreManager;
+import org.wso2.carbon.user.core.common.AbstractUserStoreManager;
+
+import static org.wso2.carbon.identity.organization.management.organization.agent.sharing.constant.AgentSharingConstants.CLAIM_MANAGED_ORGANIZATION;
+import static org.wso2.carbon.identity.organization.management.organization.agent.sharing.constant.AgentSharingConstants.ErrorMessage.ERROR_CODE_UNAUTHORIZED_DELETION_OF_SHARED_AGENT;
+import static org.wso2.carbon.identity.organization.management.service.util.Utils.getOrganizationId;
+import static org.wso2.carbon.identity.organization.management.service.util.Utils.getTenantDomain;
+import static org.wso2.carbon.user.core.UserStoreConfigConstants.DOMAIN_NAME;
+
+/**
+ * User operation event listener for shared agent management.
+ * Handles cleanup of agent sharing associations when an agent is deleted from the userstore.
+ */
+public class SharedAgentOperationEventListener extends AbstractIdentityUserOperationEventListener {
+
+    private static final Log LOG = LogFactory.getLog(SharedAgentOperationEventListener.class);
+    private final OrganizationAgentSharingService organizationAgentSharingService =
+            new OrganizationAgentSharingServiceImpl();
+
+    @Override
+    public int getExecutionOrderId() {
+
+        return 130;
+    }
+
+    /**
+     * Handles agent sharing association cleanup before deleting an agent from the userstore.
+     *
+     * <p>When a master agent is deleted, all its shared copies in sub-organizations
+     * are removed. When a shared agent copy is deleted, the corresponding association record is cleaned up,
+     * but unauthorized deletions (i.e., deleting a SHARED-type agent from a non-resident organization) are
+     * prevented.</p>
+     *
+     * @param userID           The ID of the agent being deleted.
+     * @param userStoreManager The userstore manager for the current tenant.
+     * @return True to allow the deletion to proceed, or false to abort it.
+     * @throws UserStoreException If an error occurs during the association cleanup.
+     */
+    @Override
+    public boolean doPreDeleteUserWithID(String userID, UserStoreManager userStoreManager) throws UserStoreException {
+
+        if (!isEnable() || userStoreManager == null) {
+            return true;
+        }
+        // Only handle agents; skip regular users.
+        AbstractUserStoreManager abstractUserStoreManager = (AbstractUserStoreManager) userStoreManager;
+        if (abstractUserStoreManager.getRealmConfiguration() == null ||
+                !IdentityUtil.getAgentIdentityUserstoreName().equalsIgnoreCase(
+                        userStoreManager.getRealmConfiguration().getUserStoreProperty(DOMAIN_NAME))) {
+            return true;
+        }
+
+        try {
+            // Retrieve the managedOrg claim to determine whether this is a shared agent copy or a master agent.
+            String associatedOrgId = getAgentManagedOrganizationClaim(abstractUserStoreManager, userID);
+            String orgId = getOrganizationId();
+
+            if (associatedOrgId != null) {
+                // This is a shared agent copy – clean up only its association record.
+                AgentAssociation agentAssociation = getAgentAssociation(userID, orgId);
+                SharedType sharedType = agentAssociation != null ? agentAssociation.getSharedType() : null;
+
+                int loginTenantId = IdentityTenantUtil.getLoginTenantId();
+                String tenantDomain = getTenantDomain(loginTenantId);
+                String requestInitiatedOrg = OrganizationAgentSharingDataHolder.getInstance()
+                        .getOrganizationManager()
+                        .resolveOrganizationId(tenantDomain);
+                boolean isSharedAgentOrOwner = sharedType == SharedType.SHARED || sharedType == SharedType.OWNER;
+
+                // Prevent deletion if the request originates from a sub-org and the agent has a restricted type.
+                if (isSharedAgentOrOwner && !StringUtils.equals(requestInitiatedOrg, associatedOrgId)) {
+                    throw new UserStoreClientException(
+                            ERROR_CODE_UNAUTHORIZED_DELETION_OF_SHARED_AGENT.getDescription(),
+                            ERROR_CODE_UNAUTHORIZED_DELETION_OF_SHARED_AGENT.getCode());
+                }
+                // Remove only the DB association record; the actual userstore entry is already being deleted.
+                return organizationAgentSharingService.deleteAgentAssociation(userID, associatedOrgId);
+            }
+            // This is a master agent – remove all shared copies and their associations.
+            boolean result = organizationAgentSharingService.unshareOrganizationAgents(userID, orgId);
+
+            // Clean up all resource sharing policies associated with this master agent.
+            deleteAllAgentResourceSharingPolicies(userID);
+            return result;
+        } catch (OrganizationManagementException e) {
+            throw new UserStoreException(e.getMessage(), e.getErrorCode(), e);
+        } catch (ResourceSharingPolicyMgtException e) {
+            throw new UserStoreException(e.getMessage(), e.getErrorCode(), e);
+        }
+    }
+
+    /**
+     * Retrieves the managed organization claim value for the given agent ID.
+     *
+     * @param userStoreManager The userstore manager to query.
+     * @param agentId          The ID of the agent.
+     * @return The managed organization ID, or {@code null} if the claim is not set.
+     */
+    private String getAgentManagedOrganizationClaim(AbstractUserStoreManager userStoreManager, String agentId) {
+
+        try {
+            java.util.Map<String, String> claimsMap = userStoreManager.getUserClaimValuesWithID(
+                    agentId, new String[]{CLAIM_MANAGED_ORGANIZATION}, null);
+            return claimsMap.get(CLAIM_MANAGED_ORGANIZATION);
+        } catch (UserStoreException e) {
+            if (LOG.isDebugEnabled()) {
+                String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
+                LOG.debug("ManagedOrg claim is not available in the tenant domain: " + tenantDomain);
+            }
+            return null;
+        }
+    }
+
+    /**
+     * Retrieves the agent association for a shared agent entry within the current organization.
+     *
+     * @param sharedAgentId The shared agent's ID.
+     * @param orgId         The current organization ID.
+     * @return The {@link AgentAssociation}, or {@code null} if not found.
+     * @throws OrganizationManagementException If an error occurs while retrieving the association.
+     */
+    private AgentAssociation getAgentAssociation(String sharedAgentId, String orgId)
+            throws OrganizationManagementException {
+
+        return OrganizationAgentSharingDataHolder.getInstance().getOrganizationAgentSharingService()
+                .getAgentAssociation(sharedAgentId, orgId);
+    }
+
+    /**
+     * Deletes all resource sharing policies associated with the given master agent.
+     *
+     * @param masterAgentId The ID of the master agent whose policies should be removed.
+     * @throws ResourceSharingPolicyMgtException If an error occurs while deleting the policies.
+     */
+    private void deleteAllAgentResourceSharingPolicies(String masterAgentId)
+            throws ResourceSharingPolicyMgtException {
+
+        ResourceSharingPolicyHandlerService policyService = getResourceSharingPolicyHandlerService();
+        if (policyService == null) {
+            return;
+        }
+        policyService.deleteResourceSharingPolicyByResourceTypeAndId(ResourceType.AGENT, masterAgentId);
+    }
+
+    /**
+     * Returns the {@link ResourceSharingPolicyHandlerService} from the data holder.
+     *
+     * @return The resource sharing policy handler service, or {@code null} if not registered.
+     */
+    private ResourceSharingPolicyHandlerService getResourceSharingPolicyHandlerService() {
+
+        return OrganizationAgentSharingDataHolder.getInstance().getResourceSharingPolicyHandlerService();
+    }
+}


### PR DESCRIPTION
### Proposed changes in this pull request

$subject

Issue: https://github.com/wso2/product-is/issues/27526
Related: https://github.com/wso2/carbon-identity-framework/pull/8094

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added agent association deletion and retrieval operations for managing shared agents
  * Introduced authorization validation so only resident organizations can remove certain shared agents

* **Improvements**
  * Added pre-deletion listener behavior to clean up associations and unshare master agents
  * Registered an additional user-operation listener to handle shared-agent lifecycle
  * Added clearer error handling and logging for shared-agent operations

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2-extensions/identity-organization-management/pull/636)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->