### PR TITLE
Add shared_user_id claim to organization claim provider

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.claim.provider/pom.xml
+++ b/components/org.wso2.carbon.identity.organization.management.claim.provider/pom.xml
@@ -49,6 +49,10 @@
             <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.organization.user.sharing</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
@@ -95,9 +99,12 @@
                             org.wso2.carbon.identity.oauth2.token.handlers.claims;version="${identity.inbound.auth.oauth.import.version.range}",
                             org.wso2.carbon.identity.openidconnect.*;version="${identity.inbound.auth.oauth.import.version.range}",
                             org.wso2.carbon.identity.application.authentication.framework.model;version="${carbon.identity.package.import.version.range}",
+                            org.wso2.carbon.identity.application.authentication.framework.exception;version="${carbon.identity.package.import.version.range}",
                             org.wso2.carbon.identity.organization.management.service;version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
                             org.wso2.carbon.identity.organization.management.service.exception;version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
                             org.wso2.carbon.identity.organization.management.service.constant;version="${org.wso2.identity.organization.mgt.core.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.management.organization.user.sharing;version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.organization.management.organization.user.sharing.models;version="${org.wso2.identity.organization.mgt.imp.pkg.version.range}",
                         </Import-Package>
                     </instructions>
                 </configuration>

--- a/components/org.wso2.carbon.identity.organization.management.claim.provider/src/main/java/org/wso2/carbon/identity/organization/management/claim/provider/OrganizationClaimProvider.java
+++ b/components/org.wso2.carbon.identity.organization.management.claim.provider/src/main/java/org/wso2/carbon/identity/organization/management/claim/provider/OrganizationClaimProvider.java
@@ -21,7 +21,6 @@ package org.wso2.carbon.identity.organization.management.claim.provider;
 import org.apache.commons.lang.StringUtils;
 import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
-import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
@@ -171,9 +170,8 @@ public class OrganizationClaimProvider implements ClaimProvider, JWTAccessTokenC
             return authenticatedUser.getSharedUserId();
         }
 
