### PR TITLE
Strip the adaptive script content for consistent updates

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/FragmentApplicationMgtListener.java
@@ -204,12 +204,15 @@ public class FragmentApplicationMgtListener extends AbstractApplicationMgtListen
                     AuthenticationScriptConfig authenticationScriptConfig =
                             localAndOutBoundAuthenticationConfig.getAuthenticationScriptConfig();
                     if (authenticationScriptConfig.isEnabled() &&
-                            !StringUtils.isBlank(authenticationScriptConfig.getContent()) &&
-                            !OrgApplicationManagerUtil.isAdaptiveScriptUnchanged(existingApplication,
-                                    authenticationScriptConfig)) {
-                        if (OrgApplicationManagerUtil.isAdaptiveAuthBlockedByGovernance(tenantDomain)) {
-                            throw new IdentityApplicationManagementClientException(
-                                    "Authentication script configuration not allowed for shared applications.");
+                            !StringUtils.isBlank(authenticationScriptConfig.getContent())) {
+                        authenticationScriptConfig.setContent(
+                                StringUtils.stripEnd(authenticationScriptConfig.getContent(), null));
+                        if (!OrgApplicationManagerUtil.isAdaptiveScriptUnchanged(existingApplication,
+                                authenticationScriptConfig)) {
+                            if (OrgApplicationManagerUtil.isAdaptiveAuthBlockedByGovernance(tenantDomain)) {
+                                throw new IdentityApplicationManagementClientException(
+                                        "Authentication script configuration not allowed for shared applications.");
+                            }
                         }
                     }
                 }

--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/SubOrgApplicationMgtListener.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/listener/SubOrgApplicationMgtListener.java
@@ -117,6 +117,7 @@ public class SubOrgApplicationMgtListener extends AbstractApplicationMgtListener
                 StringUtils.isBlank(authenticationScriptConfig.getContent())) {
             return;
         }
+        authenticationScriptConfig.setContent(StringUtils.stripEnd(authenticationScriptConfig.getContent(), null));
         if (OrgApplicationManagerUtil.isAdaptiveScriptUnchanged(existingServiceProvider, authenticationScriptConfig)) {
             return;
         }

--- a/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/util/OrgApplicationManagerUtil.java
+++ b/components/org.wso2.carbon.identity.organization.management.application/src/main/java/org/wso2/carbon/identity/organization/management/application/util/OrgApplicationManagerUtil.java
@@ -392,7 +392,8 @@ public class OrgApplicationManagerUtil {
         }
         AuthenticationScriptConfig existingScript = existingConfig.getAuthenticationScriptConfig();
         return existingScript.isEnabled() == newScript.isEnabled() &&
-                StringUtils.equals(existingScript.getContent(), newScript.getContent());
+                StringUtils.equals(StringUtils.stripEnd(existingScript.getContent(), null),
+                        StringUtils.stripEnd(newScript.getContent(), null));
     }
 
     /**


### PR DESCRIPTION
## Purpose
> When a sub organization adaptive script is updated by an authorized party with trailing spaces or new lines, and then when unauthorized party tries to update the script in a classic editor without changing, it gives an error since classic editor strips the trailing characters. Hence, sub organization adaptive script is persisted after striping the trailing new lines and spaces

Issue - https://github.com/wso2/product-is/issues/27976

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved adaptive authentication script handling to properly normalize whitespace when checking for script changes and governance compliance, ensuring more accurate detection of actual modifications to authentication configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->