### PR TITLE
Share selected descendant organizations in selective user share

### DIFF
--- a/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImplV2.java
+++ b/components/org.wso2.carbon.identity.organization.management.organization.user.sharing/src/main/java/org/wso2/carbon/identity/organization/management/organization/user/sharing/UserSharingPolicyHandlerServiceImplV2.java
@@ -1739,15 +1739,15 @@ public class UserSharingPolicyHandlerServiceImplV2 implements UserSharingPolicyH
             List<SelectiveUserShareOrgDetailsV2DO> organizations, String sharingInitiatedOrgId)
             throws UserSharingMgtServerException {
 
-        List<String> immediateChildOrgs = getImmediateChildOrgsOfSharingInitiatedOrg(sharingInitiatedOrgId);
+        List<String> descendantOrgs = getDescendantOrgsOfSharingInitiatedOrg(sharingInitiatedOrgId);
 
         List<SelectiveUserShareOrgDetailsV2DO> validOrganizations = organizations.stream()
-                .filter(org -> immediateChildOrgs.contains(org.getOrganizationId()))
+                .filter(org -> descendantOrgs.contains(org.getOrganizationId()))
                 .collect(Collectors.toList());
 
         List<String> skippedOrganizations = organizations.stream()
                 .map(SelectiveUserShareOrgDetailsV2DO::getOrganizationId)
-                .filter(orgId -> !immediateChildOrgs.contains(orgId))
+                .filter(orgId -> !descendantOrgs.contains(orgId))
                 .collect(Collectors.toList());
 
         if (!skippedOrganizations.isEmpty() && LOG.isDebugEnabled()) {
@@ -1758,16 +1758,20 @@ public class UserSharingPolicyHandlerServiceImplV2 implements UserSharingPolicyH
     }
 
     /**
-     * Retrieves the list of immediate child organizations for a given organization.
+     * Retrieves the list of descendant organizations for a given organization.
+     *
+     * <p>Selective user sharing must accept any organization in the sharing-initiated org's subtree, not just
+     * its immediate children. Restricting to immediate children silently drops second-level (and deeper)
+     * organizations from the request even though the share API reports success, leaving them unshared.</p>
      *
      * @param sharingInitiatedOrgId The ID of the organization that initiated the sharing.
-     * @return A list of organization IDs representing the immediate child organizations.
+     * @return A list of organization IDs representing all descendant organizations (recursive).
      */
-    private List<String> getImmediateChildOrgsOfSharingInitiatedOrg(String sharingInitiatedOrgId)
+    private List<String> getDescendantOrgsOfSharingInitiatedOrg(String sharingInitiatedOrgId)
             throws UserSharingMgtServerException {
 
         try {
-            return getOrganizationManager().getChildOrganizationsIds(sharingInitiatedOrgId, false);
+            return getOrganizationManager().getChildOrganizationsIds(sharingInitiatedOrgId, true);
         } catch (OrganizationManagementException e) {
             String errorMessage = String.format(
                     ERROR_CODE_GET_IMMEDIATE_CHILD_ORGS.getMessage(), sharingInitiatedOrgId);


### PR DESCRIPTION
## Problem

Selective user sharing only shared a user with the **immediate children** of the sharing-initiated organization. When the share request included an organization deeper in the hierarchy (a second-level sub-organization or below), that organization was silently dropped — the API still returned `202 Accepted`, but the user was never shared with it. The admin saw a success response while the deeper organizations remained unshared.

## Root cause

`UserSharingPolicyHandlerServiceImplV2.filterValidOrganizations()` validated each requested organization against `getChildOrganizationsIds(sharingInitiatedOrgId, false)` — the **non-recursive** (immediate-children-only) child list. Any requested organization outside that immediate-child set was filtered out before sharing, with only a debug-level log.

The downstream sharing logic (`SELECTED_ORG_ONLY` → `shareUserWithOrganization`) already targets the requested organization directly regardless of depth, so the filter was the sole gate blocking deeper organizations.

## Fix

Validate requested organizations against the **recursive descendant set** of the sharing-initiated organization instead of only its immediate children (`getChildOrganizationsIds(sharingInitiatedOrgId, true)`). Organizations outside the initiator's subtree are still excluded, so the sharing boundary is unchanged.

## Testing

Verified at runtime against a built pack:

- Sharing a user (from the root organization) with a first-level org **and** a second-level org now shares **both**; previously only the first-level org was shared.
- Boundary check: from a first-level org's context, sharing with a descendant succeeds while a **sibling** organization (outside the subtree) is still correctly rejected.

> Note: the V1 handler (`UserSharingPolicyHandlerServiceImpl`) has the same immediate-children-only filter and is not addressed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved selective user sharing so organizations are now filtered using the full descendant hierarchy, not just immediate child organizations.
  * Sharing-related organization lists now include deeper nested organizations, helping ensure valid destinations are correctly available while skipping unsupported ones as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->