-        if (FrameworkConstants.ORGANIZATION_LOGIN_IDP_NAME.equals(authenticatedUser.getFederatedIdPName()) &&
-                !StringUtils.equals(authenticatedUser.getAccessingOrganization(),
-                        authenticatedUser.getUserResidentOrganization())) {
+        if (!StringUtils.equals(authenticatedUser.getAccessingOrganization(),
+                authenticatedUser.getUserResidentOrganization())) {
             try {
                 UserAssociation userAssociation = getOrganizationUserSharingService()
                         .getUserAssociationOfAssociatedUserByOrgId(authenticatedUser.getUserId(),

--- a/components/org.wso2.carbon.identity.organization.management.claim.provider/src/main/java/org/wso2/carbon/identity/organization/management/claim/provider/OrganizationClaimProvider.java
+++ b/components/org.wso2.carbon.identity.organization.management.claim.provider/src/main/java/org/wso2/carbon/identity/organization/management/claim/provider/OrganizationClaimProvider.java
@@ -19,6 +19,9 @@
 package org.wso2.carbon.identity.organization.management.claim.provider;
 
 import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.identity.application.authentication.framework.exception.UserIdNotFoundException;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.authz.OAuthAuthzReqMessageContext;
@@ -28,6 +31,8 @@ import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
 import org.wso2.carbon.identity.oauth2.token.handlers.claims.JWTAccessTokenClaimProvider;
 import org.wso2.carbon.identity.openidconnect.ClaimProvider;
 import org.wso2.carbon.identity.organization.management.claim.provider.internal.OrganizationClaimProviderServiceComponentHolder;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.OrganizationUserSharingService;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.models.UserAssociation;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementClientException;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
@@ -47,6 +52,7 @@ public class OrganizationClaimProvider implements ClaimProvider, JWTAccessTokenC
     private static final String AUTHORIZED_ORGANIZATION_HANDLE_ATTRIBUTE = "org_handle";
     private static final String USER_RESIDENT_ORGANIZATION_NAME_ATTRIBUTE = "user_org";
     private static final String AGENT_RESIDENT_ORGANIZATION_NAME_ATTRIBUTE = "agent_org";
+    private static final String SHARED_USER_ID_ATTRIBUTE = "shared_user_id";
 
     @Override
     public Map<String, Object> getAdditionalClaims(OAuthAuthzReqMessageContext oAuthAuthzReqMessageContext,
@@ -63,11 +69,12 @@ public class OrganizationClaimProvider implements ClaimProvider, JWTAccessTokenC
 
         String userResidentOrgId = oAuthTokenReqMessageContext.getAuthorizedUser().getUserResidentOrganization();
         String authorizedOrgId = oAuthTokenReqMessageContext.getAuthorizedUser().getAccessingOrganization();
+        String sharedUserId = resolveSharedUserId(oAuthTokenReqMessageContext.getAuthorizedUser());
         if (StringUtils.isEmpty(authorizedOrgId)) {
             authorizedOrgId = resolveOrganizationId(oAuthTokenReqMessageContext.getAuthorizedUser().getTenantDomain());
         }
         boolean isAgent = isAgentUser(oAuthTokenReqMessageContext.getAuthorizedUser().getUserStoreDomain());
-        return buildOrganizationInformation(userResidentOrgId, authorizedOrgId, isAgent);
+        return buildOrganizationInformation(userResidentOrgId, authorizedOrgId, isAgent, sharedUserId);
     }
 
     @Override
@@ -78,13 +85,15 @@ public class OrganizationClaimProvider implements ClaimProvider, JWTAccessTokenC
                 .getUserResidentOrganization();
         String authorizedOrgId = oAuthAuthzReqMessageContext.getAuthorizationReqDTO().getUser()
                 .getAccessingOrganization();
+        String sharedUserId = resolveSharedUserId(oAuthAuthzReqMessageContext.getAuthorizationReqDTO()
+                .getUser());
         if (StringUtils.isEmpty(authorizedOrgId)) {
             String tenantDomain = oAuthAuthzReqMessageContext.getAuthorizationReqDTO().getLoggedInTenantDomain();
             authorizedOrgId = resolveOrganizationId(tenantDomain);
         }
         boolean isAgent = isAgentUser(oAuthAuthzReqMessageContext.getAuthorizationReqDTO().getUser()
                 .getUserStoreDomain());
-        return buildOrganizationInformation(userResidentOrgId, authorizedOrgId, isAgent);
+        return buildOrganizationInformation(userResidentOrgId, authorizedOrgId, isAgent, sharedUserId);
     }
 
     @Override
@@ -93,16 +102,17 @@ public class OrganizationClaimProvider implements ClaimProvider, JWTAccessTokenC
 
         String userResidentOrgId = oAuthTokenReqMessageContext.getAuthorizedUser().getUserResidentOrganization();
         String authorizedOrgId = oAuthTokenReqMessageContext.getAuthorizedUser().getAccessingOrganization();
+        String sharedUserId = resolveSharedUserId(oAuthTokenReqMessageContext.getAuthorizedUser());
         // The below condition is not required once console is modeled as B2B app.
         if (StringUtils.isEmpty(authorizedOrgId)) {
             authorizedOrgId = resolveOrganizationId(oAuthTokenReqMessageContext.getAuthorizedUser().getTenantDomain());
         }
         boolean isAgent = isAgentUser(oAuthTokenReqMessageContext.getAuthorizedUser().getUserStoreDomain());
-        return buildOrganizationInformation(userResidentOrgId, authorizedOrgId, isAgent);
+        return buildOrganizationInformation(userResidentOrgId, authorizedOrgId, isAgent, sharedUserId);
     }
 
     private Map<String, Object> buildOrganizationInformation(String userResideOrgId, String authorizedOrgId,
-                                                             boolean isAgent)
+                                                             boolean isAgent, String sharedUserId)
             throws IdentityOAuth2Exception {
 
         Map<String, Object> additionalClaims = new HashMap<>();
@@ -119,6 +129,9 @@ public class OrganizationClaimProvider implements ClaimProvider, JWTAccessTokenC
                 additionalClaims.put(AUTHORIZED_ORGANIZATION_ID_ATTRIBUTE, authorizedOrgId);
                 additionalClaims.put(AUTHORIZED_ORGANIZATION_NAME_ATTRIBUTE, authorizedOrgName);
                 additionalClaims.put(AUTHORIZED_ORGANIZATION_HANDLE_ATTRIBUTE, authorizedOrgHandle);
+            }
+            if (StringUtils.isNotBlank(sharedUserId)) {
+                additionalClaims.put(SHARED_USER_ID_ATTRIBUTE, sharedUserId);
             }
         } catch (OrganizationManagementException e) {
             throw new IdentityOAuth2Exception("Error while resolving organization name by ID.", e);
@@ -150,5 +163,35 @@ public class OrganizationClaimProvider implements ClaimProvider, JWTAccessTokenC
     private OrganizationManager getOrganizationManager() {
 
         return OrganizationClaimProviderServiceComponentHolder.getInstance().getOrganizationManager();
+    }
+
+    private String resolveSharedUserId(AuthenticatedUser authenticatedUser) throws IdentityOAuth2Exception {
+
+        if (authenticatedUser.isSharedUser() && StringUtils.isNotBlank(authenticatedUser.getSharedUserId())) {
+            return authenticatedUser.getSharedUserId();
+        }
+
+        if (FrameworkConstants.ORGANIZATION_LOGIN_IDP_NAME.equals(authenticatedUser.getFederatedIdPName()) &&
+                !StringUtils.equals(authenticatedUser.getAccessingOrganization(),
+                        authenticatedUser.getUserResidentOrganization())) {
+            try {
+                UserAssociation userAssociation = getOrganizationUserSharingService()
+                        .getUserAssociationOfAssociatedUserByOrgId(authenticatedUser.getUserId(),
+                                authenticatedUser.getAccessingOrganization());
+                if (userAssociation != null) {
+                    return userAssociation.getUserId();
+                }
+            } catch (UserIdNotFoundException e) {
+                throw new IdentityOAuth2Exception("Error while resolving the user id of the authenticated user.", e);
+            } catch (OrganizationManagementException e) {
+                throw new IdentityOAuth2Exception("Error while resolving the shared user association for user.", e);
+            }
+        }
+        return null;
+    }
+
+    private OrganizationUserSharingService getOrganizationUserSharingService() {
+
+        return OrganizationClaimProviderServiceComponentHolder.getInstance().getOrganizationUserSharingService();
     }
 }

--- a/components/org.wso2.carbon.identity.organization.management.claim.provider/src/main/java/org/wso2/carbon/identity/organization/management/claim/provider/internal/OrganizationClaimProviderServiceComponent.java
+++ b/components/org.wso2.carbon.identity.organization.management.claim.provider/src/main/java/org/wso2/carbon/identity/organization/management/claim/provider/internal/OrganizationClaimProviderServiceComponent.java
@@ -29,6 +29,7 @@ import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.identity.oauth2.token.handlers.claims.JWTAccessTokenClaimProvider;
 import org.wso2.carbon.identity.openidconnect.ClaimProvider;
 import org.wso2.carbon.identity.organization.management.claim.provider.OrganizationClaimProvider;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.OrganizationUserSharingService;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManagementInitialize;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 
@@ -97,5 +98,27 @@ public class OrganizationClaimProviderServiceComponent {
 
         OrganizationClaimProviderServiceComponentHolder.getInstance().setOrganizationManagementEnable(null);
         LOG.debug("Unset organization management enable check service.");
+    }
+
+    @Reference(
+            name = "organization.user.sharing.service",
+            service = OrganizationUserSharingService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetOrganizationUserSharingService"
+    )
+    protected void setOrganizationUserSharingService(
+            OrganizationUserSharingService organizationUserSharingService) {
+
+        OrganizationClaimProviderServiceComponentHolder.getInstance()
+                .setOrganizationUserSharingService(organizationUserSharingService);
+        LOG.debug("Set the organization user sharing service.");
+    }
+
+    protected void unsetOrganizationUserSharingService(
+            OrganizationUserSharingService organizationUserSharingService) {
+
+        OrganizationClaimProviderServiceComponentHolder.getInstance().setOrganizationUserSharingService(null);
+        LOG.debug("Unset organization user sharing service.");
     }
 }

--- a/components/org.wso2.carbon.identity.organization.management.claim.provider/src/main/java/org/wso2/carbon/identity/organization/management/claim/provider/internal/OrganizationClaimProviderServiceComponentHolder.java
+++ b/components/org.wso2.carbon.identity.organization.management.claim.provider/src/main/java/org/wso2/carbon/identity/organization/management/claim/provider/internal/OrganizationClaimProviderServiceComponentHolder.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.identity.organization.management.claim.provider.internal;
 
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.OrganizationUserSharingService;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManagementInitialize;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 
@@ -29,6 +30,7 @@ public class OrganizationClaimProviderServiceComponentHolder {
     private static final OrganizationClaimProviderServiceComponentHolder INSTANCE =
             new OrganizationClaimProviderServiceComponentHolder();
     private OrganizationManager organizationManager;
+    private OrganizationUserSharingService organizationUserSharingService;
     private boolean isOrganizationManagementEnable = false;
     
     private OrganizationClaimProviderServiceComponentHolder() {
@@ -48,6 +50,16 @@ public class OrganizationClaimProviderServiceComponentHolder {
     public void setOrganizationManager(OrganizationManager organizationManager) {
 
         this.organizationManager = organizationManager;
+    }
+
+    public OrganizationUserSharingService getOrganizationUserSharingService() {
+
+        return organizationUserSharingService;
+    }
+
+    public void setOrganizationUserSharingService(OrganizationUserSharingService organizationUserSharingService) {
+
+        this.organizationUserSharingService = organizationUserSharingService;
     }
 
     public boolean isOrganizationManagementEnable() {

--- a/components/org.wso2.carbon.identity.organization.management.claim.provider/src/test/java/org/wso2/carbon/identity/organization/management/claim/provider/OrganizationClaimProviderTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.claim.provider/src/test/java/org/wso2/carbon/identity/organization/management/claim/provider/OrganizationClaimProviderTest.java
@@ -25,10 +25,13 @@ import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
 import org.wso2.carbon.identity.organization.management.claim.provider.internal.OrganizationClaimProviderServiceComponentHolder;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.OrganizationUserSharingService;
+import org.wso2.carbon.identity.organization.management.organization.user.sharing.models.UserAssociation;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManagementInitialize;
 import org.wso2.carbon.identity.organization.management.service.OrganizationManager;
 import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
@@ -55,6 +58,9 @@ public class OrganizationClaimProviderTest {
     private static final String USER_ORG_CLAIM = "user_org";
     private static final String AGENT_ORG_CLAIM = "agent_org";
     private static final String AGENT_USERSTORE_DOMAIN = "AGENT_USER_STORE";
+    private static final String SHARED_USER_ID_CLAIM = "shared_user_id";
+    private static final String SHARED_USER_ID = "sharedUserId";
+    private static final String RESIDENT_USER_ID = "residentUserId";
 
     private OrganizationClaimProvider organizationClaimProvider;
 
@@ -68,6 +74,9 @@ public class OrganizationClaimProviderTest {
     private OrganizationManager organizationManager;
 
     @Mock
+    private OrganizationUserSharingService organizationUserSharingService;
+
+    @Mock
     private OrganizationManagementInitialize organizationManagementInitializeService;
 
     @BeforeMethod
@@ -76,6 +85,8 @@ public class OrganizationClaimProviderTest {
         MockitoAnnotations.openMocks(this);
         organizationClaimProvider = new OrganizationClaimProvider();
         OrganizationClaimProviderServiceComponentHolder.getInstance().setOrganizationManager(organizationManager);
+        OrganizationClaimProviderServiceComponentHolder.getInstance()
+                .setOrganizationUserSharingService(organizationUserSharingService);
     }
 
     @Test
@@ -101,6 +112,73 @@ public class OrganizationClaimProviderTest {
         assertEquals(AUTH_ORG_ID, additionalClaims.get(ORG_ID_CLAIM));
         assertEquals(AUTHORIZED_ORG_NAME, additionalClaims.get(ORG_NAME_CLAIM));
         assertEquals(AUTHORIZED_ORG_HANDLE, additionalClaims.get(ORG_HANDLE_CLAIM));
+        assertFalse(additionalClaims.containsKey(SHARED_USER_ID_CLAIM));
+    }
+
+    /**
+     * Test that the shared_user_id claim is added for a shared user that carries a shared user id.
+     *
+     * `@throws` IdentityOAuth2Exception if OAuth2 operation fails.
+     * `@throws` OrganizationManagementException if organization management operation fails.
+     */
+    @Test
+    public void testGetAdditionalClaimsForSharedUser() throws IdentityOAuth2Exception,
+            OrganizationManagementException {
+
+        when(organizationManagementInitializeService.isOrganizationManagementEnabled()).thenReturn(true);
+        OrganizationClaimProviderServiceComponentHolder.getInstance()
+                .setOrganizationManagementEnable(organizationManagementInitializeService);
+
+        when(oAuthTokenReqMessageContext.getAuthorizedUser()).thenReturn(authenticatedUser);
+        when(authenticatedUser.getUserResidentOrganization()).thenReturn(USER_ORG_ID);
+        when(authenticatedUser.getAccessingOrganization()).thenReturn(AUTH_ORG_ID);
+        when(authenticatedUser.isSharedUser()).thenReturn(true);
+        when(authenticatedUser.getSharedUserId()).thenReturn(SHARED_USER_ID);
+
+        when(organizationManager.getOrganizationNameById(AUTH_ORG_ID)).thenReturn(AUTHORIZED_ORG_NAME);
+        when(organizationManager.resolveTenantDomain(AUTH_ORG_ID)).thenReturn(AUTHORIZED_ORG_HANDLE);
+
+        Map<String, Object> additionalClaims =
+                organizationClaimProvider.getAdditionalClaims(oAuthTokenReqMessageContext);
+
+        assertTrue(additionalClaims.containsKey(SHARED_USER_ID_CLAIM));
+        assertEquals(additionalClaims.get(SHARED_USER_ID_CLAIM), SHARED_USER_ID);
+    }
+
+    /**
+     * Test that the shared_user_id claim is resolved from the user association for an organization login user
+     * accessing a different organization than the resident organization.
+     *
+     * `@throws` Exception if any operation fails.
+     */
+    @Test
+    public void testGetAdditionalClaimsForOrganizationLoginUser() throws Exception {
+
+        when(organizationManagementInitializeService.isOrganizationManagementEnabled()).thenReturn(true);
+        OrganizationClaimProviderServiceComponentHolder.getInstance()
+                .setOrganizationManagementEnable(organizationManagementInitializeService);
+
+        when(oAuthTokenReqMessageContext.getAuthorizedUser()).thenReturn(authenticatedUser);
+        when(authenticatedUser.getUserResidentOrganization()).thenReturn(USER_ORG_ID);
+        when(authenticatedUser.getAccessingOrganization()).thenReturn(AUTH_ORG_ID);
+        when(authenticatedUser.isSharedUser()).thenReturn(false);
+        when(authenticatedUser.getFederatedIdPName())
+                .thenReturn(FrameworkConstants.ORGANIZATION_LOGIN_IDP_NAME);
+        when(authenticatedUser.getUserId()).thenReturn(RESIDENT_USER_ID);
+
+        UserAssociation userAssociation = Mockito.mock(UserAssociation.class);
+        when(userAssociation.getUserId()).thenReturn(SHARED_USER_ID);
+        when(organizationUserSharingService.getUserAssociationOfAssociatedUserByOrgId(RESIDENT_USER_ID, AUTH_ORG_ID))
+                .thenReturn(userAssociation);
+
+        when(organizationManager.getOrganizationNameById(AUTH_ORG_ID)).thenReturn(AUTHORIZED_ORG_NAME);
+        when(organizationManager.resolveTenantDomain(AUTH_ORG_ID)).thenReturn(AUTHORIZED_ORG_HANDLE);
+
+        Map<String, Object> additionalClaims =
+                organizationClaimProvider.getAdditionalClaims(oAuthTokenReqMessageContext);
+
+        assertTrue(additionalClaims.containsKey(SHARED_USER_ID_CLAIM));
+        assertEquals(additionalClaims.get(SHARED_USER_ID_CLAIM), SHARED_USER_ID);
     }
 
     /**

--- a/components/org.wso2.carbon.identity.organization.management.claim.provider/src/test/java/org/wso2/carbon/identity/organization/management/claim/provider/OrganizationClaimProviderTest.java
+++ b/components/org.wso2.carbon.identity.organization.management.claim.provider/src/test/java/org/wso2/carbon/identity/organization/management/claim/provider/OrganizationClaimProviderTest.java
@@ -25,7 +25,6 @@ import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
-import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
@@ -162,8 +161,6 @@ public class OrganizationClaimProviderTest {
         when(authenticatedUser.getUserResidentOrganization()).thenReturn(USER_ORG_ID);
         when(authenticatedUser.getAccessingOrganization()).thenReturn(AUTH_ORG_ID);
         when(authenticatedUser.isSharedUser()).thenReturn(false);
-        when(authenticatedUser.getFederatedIdPName())
-                .thenReturn(FrameworkConstants.ORGANIZATION_LOGIN_IDP_NAME);
         when(authenticatedUser.getUserId()).thenReturn(RESIDENT_USER_ID);
 
         UserAssociation userAssociation = Mockito.mock(UserAssociation.class);

--- a/pom.xml
+++ b/pom.xml
@@ -625,7 +625,7 @@
         <identity.inbound.provisioning.scim2.version>3.7.9</identity.inbound.provisioning.scim2.version>
         <identity.scim2.imp.pkg.version.range>[3.4.0, 4.0.0)</identity.scim2.imp.pkg.version.range>
 
-        <carbon.identity.framework.version>7.10.68</carbon.identity.framework.version>
+        <carbon.identity.framework.version>7.11.126</carbon.identity.framework.version>
         <carbon.identity.package.import.version.range>[5.20.0, 8.0.0)
         </carbon.identity.package.import.version.range>
 


### PR DESCRIPTION
## Purpose

Adds a new `shared_user_id` claim to the organization claim provider so that the
shared user's ID is surfaced in issued tokens for shared user logins.

## Changes

- **`OrganizationClaimProvider`**
  - Added a new `shared_user_id` claim attribute.
  - Introduced `resolveSharedUserId(AuthenticatedUser)` which resolves the shared user ID by:
    1. Returning `getSharedUserId()` directly when the authenticated user is a shared user and the value is present, **or**
    2. Resolving it from the user association (`getUserAssociationOfAssociatedUserByOrgId`) when the user logged in via the organization-login IdP and the accessing organization differs from the resident organization.
  - Wired `resolveSharedUserId` into all overloaded `getAdditionalClaims(...)` methods and passed the resolved value to `buildOrganizationInformation(...)`.
  - The `shared_user_id` claim is added to the additional claims **only when it is non-blank**.

## Testing

- Added unit tests in `OrganizationClaimProviderTest`:
  - `testGetAdditionalClaimsForSharedUser` — verifies the `shared_user_id` claim is set from the shared user's ID.
  - `testGetAdditionalClaimsForOrganizationLoginUser` — verifies the claim is resolved from the user association for an organization-login user accessing a different organization.
  - Extended the existing test to assert the `shared_user_id` claim is **absent** when the user is neither a shared user nor an organization-login user.

### Related issue
- https://github.com/wso2/product-is/issues/27371

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `shared_user_id` claim to OAuth tokens for shared user scenarios

* **Tests**
  * Extended test coverage for shared user and organization login scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->